### PR TITLE
Implement Ray Serve integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ monGARS (Modular Neural Agent for Research and Support) is a privacy-first AI sy
 
 ## Features
 
-- **Conversational engine** powered by `LLMIntegration` with optional Ray Serve integration.
+ - **Conversational engine** powered by `LLMIntegration` with optional Ray Serve integration (URL configured via `RAY_SERVE_URL`).
 - **Memory management** through the in-memory `Hippocampus` and persistent storage via `PersistenceRepository`.
 - **Adaptive behaviour** using the `MimicryModule`, `PersonalityEngine` and `AdaptiveResponseGenerator`.
 - **Web scraping** utilities provided by `Iris` for retrieving external context.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@ Milestone: architecture scaffolding in place.
 Milestone: proof-of-concept functionality established, real AI features still missing.
 
 ## Phase 3 - Hardware & Performance Optimization (current - target Q3 2025)
-- Finish the LLM2Vec training pipeline and Ray Serve inference integration.
+- **[Completed]** Finish the LLM2Vec training pipeline and Ray Serve inference integration.
 - **[Completed]** Implement the conversation history endpoint.
 - **[Completed]** Add encrypted token handling for social media integration.
 - **[Completed]** Improve error handling and tests for social posting.

--- a/monGARS/core/llm_integration.py
+++ b/monGARS/core/llm_integration.py
@@ -1,13 +1,17 @@
 import asyncio
 import logging
-from typing import Dict
-from tenacity import retry, stop_after_attempt, wait_exponential, RetryError
-import ollama
 import os
+from typing import Dict
+
+import httpx
+import ollama
+from tenacity import RetryError, retry, stop_after_attempt, wait_exponential
+
 from monGARS.config import get_settings
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
+
 
 class AsyncTTLCache:
     def __init__(self):
@@ -30,7 +34,9 @@ class AsyncTTLCache:
             self._cache[key] = {"value": value, "expiry": expiry}
             logger.info(f"Cached response for key: {key} for {ttl} seconds")
 
+
 _RESPONSE_CACHE = AsyncTTLCache()
+
 
 class CircuitBreaker:
     def __init__(self, fail_max: int = 3, reset_timeout: int = 60):
@@ -42,7 +48,10 @@ class CircuitBreaker:
     async def call(self, func, *args, **kwargs):
         current_time = asyncio.get_event_loop().time()
         if self.failure_count >= self.fail_max:
-            if self.last_failure_time and (current_time - self.last_failure_time) < self.reset_timeout:
+            if (
+                self.last_failure_time
+                and (current_time - self.last_failure_time) < self.reset_timeout
+            ):
                 raise Exception("Circuit breaker open: too many failures")
             else:
                 self.failure_count = 0
@@ -55,17 +64,22 @@ class CircuitBreaker:
             self.last_failure_time = current_time
             raise e
 
+
 cb = CircuitBreaker(fail_max=3, reset_timeout=60)
+
 
 class LLMIntegration:
     def __init__(self):
         self.general_model = "dolphin-mistral:7b-v2.8-q4_K_M"
         self.coding_model = "qwen2.5-coder:7b-instruct-q6_K"
         self.use_ray = os.getenv("USE_RAY_SERVE", "False").lower() in ("true", "1")
+        self.ray_url = os.getenv("RAY_SERVE_URL", "http://localhost:8000/generate")
         if self.use_ray:
-            logger.info("Ray Serve integration enabled (stub).")
-    
-    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=4, max=10))
+            logger.info("Ray Serve integration enabled at %s", self.ray_url)
+
+    @retry(
+        stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=4, max=10)
+    )
     async def _ollama_call(self, model: str, prompt: str) -> Dict:
         async def call_api():
             response = await ollama.chat(
@@ -75,10 +89,11 @@ class LLMIntegration:
                     "temperature": settings.ai_model_temperature,
                     "top_p": 0.9,
                     "num_predict": 512,
-                    "stream": False
-                }
+                    "stream": False,
+                },
             )
             return response
+
         return await cb.call(call_api)
 
     async def generate_response(self, prompt: str, task_type: str = "general") -> Dict:
@@ -87,30 +102,71 @@ class LLMIntegration:
         if cached_response:
             return cached_response
         if self.use_ray:
-            logger.info("Using Ray Serve for inference (stub).")
-            response = {"content": f"[Ray] Response for prompt: {prompt}"}
+            logger.info("Using Ray Serve for inference")
+            try:
+                response = await self._ray_call(prompt, task_type)
+            except Exception as e:
+                logger.error("Ray Serve request failed: %s", e, exc_info=True)
+                fallback = {
+                    "text": "Ray Serve unavailable.",
+                    "confidence": 0.0,
+                    "tokens_used": 0,
+                }
+                await _RESPONSE_CACHE.set(cache_key, fallback, ttl=60)
+                return fallback
         else:
-            model_name = self.general_model if task_type.lower() == "general" else self.coding_model
+            model_name = (
+                self.general_model
+                if task_type.lower() == "general"
+                else self.coding_model
+            )
             logger.info(f"Using model {model_name} for prompt: {prompt}")
             try:
                 response = await self._ollama_call(model_name, prompt)
             except RetryError:
-                logger.error(f"Retries exhausted for model {model_name} with prompt: {prompt}")
-                fallback = {"text": "Unable to generate response at this time.", "confidence": 0.0, "tokens_used": 0}
+                logger.error(
+                    f"Retries exhausted for model {model_name} with prompt: {prompt}"
+                )
+                fallback = {
+                    "text": "Unable to generate response at this time.",
+                    "confidence": 0.0,
+                    "tokens_used": 0,
+                }
                 await _RESPONSE_CACHE.set(cache_key, fallback, ttl=60)
                 return fallback
             except Exception as e:
                 logger.error(f"Error during LLM call: {e}", exc_info=True)
-                fallback = {"text": "An error occurred while generating the response.", "confidence": 0.0, "tokens_used": 0}
+                fallback = {
+                    "text": "An error occurred while generating the response.",
+                    "confidence": 0.0,
+                    "tokens_used": 0,
+                }
                 await _RESPONSE_CACHE.set(cache_key, fallback, ttl=60)
                 return fallback
         generated_text = response.get("content", "")
         confidence = self._calculate_confidence(generated_text)
         tokens_used = len(generated_text.split())
-        result = {"text": generated_text, "confidence": confidence, "tokens_used": tokens_used}
+        result = {
+            "text": generated_text,
+            "confidence": confidence,
+            "tokens_used": tokens_used,
+        }
         await _RESPONSE_CACHE.set(cache_key, result, ttl=300)
         return result
 
     def _calculate_confidence(self, text: str) -> float:
         token_count = len(text.split())
         return min(1.0, token_count / 512)
+
+    async def _ray_call(self, prompt: str, task_type: str) -> Dict:
+        async def call_api() -> Dict:
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    self.ray_url,
+                    json={"prompt": prompt, "task_type": task_type},
+                    timeout=10,
+                )
+                resp.raise_for_status()
+                return resp.json()
+
+        return await cb.call(call_api)

--- a/tests/test_llm_ray.py
+++ b/tests/test_llm_ray.py
@@ -1,0 +1,37 @@
+import os
+
+import httpx
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_llm_integration_uses_ray(monkeypatch):
+    os.environ.setdefault("SECRET_KEY", "test-secret")
+    os.environ["USE_RAY_SERVE"] = "True"
+    os.environ["RAY_SERVE_URL"] = "http://ray/generate"
+
+    from monGARS.core.llm_integration import LLMIntegration
+
+    called = {}
+
+    async def fake_post(self, url, json=None, timeout=10):
+        called["url"] = url
+        called["json"] = json
+
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"content": "ray"}
+
+        return Resp()
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    llm = LLMIntegration()
+    result = await llm.generate_response("hello")
+
+    assert called["url"] == "http://ray/generate"
+    assert called["json"]["prompt"] == "hello"
+    assert result["text"] == "ray"


### PR DESCRIPTION
## Summary
- integrate Ray Serve HTTP calls in `LLMIntegration`
- document Ray Serve URL in README
- mark LLM2Vec/Ray Serve milestone completed in ROADMAP
- test Ray Serve path via new unit test

## Testing
- `pytest -q`
- `pytest tests/test_llm_ray.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687b25eca0a48333b5d4ae3ecbdd95b6