### PR TITLE
Add memory and output modules

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,9 +3,9 @@
 This roadmap summarizes the planned phases for monGARS based on the current architecture and goals.
 
 ## Phase 1 – Core Infrastructure
-- Establish module framework (Cortex, Hippocampus, Neurons, Bouche).
-- Integrate basic memory storage and conversation flow.
-- Provide Docker Compose and initial deployment scripts.
+- [x] Establish module framework (Cortex, Hippocampus, Neurons, Bouche).
+- [ ] Integrate basic memory storage and conversation flow.
+- [ ] Provide Docker Compose and initial deployment scripts.
 
 ## Phase 2 – Functional Expansion
 - Add Mimicry for behavioral adaptation and Mains Virtuelles for executing user-defined code.

--- a/monGARS/core/bouche.py
+++ b/monGARS/core/bouche.py
@@ -1,0 +1,11 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class Bouche:
+    """Output interface for delivering responses."""
+
+    async def speak(self, text: str) -> str:
+        logger.info("Bouche delivers response: %s", text)
+        return text

--- a/monGARS/core/conversation.py
+++ b/monGARS/core/conversation.py
@@ -1,22 +1,26 @@
 import asyncio
 import logging
 from datetime import datetime
-from monGARS.core.caching.tiered_cache import get_cached_data
-from monGARS.core.neurones import EmbeddingSystem
-from monGARS.core.llm_integration import LLMIntegration
-from monGARS.core.neuro_symbolic.advanced_reasoner import AdvancedReasoner
+
+from sqlalchemy import desc, select
+
+from monGARS.config import get_settings
+from monGARS.core.bouche import Bouche
 from monGARS.core.cortex.curiosity_engine import CuriosityEngine
 from monGARS.core.dynamic_response import AdaptiveResponseGenerator
 from monGARS.core.evolution_engine import EvolutionEngine
-from monGARS.core.mimicry import MimicryModule
+from monGARS.core.hippocampus import Hippocampus
+from monGARS.core.init_db import ConversationHistory, Interaction, async_session_factory
+from monGARS.core.llm_integration import LLMIntegration
 from monGARS.core.mains_virtuelles import ImageCaptioning
+from monGARS.core.mimicry import MimicryModule
+from monGARS.core.neuro_symbolic.advanced_reasoner import AdvancedReasoner
+from monGARS.core.neurones import EmbeddingSystem
 from monGARS.core.personality import PersonalityEngine
-from monGARS.config import get_settings
-from monGARS.core.init_db import async_session_factory, ConversationHistory, Interaction
-from sqlalchemy import select, update, desc
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
+
 
 class ConversationalModule:
     def __init__(self):
@@ -29,8 +33,23 @@ class ConversationalModule:
         self.curiosity = CuriosityEngine()
         self.personality_engine = PersonalityEngine()
         self.captioner = ImageCaptioning()
+        self.hippocampus = Hippocampus()
+        self.bouche = Bouche()
 
-    async def _save_interaction(self, user_id: str, session_id: str, input_data: str, output_data: str, message: str, response: str, personality: dict, context: dict, meta_data: str, confidence: float, processing_time: float):
+    async def _save_interaction(
+        self,
+        user_id: str,
+        session_id: str,
+        input_data: str,
+        output_data: str,
+        message: str,
+        response: str,
+        personality: dict,
+        context: dict,
+        meta_data: str,
+        confidence: float,
+        processing_time: float,
+    ):
         async with async_session_factory() as session:
             try:
                 new_interaction = Interaction(
@@ -44,7 +63,7 @@ class ConversationalModule:
                     context=context,
                     meta_data=meta_data,
                     confidence=confidence,
-                    processing_time=processing_time
+                    processing_time=processing_time,
                 )
                 session.add(new_interaction)
                 await session.commit()
@@ -63,12 +82,21 @@ class ConversationalModule:
                     .limit(limit)
                 )
                 history = result.scalars().all()
-                return [{"query": entry.query, "response": entry.response, "timestamp": entry.timestamp} for entry in history]
+                return [
+                    {
+                        "query": entry.query,
+                        "response": entry.response,
+                        "timestamp": entry.timestamp,
+                    }
+                    for entry in history
+                ]
             except Exception as e:
                 logger.error(f"Error retrieving conversation history: {e}")
                 return []
 
-    async def generate_response(self, user_id: str, query: str, session_id: str = None, image_data: bytes = None) -> dict:
+    async def generate_response(
+        self, user_id: str, query: str, session_id: str = None, image_data: bytes = None
+    ) -> dict:
         start_time = datetime.utcnow()
         if image_data:
             caption = await self.captioner.generate_caption(image_data)
@@ -78,7 +106,9 @@ class ConversationalModule:
         gap_info = await self.curiosity.detect_gaps(conversation_context)
         if gap_info.get("status") == "insufficient_knowledge":
             query += " " + gap_info.get("additional_context", "")
-            logger.info("Query augmented with additional context from curiosity engine.")
+            logger.info(
+                "Query augmented with additional context from curiosity engine."
+            )
         reason_result = await self.reasoner.reason(query, user_id)
         if "result" in reason_result:
             refined_query = f"{query} {reason_result['result']}"
@@ -87,17 +117,47 @@ class ConversationalModule:
             refined_query = query
         llm_response = await self.llm.generate_response(refined_query)
         base_response = llm_response.get("text", "")
-        user_personality = await self.personality_engine.analyze_personality(user_id, [])
-        adapted_response = await self.dynamic_response.generate_adaptive_response(base_response, user_personality)
-        interaction_data = {"feedback": 0.8, "response_time": (datetime.utcnow()-start_time).total_seconds()}
+        user_personality = await self.personality_engine.analyze_personality(
+            user_id, []
+        )
+        adapted_response = await self.dynamic_response.generate_adaptive_response(
+            base_response, user_personality
+        )
+        interaction_data = {
+            "feedback": 0.8,
+            "response_time": (datetime.utcnow() - start_time).total_seconds(),
+        }
         await self.mimicry_module.update_profile(user_id, interaction_data)
-        final_response = await self.mimicry_module.adapt_response_style(adapted_response, user_id)
-        processing_time = (datetime.utcnow()-start_time).total_seconds()
-        await self.log_interaction(user_id, refined_query, final_response, llm_response.get("confidence", 0.9), processing_time)
-        return {"text": final_response, "confidence": llm_response.get("confidence", 0.9), "processing_time": processing_time}
+        final_response = await self.mimicry_module.adapt_response_style(
+            adapted_response, user_id
+        )
+        processing_time = (datetime.utcnow() - start_time).total_seconds()
+        await self.hippocampus.store(user_id, refined_query, final_response)
+        await self.log_interaction(
+            user_id,
+            refined_query,
+            final_response,
+            llm_response.get("confidence", 0.9),
+            processing_time,
+        )
+        spoken_response = await self.bouche.speak(final_response)
+        return {
+            "text": spoken_response,
+            "confidence": llm_response.get("confidence", 0.9),
+            "processing_time": processing_time,
+        }
 
-    async def log_interaction(self, user_id: str, query: str, response: str, confidence: float, processing_time: float):
-        logger.info(f"User: {user_id} | Query: {query} | Response: {response} | Confidence: {confidence} | Processing Time: {processing_time:.2f}s")
+    async def log_interaction(
+        self,
+        user_id: str,
+        query: str,
+        response: str,
+        confidence: float,
+        processing_time: float,
+    ):
+        logger.info(
+            f"User: {user_id} | Query: {query} | Response: {response} | Confidence: {confidence} | Processing Time: {processing_time:.2f}s"
+        )
 
     async def run_loop(self):
         while True:

--- a/monGARS/core/hippocampus.py
+++ b/monGARS/core/hippocampus.py
@@ -1,0 +1,33 @@
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MemoryItem:
+    user_id: str
+    query: str
+    response: str
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class Hippocampus:
+    """Simple in-memory store for conversation history."""
+
+    def __init__(self) -> None:
+        self._memory: Dict[str, List[MemoryItem]] = {}
+
+    async def store(self, user_id: str, query: str, response: str) -> None:
+        """Persist a query/response pair for a user."""
+        logger.debug("Storing interaction for %s", user_id)
+        self._memory.setdefault(user_id, []).append(
+            MemoryItem(user_id=user_id, query=query, response=response)
+        )
+
+    async def history(self, user_id: str, limit: int = 10) -> List[MemoryItem]:
+        """Return recent conversation history."""
+        items = self._memory.get(user_id, [])
+        return list(reversed(items[-limit:]))

--- a/tests/hippocampus_test.py
+++ b/tests/hippocampus_test.py
@@ -1,0 +1,12 @@
+import pytest
+
+from monGARS.core.hippocampus import Hippocampus
+
+
+@pytest.mark.asyncio
+async def test_hippocampus_store_and_history():
+    hippocampus = Hippocampus()
+    await hippocampus.store("u1", "hello", "hi")
+    history = await hippocampus.history("u1")
+    assert history[0].query == "hello"
+    assert history[0].response == "hi"


### PR DESCRIPTION
## Summary
- add Hippocampus memory storage and Bouche output modules
- wire new modules into conversation flow
- document completed roadmap task
- add unit test for new memory module
- improve Hippocampus performance and async testing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879c0a0420c8333a6e72b547d91683b