### PR TITLE
Implement SelfTrainingEngine and add tests

### DIFF
--- a/monGARS/core/self_training.py
+++ b/monGARS/core/self_training.py
@@ -1,3 +1,46 @@
-*(Already provided above in section 46)*
+from __future__ import annotations
 
----
+import asyncio
+import logging
+from typing import Any, Dict
+
+from monGARS.core.neurones import EmbeddingSystem
+
+logger = logging.getLogger(__name__)
+
+
+class SelfTrainingEngine:
+    """Simplified self-training engine that batches data and records model versions."""
+
+    def __init__(
+        self, training_threshold: float = 0.8, retrain_interval: int = 3600
+    ) -> None:
+        self.training_threshold = training_threshold
+        self.retrain_interval = retrain_interval
+        self.training_queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue(maxsize=1000)
+        self.model_versions: Dict[str, Dict[str, Any]] = {}
+        self.last_retrain_time: float = 0.0
+        self._embedding_model = EmbeddingSystem()
+        self.lock = asyncio.Lock()
+        logger.info("SelfTrainingEngine initialized.")
+
+    async def auto_improve(self) -> None:
+        """Periodically trigger training cycles."""
+        while True:
+            await asyncio.sleep(self.retrain_interval)
+            await self._run_training_cycle()
+
+    async def _run_training_cycle(self) -> None:
+        batch = []
+        while not self.training_queue.empty() and len(batch) < 100:
+            batch.append(await self.training_queue.get())
+        if not batch:
+            return
+        async with self.lock:
+            new_version = len(self.model_versions) + 1
+            self.model_versions[f"v{new_version}"] = {
+                "trained_at": asyncio.get_event_loop().time(),
+                "data_count": len(batch),
+            }
+            logger.info("Training complete. New model version: v%s", new_version)
+            self.last_retrain_time = asyncio.get_event_loop().time()

--- a/tests/chaos_test.py
+++ b/tests/chaos_test.py
@@ -1,3 +1,31 @@
-def test_placeholder():
-    assert True
+import asyncio
+import os
 
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("JWT_ALGORITHM", "HS256")
+
+from monGARS.core.llm_integration import CircuitBreaker
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_trips_and_recovers():
+    cb = CircuitBreaker(fail_max=2, reset_timeout=1)
+
+    async def fail():
+        raise RuntimeError("boom")
+
+    async def succeed():
+        return 42
+
+    with pytest.raises(RuntimeError):
+        await cb.call(fail)
+    with pytest.raises(RuntimeError):
+        await cb.call(fail)
+    with pytest.raises(Exception):
+        await cb.call(succeed)
+
+    await asyncio.sleep(1.1)
+    result = await cb.call(succeed)
+    assert result == 42

--- a/tests/property_test.py
+++ b/tests/property_test.py
@@ -1,3 +1,37 @@
-def test_placeholder():
-    assert True
+import asyncio
+import os
+import sys
+import types
 
+import pytest
+
+# Disable metrics exporter during tests
+os.environ.setdefault("OTEL_METRICS_ENABLED", "False")
+os.environ.setdefault("OTEL_SDK_DISABLED", "True")
+metric_module = types.ModuleType(
+    "opentelemetry.exporter.otlp.proto.http.metric_exporter"
+)
+metric_module.OTLPMetricExporter = lambda *a, **k: types.SimpleNamespace(
+    export=lambda *x, **y: None
+)
+sys.modules["opentelemetry.exporter.otlp.proto.http.metric_exporter"] = metric_module
+
+from monGARS.core.caching.tiered_cache import TieredCache
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("key,value", [("a", "b"), ("1", "2"), ("x", "y")])
+async def test_tiered_cache_roundtrip(tmp_path, key, value):
+    cache = TieredCache(directory=str(tmp_path))
+    await cache.clear_all()
+    await cache.set(key, value)
+    assert await cache.get(key) == value
+
+
+@pytest.mark.asyncio
+async def test_tiered_cache_ttl_expiry(tmp_path):
+    cache = TieredCache(directory=str(tmp_path))
+    await cache.clear_all()
+    await cache.set("expire", "v", ttl=1)
+    await asyncio.sleep(1.1)
+    assert await cache.get("expire") is None

--- a/tests/self_training_test.py
+++ b/tests/self_training_test.py
@@ -1,3 +1,27 @@
-def test_placeholder():
-    assert True
+import sys
+import types
 
+import pytest
+
+# Provide a minimal EmbeddingSystem to satisfy imports
+module = types.ModuleType("monGARS.core.neurones")
+module.EmbeddingSystem = object
+sys.modules["monGARS.core.neurones"] = module
+
+from monGARS.core.self_training import SelfTrainingEngine
+
+
+@pytest.mark.asyncio
+async def test_run_training_cycle_creates_version():
+    engine = SelfTrainingEngine()
+    await engine.training_queue.put({"data": 1})
+    await engine._run_training_cycle()
+    assert "v1" in engine.model_versions
+    assert engine.model_versions["v1"]["data_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_run_training_cycle_no_data():
+    engine = SelfTrainingEngine()
+    await engine._run_training_cycle()
+    assert engine.model_versions == {}


### PR DESCRIPTION
## Summary
- flesh out self_training module
- add circuit breaker test
- add tiered cache tests and disable OTEL metrics
- add self training engine tests

## Testing
- `pytest tests/chaos_test.py tests/property_test.py tests/self_training_test.py -q` *(fails: Connection refused to metrics exporter)*

------
https://chatgpt.com/codex/tasks/task_e_687b2fa402648333a6e30611a24ceef8