### PR TITLE
Implement social token encryption

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,8 @@ Milestone: proof-of-concept functionality established, real AI features still mi
 
 ## Phase 3 - Hardware & Performance Optimization (current - target Q3 2025)
 - Finish the LLM2Vec training pipeline and Ray Serve inference integration.
-- **[Completed]** Implement the conversation history endpoint. Social media token handling pending.
+- **[Completed]** Implement the conversation history endpoint.
+- **[Completed]** Add encrypted token handling for social media integration.
 - Optimize CPU and memory usage for Raspberry Pi and Jetson boards.
 - Build container images for embedded hardware targets.
 - **[Completed]** Added cache hit/miss metrics with OTEL units and layer labels. PostgreSQL migrations pending.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,6 +22,7 @@ Milestone: proof-of-concept functionality established, real AI features still mi
 - Finish the LLM2Vec training pipeline and Ray Serve inference integration.
 - **[Completed]** Implement the conversation history endpoint.
 - **[Completed]** Add encrypted token handling for social media integration.
+- **[Completed]** Improve error handling and tests for social posting.
 - Optimize CPU and memory usage for Raspberry Pi and Jetson boards.
 - Build container images for embedded hardware targets.
 - **[Completed]** Added cache hit/miss metrics with OTEL units and layer labels. PostgreSQL migrations pending.

--- a/monGARS/core/security.py
+++ b/monGARS/core/security.py
@@ -1,38 +1,81 @@
 import re
-from jose import jwt, JWTError
-from passlib.context import CryptContext
+from base64 import urlsafe_b64encode
 from datetime import datetime, timedelta, timezone
-from monGARS.config import get_settings
+from typing import Optional, Union
+
 import bleach
+from cryptography.fernet import Fernet, InvalidToken
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+from monGARS.config import get_settings
 
 settings = get_settings()
 
+
 class SecurityManager:
-    def __init__(self, secret_key: str = settings.SECRET_KEY, algorithm: str = settings.JWT_ALGORITHM):
+    def __init__(
+        self,
+        secret_key: str = settings.SECRET_KEY,
+        algorithm: str = settings.JWT_ALGORITHM,
+    ) -> None:
         self.secret_key = secret_key
         self.algorithm = algorithm
         self.pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
-    def create_access_token(self, data: dict, expires_delta: timedelta = None) -> str:
+    def create_access_token(
+        self, data: dict, expires_delta: Optional[timedelta] = None
+    ) -> str:
         to_encode = data.copy()
-        expire = datetime.now(timezone.utc) + (expires_delta if expires_delta else timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES))
+        expire = datetime.now(timezone.utc) + (
+            expires_delta
+            if expires_delta
+            else timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+        )
         to_encode.update({"exp": expire.timestamp()})
         return jwt.encode(to_encode, self.secret_key, algorithm=self.algorithm)
 
     def verify_token(self, token: str) -> dict:
         try:
             payload = jwt.decode(token, self.secret_key, algorithms=[self.algorithm])
-            if datetime.fromtimestamp(payload['exp'], tz=timezone.utc) <= datetime.now(timezone.utc):
+            if datetime.fromtimestamp(payload["exp"], tz=timezone.utc) <= datetime.now(
+                timezone.utc
+            ):
                 raise ValueError("Token expired")
             return payload
-        except JWTError as e:
-            raise ValueError(f"Token verification failed: {e}")
+        except JWTError as exc:
+            raise ValueError(f"Token verification failed: {exc}")
 
     def get_password_hash(self, password: str) -> str:
         return self.pwd_context.hash(password)
 
     def verify_password(self, plain_password: str, hashed_password: str) -> bool:
         return self.pwd_context.verify(plain_password, hashed_password)
+
+
+def _get_fernet(key: Union[str, bytes, None] = None) -> Fernet:
+    key_bytes = (
+        key.encode()
+        if isinstance(key, str)
+        else key if key is not None else settings.SECRET_KEY.encode()
+    )
+    if len(key_bytes) != 32:
+        key_bytes = urlsafe_b64encode(key_bytes[:32])
+    return Fernet(key_bytes)
+
+
+def encrypt_token(token: str, key: Union[str, bytes, None] = None) -> str:
+    f = _get_fernet(key)
+    return f.encrypt(token.encode()).decode()
+
+
+def decrypt_token(token: str, key: Union[str, bytes, None] = None) -> str:
+    f = _get_fernet(key)
+    try:
+        return f.decrypt(token.encode()).decode()
+    except InvalidToken as exc:
+        raise ValueError("Invalid encrypted token") from exc
+
 
 def validate_user_input(data: dict) -> dict:
     for key, value in data.items():
@@ -43,7 +86,8 @@ def validate_user_input(data: dict) -> dict:
         raise ValueError("Missing required fields: user_id and query.")
     return data
 
+
 class Credentials:
-    def __init__(self, username: str, password: str):
+    def __init__(self, username: str, password: str) -> None:
         self.username = username
         self.password = password

--- a/monGARS/core/social.py
+++ b/monGARS/core/social.py
@@ -1,3 +1,45 @@
-*(Already provided above in section 47)*
+import logging
+from typing import Optional
 
----
+import aiohttp
+
+from monGARS.config import get_settings
+from monGARS.core.security import decrypt_token
+
+logger = logging.getLogger(__name__)
+
+
+class SocialMediaManager:
+    """Simple interface for posting content to social platforms."""
+
+    def __init__(self) -> None:
+        self.settings = get_settings()
+
+    async def post_to_twitter(self, content: str, encrypted_token: str) -> bool:
+        """Post a tweet using an encrypted bearer token."""
+        access_token = decrypt_token(encrypted_token)
+        async with aiohttp.ClientSession() as session:
+            headers = {"Authorization": f"Bearer {access_token}"}
+            async with session.post(
+                "https://api.twitter.com/2/tweets",
+                json={"text": content},
+                headers=headers,
+            ) as response:
+                return response.status == 201
+
+    async def analyze_social_sentiment(self, post: str) -> dict:
+        """Placeholder sentiment analysis for a social post."""
+        score = 0
+        positive_words = {"great", "love", "good", "happy"}
+        negative_words = {"bad", "hate", "terrible", "sad"}
+        for word in post.lower().split():
+            if word in positive_words:
+                score += 1
+            if word in negative_words:
+                score -= 1
+        sentiment = "neutral"
+        if score > 0:
+            sentiment = "positive"
+        elif score < 0:
+            sentiment = "negative"
+        return {"sentiment": sentiment, "score": score}

--- a/monGARS/core/social.py
+++ b/monGARS/core/social.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Optional
 
@@ -17,15 +18,30 @@ class SocialMediaManager:
 
     async def post_to_twitter(self, content: str, encrypted_token: str) -> bool:
         """Post a tweet using an encrypted bearer token."""
-        access_token = decrypt_token(encrypted_token)
-        async with aiohttp.ClientSession() as session:
-            headers = {"Authorization": f"Bearer {access_token}"}
-            async with session.post(
-                "https://api.twitter.com/2/tweets",
-                json={"text": content},
-                headers=headers,
-            ) as response:
-                return response.status == 201
+        try:
+            access_token = decrypt_token(encrypted_token)
+        except ValueError as exc:
+            logger.error("Token decryption failed: %s", exc)
+            return False
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                headers = {"Authorization": f"Bearer {access_token}"}
+                async with session.post(
+                    "https://api.twitter.com/2/tweets",
+                    json={"text": content},
+                    headers=headers,
+                ) as response:
+                    if response.status != 201:
+                        logger.error("Twitter API returned status %s", response.status)
+                        return False
+                    return True
+        except asyncio.TimeoutError:
+            logger.error("Twitter request timed out")
+            return False
+        except aiohttp.ClientError as exc:
+            logger.error("Twitter request failed: %s", exc)
+            return False
 
     async def analyze_social_sentiment(self, post: str) -> dict:
         """Placeholder sentiment analysis for a social post."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ uvicorn
 llm2vec
 pytest
 pytest-asyncio
+cryptography

--- a/tests/test_social_media.py
+++ b/tests/test_social_media.py
@@ -1,0 +1,42 @@
+import importlib
+import os
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key-123456789012345678901234")
+
+from monGARS.core import security, social
+
+importlib.reload(social)
+importlib.reload(security)
+
+
+class FakeResponse:
+    def __init__(self, status: int = 201) -> None:
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+class FakeSession:
+    def post(self, *args, **kwargs):
+        return FakeResponse()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_post_to_twitter(monkeypatch):
+    monkeypatch.setattr(social.aiohttp, "ClientSession", lambda: FakeSession())
+    mgr = social.SocialMediaManager()
+    token = security.encrypt_token("secret-token")
+
+    assert await mgr.post_to_twitter("hi", token)

--- a/tests/test_social_media.py
+++ b/tests/test_social_media.py
@@ -1,9 +1,11 @@
+import asyncio
 import importlib
 import os
 
+import aiohttp
 import pytest
 
-os.environ.setdefault("SECRET_KEY", "test-secret-key-123456789012345678901234")
+os.environ.setdefault("SECRET_KEY", "test-secret-key")
 
 from monGARS.core import security, social
 
@@ -40,3 +42,65 @@ async def test_post_to_twitter(monkeypatch):
     token = security.encrypt_token("secret-token")
 
     assert await mgr.post_to_twitter("hi", token)
+
+
+class UnauthorizedSession(FakeSession):
+    def post(self, *args, **kwargs):
+        return FakeResponse(status=401)
+
+
+class TimeoutSession:
+    def post(self, *args, **kwargs):
+        raise asyncio.TimeoutError
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+class ErrorSession:
+    def post(self, *args, **kwargs):
+        raise aiohttp.ClientError("boom")
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_post_to_twitter_auth_failure(monkeypatch):
+    monkeypatch.setattr(social.aiohttp, "ClientSession", lambda: UnauthorizedSession())
+    mgr = social.SocialMediaManager()
+    token = security.encrypt_token("secret-token")
+
+    assert not await mgr.post_to_twitter("fail", token)
+
+
+@pytest.mark.asyncio
+async def test_post_to_twitter_timeout(monkeypatch):
+    monkeypatch.setattr(social.aiohttp, "ClientSession", lambda: TimeoutSession())
+    mgr = social.SocialMediaManager()
+    token = security.encrypt_token("secret-token")
+
+    assert not await mgr.post_to_twitter("timeout", token)
+
+
+@pytest.mark.asyncio
+async def test_post_to_twitter_network_error(monkeypatch):
+    monkeypatch.setattr(social.aiohttp, "ClientSession", lambda: ErrorSession())
+    mgr = social.SocialMediaManager()
+    token = security.encrypt_token("secret-token")
+
+    assert not await mgr.post_to_twitter("boom", token)
+
+
+@pytest.mark.asyncio
+async def test_post_to_twitter_bad_token(monkeypatch):
+    monkeypatch.setattr(social.aiohttp, "ClientSession", lambda: FakeSession())
+    mgr = social.SocialMediaManager()
+
+    assert not await mgr.post_to_twitter("hi", "not-encrypted")

--- a/tests/test_token_security.py
+++ b/tests/test_token_security.py
@@ -1,0 +1,22 @@
+import importlib
+import os
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key-123456789012345678901234")
+
+from monGARS.core import security
+
+importlib.reload(security)
+
+
+def test_encrypt_and_decrypt_roundtrip():
+    token = "mytoken"
+    encrypted = security.encrypt_token(token)
+    assert encrypted != token
+    assert security.decrypt_token(encrypted) == token
+
+
+def test_decrypt_invalid_token():
+    with pytest.raises(ValueError):
+        security.decrypt_token("invalid")

--- a/tests/test_token_security.py
+++ b/tests/test_token_security.py
@@ -3,7 +3,7 @@ import os
 
 import pytest
 
-os.environ.setdefault("SECRET_KEY", "test-secret-key-123456789012345678901234")
+os.environ.setdefault("SECRET_KEY", "test-secret-key")
 
 from monGARS.core import security
 
@@ -12,6 +12,53 @@ importlib.reload(security)
 
 def test_encrypt_and_decrypt_roundtrip():
     token = "mytoken"
+    encrypted = security.encrypt_token(token)
+    assert encrypted != token
+    assert security.decrypt_token(encrypted) == token
+
+
+def test_encrypt_and_decrypt_with_custom_key(monkeypatch):
+    custom_key = "custom-secret-key-987654321098765432109876"
+    monkeypatch.setenv("SECRET_KEY", custom_key)
+    import monGARS.config as config
+
+    config.get_settings.cache_clear()
+    import importlib
+
+    import monGARS.core.security as security_mod
+
+    importlib.reload(security_mod)
+    token = "customkeytoken"
+    encrypted = security_mod.encrypt_token(token)
+    assert encrypted != token
+    assert security_mod.decrypt_token(encrypted) == token
+
+
+def test_decrypt_with_wrong_key(monkeypatch):
+    token = "wrongkeytoken"
+    encrypted = security.encrypt_token(token)
+    monkeypatch.setenv("SECRET_KEY", "another-secret-key-0000000000000000000000")
+    import monGARS.config as config
+
+    config.get_settings.cache_clear()
+    import importlib
+
+    import monGARS.core.security as security_mod
+
+    importlib.reload(security_mod)
+    with pytest.raises(ValueError):
+        security_mod.decrypt_token(encrypted)
+
+
+def test_encrypt_and_decrypt_empty_token():
+    token = ""
+    encrypted = security.encrypt_token(token)
+    assert encrypted != token
+    assert security.decrypt_token(encrypted) == token
+
+
+def test_encrypt_and_decrypt_very_long_token():
+    token = "a" * 10000
     encrypted = security.encrypt_token(token)
     assert encrypted != token
     assert security.decrypt_token(encrypted) == token


### PR DESCRIPTION
## Summary
- add Fernet-based token encryption/decryption
- introduce SocialMediaManager with encrypted token support
- include new tests for security helpers and social module
- install additional requirement `cryptography`
- update roadmap for completed task

## Testing
- `pytest tests/test_token_security.py tests/test_social_media.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687b15ac73a88333852de773db0d32e8

## Summary by Sourcery

Implement secure token encryption via Fernet, provide a SocialMediaManager for encrypted-token posting and sentiment analysis, update dependencies and tests accordingly

New Features:
- Add Fernet-based encrypt_token and decrypt_token functions for secure token handling
- Introduce SocialMediaManager with encrypted token support for posting to Twitter and basic sentiment analysis

Build:
- Add cryptography to project dependencies

Documentation:
- Update roadmap to mark encrypted token handling as completed

Tests:
- Add tests for token encryption/decryption
- Add async tests for social media posting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added encrypted token handling for social media integration.
  * Introduced a Social Media Manager with the ability to post to Twitter and perform basic sentiment analysis.
* **Bug Fixes**
  * Improved security for social media tokens through encryption and decryption utilities.
* **Documentation**
  * Updated the roadmap to reflect completed conversation history endpoint and encrypted token handling.
* **Tests**
  * Added tests for social media posting and token encryption/decryption functionality.
* **Chores**
  * Added the cryptography package as a new dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->