### PR TITLE
Add embedded build script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ This repository contains the source code for **monGARS**, a modular, privacy-fir
 - Hardware-specific optimisations automatically adjust worker count using
   `monGARS.utils.hardware`. Physical cores are preferred but the helper
   falls back to logical CPUs when necessary. See `README.md` for details.
+- Use `build_embedded.sh` to create multi-arch images for Raspberry Pi and Jetson using Docker Buildx.
 - Kubernetes RBAC policies were tightened. Refer to `rbac.yaml`.
  - Record common errors and the strategies developed to resolve them here so
   future contributors don't repeat the same investigation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ This repository contains the source code for **monGARS**, a modular, privacy-fir
 - Hardware-specific optimisations automatically adjust worker count using
   `monGARS.utils.hardware`. Physical cores are preferred but the helper
   falls back to logical CPUs when necessary. See `README.md` for details.
-- Use `build_embedded.sh` to create multi-arch images for Raspberry Pi and Jetson using Docker Buildx.
+- Use `build_embedded.sh` to create and push multi-arch images for Raspberry Pi and Jetson using Docker Buildx. Ensure you are logged in to your registry before running the script.
 - Use `build_native.sh` to build an optimized x86_64 image leveraging all CPU cores on a developer workstation.
 - Kubernetes RBAC policies were tightened. Refer to `rbac.yaml`.
  - Record common errors and the strategies developed to resolve them here so

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ This repository contains the source code for **monGARS**, a modular, privacy-fir
   `monGARS.utils.hardware`. Physical cores are preferred but the helper
   falls back to logical CPUs when necessary. See `README.md` for details.
 - Use `build_embedded.sh` to create multi-arch images for Raspberry Pi and Jetson using Docker Buildx.
+- Use `build_native.sh` to build an optimized x86_64 image leveraging all CPU cores on a developer workstation.
 - Kubernetes RBAC policies were tightened. Refer to `rbac.yaml`.
  - Record common errors and the strategies developed to resolve them here so
   future contributors don't repeat the same investigation.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # --- Build Stage ---
 FROM nvcr.io/nvidia/pytorch:23.10-py3 AS builder
+ARG JOBS=1
+ENV MAKEFLAGS="-j${JOBS}"
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/Dockerfile.embedded
+++ b/Dockerfile.embedded
@@ -1,0 +1,11 @@
+FROM python:3.10-slim AS builder
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . /app
+
+FROM python:3.10-slim
+WORKDIR /app
+COPY --from=builder /app /app
+EXPOSE 8000
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Code style is enforced using `black` and `isort` as outlined in `AGENTS.md`.
 ## Deployment
 
 Production deployments can be containerised via the provided `Dockerfile`. Kubernetes manifests live in `k8s/` for cluster environments. Adjust resource limits and RBAC rules as required for your infrastructure.
-Use `./build_embedded.sh` with Docker Buildx to build multi-architecture images for Raspberry Pi and Jetson using `Dockerfile.embedded`.
+Use `./build_embedded.sh` with Docker Buildx to build and push multi-architecture images for Raspberry Pi and Jetson using `Dockerfile.embedded`. Provide a repository name (e.g. `user/image:tag`) and ensure you're logged in to your container registry.
 The `build_native.sh` helper builds an optimized x86_64 image tuned for fast compiles on a typical Intel i7 workstation.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Code style is enforced using `black` and `isort` as outlined in `AGENTS.md`.
 
 Production deployments can be containerised via the provided `Dockerfile`. Kubernetes manifests live in `k8s/` for cluster environments. Adjust resource limits and RBAC rules as required for your infrastructure.
 Use `./build_embedded.sh` with Docker Buildx to build multi-architecture images for Raspberry Pi and Jetson using `Dockerfile.embedded`.
+The `build_native.sh` helper builds an optimized x86_64 image tuned for fast compiles on a typical Intel i7 workstation.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Code style is enforced using `black` and `isort` as outlined in `AGENTS.md`.
 ## Deployment
 
 Production deployments can be containerised via the provided `Dockerfile`. Kubernetes manifests live in `k8s/` for cluster environments. Adjust resource limits and RBAC rules as required for your infrastructure.
+Use `./build_embedded.sh` with Docker Buildx to build multi-architecture images for Raspberry Pi and Jetson using `Dockerfile.embedded`.
 
 ## Contributing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,6 +27,7 @@ Milestone: proof-of-concept functionality established, real AI features still mi
   Worker auto-tuning now falls back to logical CPUs when physical core count is
   unavailable.
 - **[Completed]** Build container images for embedded hardware targets.
+- **[Completed]** Provide a host-optimized build script for Intel i7 developer workstations.
 - **[Completed]** Added cache hit/miss metrics with OTEL units and layer labels. PostgreSQL migrations pending.
 - **[Completed]** Harden security policies and RBAC rules.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,6 +28,7 @@ Milestone: proof-of-concept functionality established, real AI features still mi
   unavailable.
 - **[Completed]** Build container images for embedded hardware targets.
 - **[Completed]** Provide a host-optimized build script for Intel i7 developer workstations.
+- **[Completed]** Improved embedded build script to push multi-arch images to a registry.
 - **[Completed]** Added cache hit/miss metrics with OTEL units and layer labels. PostgreSQL migrations pending.
 - **[Completed]** Harden security policies and RBAC rules.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@ Milestone: proof-of-concept functionality established, real AI features still mi
 - **[Completed]** Optimize CPU and memory usage for Raspberry Pi and Jetson boards.
   Worker auto-tuning now falls back to logical CPUs when physical core count is
   unavailable.
-- Build container images for embedded hardware targets.
+- **[Completed]** Build container images for embedded hardware targets.
 - **[Completed]** Added cache hit/miss metrics with OTEL units and layer labels. PostgreSQL migrations pending.
 - **[Completed]** Harden security policies and RBAC rules.
 

--- a/build_embedded.sh
+++ b/build_embedded.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
+# Build and push a multi-architecture image for Raspberry Pi and Jetson boards.
+# Usage: ./build_embedded.sh [IMAGE_NAME]
+
 IMAGE_NAME=${1:-mongars-embedded}
 PLATFORMS="linux/arm/v7,linux/arm64/v8"
 
+# The --push flag is required for multi-platform images. Ensure you are
+# authenticated to your container registry before running this script.
 docker buildx build \
   --platform "$PLATFORMS" \
   -f Dockerfile.embedded \
   -t "$IMAGE_NAME" \
-  --load .
+  --push .

--- a/build_embedded.sh
+++ b/build_embedded.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+IMAGE_NAME=${1:-mongars-embedded}
+PLATFORMS="linux/arm/v7,linux/arm64/v8"
+
+docker buildx build \
+  --platform "$PLATFORMS" \
+  -f Dockerfile.embedded \
+  -t "$IMAGE_NAME" \
+  --load .

--- a/build_native.sh
+++ b/build_native.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Build optimized Docker image for a high-performance Intel-based workstation.
+# Usage: ./build_native.sh [IMAGE_NAME]
+
+IMAGE_NAME=${1:-mongars-native}
+JOBS=$(nproc)
+
+docker buildx build \
+  --platform linux/amd64 \
+  --build-arg JOBS="$JOBS" \
+  -t "$IMAGE_NAME" \
+  --load .


### PR DESCRIPTION
## Summary
- provide `Dockerfile.embedded` for arm builds
- script `build_embedded.sh` to produce Raspberry Pi and Jetson images
- document embedded build workflow
- mark roadmap item for embedded images completed
- mention new script in contribution guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b404991a08333be31a9384e43bc1b

## Summary by Sourcery

Add embedded build support by providing an ARM-specific Dockerfile, multi-arch build script, and accompanying documentation updates.

New Features:
- Add Dockerfile.embedded for ARM builds
- Introduce build_embedded.sh script to create multi-architecture Raspberry Pi and Jetson images

Documentation:
- Document embedded build workflow in README and AGENTS guide
- Mark embedded images milestone as completed in ROADMAP

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/monGARS/25)
<!-- GitContextEnd -->