### PR TITLE
Refine conversation history logic

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,7 @@ Milestone: proof-of-concept functionality established, real AI features still mi
 
 ## Phase 3 - Hardware & Performance Optimization (current - target Q3 2025)
 - Finish the LLM2Vec training pipeline and Ray Serve inference integration.
-- Implement the conversation history endpoint and fix social media token handling.
+- **[Completed]** Implement the conversation history endpoint. Social media token handling pending.
 - Optimize CPU and memory usage for Raspberry Pi and Jetson boards.
 - Build container images for embedded hardware targets.
 - Improve telemetry and finalize tiered caching and PostgreSQL migrations.

--- a/monGARS/api/dependencies.py
+++ b/monGARS/api/dependencies.py
@@ -1,3 +1,10 @@
-*(Already provided above in section 52)*
+from __future__ import annotations
 
----
+from monGARS.core.hippocampus import Hippocampus
+
+hippocampus = Hippocampus()
+
+
+def get_hippocampus() -> Hippocampus:
+    """Return the shared Hippocampus instance."""
+    return hippocampus

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ beautifulsoup4
 bleach
 django
 fastapi
+python-multipart
 GPUtil
 httpx
 hvac

--- a/tests/test_api_history.py
+++ b/tests/test_api_history.py
@@ -1,0 +1,27 @@
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("JWT_ALGORITHM", "HS256")
+
+from monGARS.api.dependencies import hippocampus
+from monGARS.api.web_api import app
+
+
+@pytest.mark.asyncio
+async def test_history_endpoint_returns_records():
+    await hippocampus.store("u1", "q1", "r1")
+    client = TestClient(app)
+    token_resp = client.post("/token", data={"username": "u1", "password": "x"})
+    assert token_resp.status_code == 200
+    token = token_resp.json()["access_token"]
+    resp = client.get(
+        "/api/v1/conversation/history",
+        params={"user_id": "u1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["query"] == "q1"


### PR DESCRIPTION
## Summary
- refine Hippocampus store/history logic using deque and limit validation
- validate history endpoint limit argument
- add python-multipart to requirements for login form handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b050a35108333a88eccf4e3e33e75