### PR TITLE
Add Iris web scraper and integrate into CuriosityEngine

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,7 @@ This roadmap summarizes the planned phases for monGARS based on the current arch
 
 ## Phase 2 – Functional Expansion
 - [x] Add Mimicry for behavioral adaptation and Mains Virtuelles for executing user-defined code.
-- Expand web scraping via Iris and refine the Curiosity Engine.
+- [x] Expand web scraping via Iris and refine the Curiosity Engine.
 - [x] Introduce extended tests and monitoring.
 
 ## Phase 3 – Hardware Integration

--- a/monGARS/core/cortex/curiosity_engine.py
+++ b/monGARS/core/cortex/curiosity_engine.py
@@ -6,6 +6,7 @@ import spacy
 from sqlalchemy import text
 
 from monGARS.config import get_settings
+from monGARS.core.iris import Iris
 from monGARS.core.neurones import EmbeddingSystem
 
 from ...init_db import async_session_factory
@@ -15,10 +16,11 @@ settings = get_settings()
 
 
 class CuriosityEngine:
-    def __init__(self):
+    def __init__(self, iris: Iris | None = None):
         self.embedding_system = EmbeddingSystem()
         self.knowledge_gap_threshold = 0.65
         self.nlp = spacy.load("fr_core_news_sm")
+        self.iris = iris or Iris()
 
     async def detect_gaps(self, conversation_context: dict) -> dict:
         last_query = conversation_context.get("last_query", "")
@@ -84,7 +86,15 @@ class CuriosityEngine:
                 if documents:
                     summary = " ".join(doc["summary"] for doc in documents)
                     return f"Contexte supplémentaire: {summary}"
+                result = await self.iris.search(query)
+                if result:
+                    return f"Contexte supplémentaire: {result}"
                 return "Aucun contexte supplémentaire trouvé."
             except Exception as e:
                 logger.error(f"Document retrieval error: {e}")
-                return "Échec de la récupération de documents."
+                result = await self.iris.search(query)
+                return (
+                    f"Contexte supplémentaire: {result}"
+                    if result
+                    else "Échec de la récupération de documents."
+                )

--- a/monGARS/core/cortex/curiosity_engine.py
+++ b/monGARS/core/cortex/curiosity_engine.py
@@ -86,15 +86,11 @@ class CuriosityEngine:
                 if documents:
                     summary = " ".join(doc["summary"] for doc in documents)
                     return f"Contexte supplémentaire: {summary}"
-                result = await self.iris.search(query)
-                if result:
-                    return f"Contexte supplémentaire: {result}"
-                return "Aucun contexte supplémentaire trouvé."
             except Exception as e:
                 logger.error(f"Document retrieval error: {e}")
-                result = await self.iris.search(query)
-                return (
-                    f"Contexte supplémentaire: {result}"
-                    if result
-                    else "Échec de la récupération de documents."
-                )
+
+            logger.info("Falling back to Iris for query: %s", query)
+            result = await self.iris.search(query)
+            if result:
+                return f"Contexte supplémentaire: {result}"
+            return "Aucun contexte supplémentaire trouvé."

--- a/monGARS/core/iris.py
+++ b/monGARS/core/iris.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional
 
 import httpx
+import trafilatura
 from bs4 import BeautifulSoup
 
 logger = logging.getLogger(__name__)
@@ -15,8 +16,8 @@ class Iris:
             try:
                 response = await client.get(url, timeout=10)
                 response.raise_for_status()
-                soup = BeautifulSoup(response.text, "html.parser")
-                return soup.get_text(separator=" ", strip=True)
+                text = trafilatura.extract(response.text)
+                return text.strip() if text else None
             except Exception as e:  # pragma: no cover - network issues
                 logger.error("Iris fetch error for %s: %s", url, e)
                 return None

--- a/monGARS/core/iris.py
+++ b/monGARS/core/iris.py
@@ -1,0 +1,32 @@
+import logging
+from typing import Optional
+
+import httpx
+from bs4 import BeautifulSoup
+
+logger = logging.getLogger(__name__)
+
+
+class Iris:
+    """Simple web scraper for retrieving page summaries."""
+
+    async def fetch_text(self, url: str) -> Optional[str]:
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.get(url, timeout=10)
+                response.raise_for_status()
+                soup = BeautifulSoup(response.text, "html.parser")
+                return soup.get_text(separator=" ", strip=True)
+            except Exception as e:  # pragma: no cover - network issues
+                logger.error("Iris fetch error for %s: %s", url, e)
+                return None
+
+    async def search(self, query: str) -> Optional[str]:
+        """Return snippet from the first search result."""
+        search_url = f"https://duckduckgo.com/html/?q={httpx.utils.quote(query)}"
+        text = await self.fetch_text(search_url)
+        if not text:
+            return None
+        soup = BeautifulSoup(text, "html.parser")
+        snippet = soup.find(class_="result__snippet")
+        return snippet.get_text(strip=True) if snippet else None

--- a/tests/test_iris.py
+++ b/tests/test_iris.py
@@ -1,0 +1,58 @@
+import sys
+import types
+
+import httpx
+import pytest
+
+sys.modules.setdefault("spacy", types.ModuleType("spacy"))
+sys.modules["spacy"].load = lambda name: object()
+sqlalchemy_stub = types.ModuleType("sqlalchemy")
+sqlalchemy_stub.text = lambda x: x
+sys.modules.setdefault("sqlalchemy", sqlalchemy_stub)
+
+init_db_stub = types.ModuleType("monGARS.init_db")
+init_db_stub.async_session_factory = lambda: None
+sys.modules.setdefault("monGARS.init_db", init_db_stub)
+config_stub = types.ModuleType("monGARS.config")
+config_stub.get_settings = lambda: types.SimpleNamespace(DOC_RETRIEVAL_URL="")
+sys.modules.setdefault("monGARS.config", config_stub)
+neuron_stub = types.ModuleType("monGARS.core.neurones")
+neuron_stub.EmbeddingSystem = lambda *a, **k: None
+sys.modules.setdefault("monGARS.core.neurones", neuron_stub)
+
+from monGARS.core.cortex.curiosity_engine import CuriosityEngine
+from monGARS.core.iris import Iris
+
+
+@pytest.mark.asyncio
+async def test_fetch_text_success(monkeypatch):
+    async def fake_get(self, url, timeout=10):
+        class Resp:
+            text = "<html><body>hello world</body></html>"
+
+            def raise_for_status(self):
+                pass
+
+        return Resp()
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+    iris = Iris()
+    result = await iris.fetch_text("http://example.com")
+    assert "hello world" in result
+
+
+@pytest.mark.asyncio
+async def test_curiosity_fallback_uses_iris(monkeypatch):
+    async def fake_post(*args, **kwargs):
+        raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    iris = Iris()
+
+    async def fake_search(query):
+        return "web snippet"
+
+    monkeypatch.setattr(iris, "search", fake_search)
+    engine = CuriosityEngine(iris=iris)
+    result = await engine._perform_research("test query")
+    assert "web snippet" in result

--- a/tests/test_iris.py
+++ b/tests/test_iris.py
@@ -3,6 +3,7 @@ import types
 
 import httpx
 import pytest
+import trafilatura
 
 sys.modules.setdefault("spacy", types.ModuleType("spacy"))
 sys.modules["spacy"].load = lambda name: object()
@@ -35,10 +36,14 @@ async def test_fetch_text_success(monkeypatch):
 
         return Resp()
 
+    def fake_extract(html):
+        return "hello world"
+
     monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+    monkeypatch.setattr(trafilatura, "extract", fake_extract)
     iris = Iris()
     result = await iris.fetch_text("http://example.com")
-    assert "hello world" in result
+    assert result == "hello world"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- implement `Iris` web scraping module
- integrate `Iris` with the CuriosityEngine for fallback research
- mark roadmap item complete
- add tests for Iris and new engine behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879cf94d2608333b4d33d9f32f31aaa

## Summary by Sourcery

Implement the Iris web scraper for page summaries, integrate it into CuriosityEngine as a fallback research source, update the roadmap accordingly, and add tests for the new scraper and engine behavior

New Features:
- Add Iris web scraping module with fetch_text and search methods

Enhancements:
- Integrate Iris into CuriosityEngine to provide fallback research when document retrieval fails

Documentation:
- Mark the Iris integration and CuriosityEngine refinement as completed in the roadmap

Tests:
- Add tests for Iris.fetch_text functionality and for CuriosityEngine fallback behavior using Iris.search

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new web scraping component that enables asynchronous retrieval of web page content and search result snippets.
  * Enhanced research functionality to automatically use web scraping as a fallback when external document retrieval fails.

* **Bug Fixes**
  * Improved error handling to ensure alternative knowledge sources are used in case of failures.

* **Tests**
  * Added tests to verify web scraping functionality and fallback behavior in research operations.

* **Documentation**
  * Updated roadmap to reflect completion of web scraping expansion and research engine refinement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->