### PR TITLE
Implement encrypted peer messaging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ This repository contains the source code for **monGARS**, a modular, privacy-fir
 - Use `build_embedded.sh` to create and push multi-arch images for Raspberry Pi and Jetson using Docker Buildx. Ensure you are logged in to your registry before running the script.
 - Use `build_native.sh` to build an optimized x86_64 image leveraging all CPU cores on a developer workstation.
 - Kubernetes RBAC policies were tightened. Refer to `rbac.yaml`.
+- A `PeerCommunicator` module provides encrypted message passing between nodes. Use `/api/v1/peer/message` to receive messages.
  - Record common errors and the strategies developed to resolve them here so
   future contributors don't repeat the same investigation.
  - Keep a running log of new ideas and experimental results. Note what works well

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ This repository contains the source code for **monGARS**, a modular, privacy-fir
 - Use `build_embedded.sh` to create and push multi-arch images for Raspberry Pi and Jetson using Docker Buildx. Ensure you are logged in to your registry before running the script.
 - Use `build_native.sh` to build an optimized x86_64 image leveraging all CPU cores on a developer workstation.
 - Kubernetes RBAC policies were tightened. Refer to `rbac.yaml`.
-- A `PeerCommunicator` module provides encrypted message passing between nodes. Use `/api/v1/peer/message` to receive messages.
+- A `PeerCommunicator` module provides encrypted message passing between nodes. Use `/api/v1/peer/message` to receive messages. The route requires authentication and the JSON body `{ "payload": "..." }`.
  - Record common errors and the strategies developed to resolve them here so
   future contributors don't repeat the same investigation.
  - Keep a running log of new ideas and experimental results. Note what works well

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ The helper checks physical cores first and falls back to logical CPUs when
 necessary.
 
 The `/api/v1/peer/message` endpoint allows nodes to exchange encrypted messages
-for basic coordination.
+for basic coordination. This authenticated POST route accepts a JSON body of the
+form `{"payload": "<encrypted>"}`.
 
 Unit and integration tests are located in the `tests/` directory. Execute them with:
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ monGARS (Modular Neural Agent for Research and Support) is a privacy-first AI sy
   `recommended_worker_count()`.
 - **Robust core detection** falls back to logical CPUs if physical cores
   cannot be determined.
+- **Encrypted peer-to-peer messaging** via `PeerCommunicator` for basic node coordination.
 
 A high level component overview can be found in `monGARS_structure.txt`.
 
@@ -55,6 +56,9 @@ On Raspberry Pi or Jetson boards the number of Uvicorn workers is
 automatically reduced using `monGARS.utils.hardware.recommended_worker_count`.
 The helper checks physical cores first and falls back to logical CPUs when
 necessary.
+
+The `/api/v1/peer/message` endpoint allows nodes to exchange encrypted messages
+for basic coordination.
 
 Unit and integration tests are located in the `tests/` directory. Execute them with:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,7 +33,7 @@ Milestone: proof-of-concept functionality established, real AI features still mi
 - **[Completed]** Harden security policies and RBAC rules.
 
 ## Phase 4 - Collaborative Networking (planned - target Q4 2025)
-**[In Progress]** Enable peer-to-peer coordination with encrypted communication channels. Initial `PeerCommunicator` and `/api/v1/peer/message` endpoint added for encrypted messaging.
+**[In Progress]** Enable peer-to-peer coordination with encrypted communication channels. `PeerCommunicator` now dispatches requests concurrently and `/api/v1/peer/message` requires authentication.
 - Introduce a distributed scheduler for cooperative tasks across nodes.
 - Extend Sommeil Paradoxal for idle-time optimization and auto-updates.
 - Stabilize the Evolution Engine for safe sandboxed upgrades.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,7 +33,7 @@ Milestone: proof-of-concept functionality established, real AI features still mi
 - **[Completed]** Harden security policies and RBAC rules.
 
 ## Phase 4 - Collaborative Networking (planned - target Q4 2025)
-- Enable peer-to-peer coordination with encrypted communication channels.
+**[In Progress]** Enable peer-to-peer coordination with encrypted communication channels. Initial `PeerCommunicator` and `/api/v1/peer/message` endpoint added for encrypted messaging.
 - Introduce a distributed scheduler for cooperative tasks across nodes.
 - Extend Sommeil Paradoxal for idle-time optimization and auto-updates.
 - Stabilize the Evolution Engine for safe sandboxed upgrades.

--- a/monGARS/api/dependencies.py
+++ b/monGARS/api/dependencies.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 from monGARS.core.hippocampus import Hippocampus
+from monGARS.core.peer import PeerCommunicator
 
 hippocampus = Hippocampus()
+peer_communicator = PeerCommunicator()
 
 
 def get_hippocampus() -> Hippocampus:
     """Return the shared Hippocampus instance."""
     return hippocampus
+
+
+def get_peer_communicator() -> PeerCommunicator:
+    """Return the shared PeerCommunicator instance."""
+    return peer_communicator

--- a/monGARS/api/web_api.py
+++ b/monGARS/api/web_api.py
@@ -4,9 +4,10 @@ from typing import Dict, List
 
 from fastapi import Depends, FastAPI, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
+from pydantic import BaseModel
 
 from monGARS.api.authentication import get_current_user
-from monGARS.api.dependencies import get_hippocampus
+from monGARS.api.dependencies import get_hippocampus, get_peer_communicator
 from monGARS.core.hippocampus import MemoryItem
 from monGARS.core.peer import PeerCommunicator
 from monGARS.core.security import SecurityManager
@@ -63,8 +64,19 @@ async def conversation_history(
 peer_comm = PeerCommunicator()
 
 
+class PeerMessage(BaseModel):
+    payload: str
+
+
 @app.post("/api/v1/peer/message")
-async def peer_message(payload: str) -> dict:
+async def peer_message(
+    message: PeerMessage,
+    current_user: dict = Depends(get_current_user),
+    communicator: PeerCommunicator = Depends(get_peer_communicator),
+) -> dict:
     """Receive an encrypted message from a peer."""
-    data = peer_comm.decode(payload)
+    try:
+        data = communicator.decode(message.payload)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {"status": "received", "data": data}

--- a/monGARS/api/web_api.py
+++ b/monGARS/api/web_api.py
@@ -8,6 +8,7 @@ from fastapi.security import OAuth2PasswordRequestForm
 from monGARS.api.authentication import get_current_user
 from monGARS.api.dependencies import get_hippocampus
 from monGARS.core.hippocampus import MemoryItem
+from monGARS.core.peer import PeerCommunicator
 from monGARS.core.security import SecurityManager
 
 app = FastAPI(title="monGARS API")
@@ -57,3 +58,13 @@ async def conversation_history(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
         ) from exc
+
+
+peer_comm = PeerCommunicator()
+
+
+@app.post("/api/v1/peer/message")
+async def peer_message(payload: str) -> dict:
+    """Receive an encrypted message from a peer."""
+    data = peer_comm.decode(payload)
+    return {"status": "received", "data": data}

--- a/monGARS/core/peer.py
+++ b/monGARS/core/peer.py
@@ -1,0 +1,49 @@
+"""Peer-to-peer communication utilities."""
+
+from __future__ import annotations
+
+import json
+from typing import Iterable, List, Optional
+
+import httpx
+
+from .security import decrypt_token, encrypt_token
+
+
+class PeerCommunicator:
+    """Send encrypted messages to peer nodes."""
+
+    def __init__(
+        self,
+        peers: Iterable[str] | None = None,
+        client: Optional[httpx.AsyncClient] = None,
+    ) -> None:
+        self.peers = list(peers or [])
+        self._client = client
+
+    async def send(self, message: dict) -> List[bool]:
+        """Encrypt and broadcast message to all configured peers."""
+        encoded = encrypt_token(json.dumps(message))
+        results = []
+        if self._client is None:
+            async with httpx.AsyncClient() as client:
+                for url in self.peers:
+                    try:
+                        resp = await client.post(url, json={"payload": encoded})
+                        results.append(resp.status_code == 200)
+                    except Exception:
+                        results.append(False)
+        else:
+            for url in self.peers:
+                try:
+                    resp = await self._client.post(url, json={"payload": encoded})
+                    results.append(resp.status_code == 200)
+                except Exception:
+                    results.append(False)
+        return results
+
+    @staticmethod
+    def decode(payload: str) -> dict:
+        """Decrypt incoming payload into a message dict."""
+        data = decrypt_token(payload)
+        return json.loads(data)

--- a/monGARS/core/peer.py
+++ b/monGARS/core/peer.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+import logging
 from typing import Iterable, List, Optional
 
 import httpx
@@ -21,26 +23,33 @@ class PeerCommunicator:
         self.peers = list(peers or [])
         self._client = client
 
-    async def send(self, message: dict) -> List[bool]:
+    async def send(self, message: Optional[dict]) -> List[bool]:
         """Encrypt and broadcast message to all configured peers."""
-        encoded = encrypt_token(json.dumps(message))
-        results = []
-        if self._client is None:
-            async with httpx.AsyncClient() as client:
-                for url in self.peers:
-                    try:
-                        resp = await client.post(url, json={"payload": encoded})
-                        results.append(resp.status_code == 200)
-                    except Exception:
-                        results.append(False)
-        else:
-            for url in self.peers:
-                try:
-                    resp = await self._client.post(url, json={"payload": encoded})
-                    results.append(resp.status_code == 200)
-                except Exception:
-                    results.append(False)
-        return results
+        if not message:
+            return [False] * len(self.peers)
+
+        payload = encrypt_token(json.dumps(message))
+
+        async def _post(client: httpx.AsyncClient, url: str) -> bool:
+            try:
+                resp = await client.post(url, json={"payload": payload})
+                return resp.status_code == 200
+            except httpx.HTTPError as exc:
+                logging.error("Peer request to %s failed: %s", url, exc)
+                return False
+            except Exception as exc:  # pragma: no cover - unexpected errors
+                logging.error("Peer request to %s error: %s", url, exc)
+                return False
+
+        async def _broadcast(client: httpx.AsyncClient) -> List[bool]:
+            tasks = [_post(client, url) for url in self.peers]
+            return await asyncio.gather(*tasks) if tasks else []
+
+        if self._client:
+            return await _broadcast(self._client)
+
+        async with httpx.AsyncClient() as client:
+            return await _broadcast(client)
 
     @staticmethod
     def decode(payload: str) -> dict:

--- a/tests/test_peer_communication.py
+++ b/tests/test_peer_communication.py
@@ -2,25 +2,99 @@ import os
 
 import httpx
 import pytest
+import pytest_asyncio
 
-os.environ.setdefault("SECRET_KEY", "test-peer")
-
-from monGARS.api.web_api import app, peer_comm
+from monGARS.api.authentication import get_current_user
+from monGARS.api.dependencies import get_peer_communicator
+from monGARS.api.web_api import app
 from monGARS.core.peer import PeerCommunicator
 
 
-@pytest.fixture
-async def client():
-    async with httpx.AsyncClient(app=app, base_url="http://test") as async_client:
-        peer_comm.peers = ["http://test/api/v1/peer/message"]
-        peer_comm._client = async_client
+@pytest.fixture(autouse=True)
+def secret_key_env(monkeypatch):
+    original = os.environ.get("SECRET_KEY")
+    monkeypatch.setenv("SECRET_KEY", "test-peer")
+    yield
+    if original is not None:
+        monkeypatch.setenv("SECRET_KEY", original)
+    else:
+        monkeypatch.delenv("SECRET_KEY", raising=False)
+
+
+@pytest_asyncio.fixture
+async def client(secret_key_env):
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test"
+    ) as async_client:
+        app.dependency_overrides[get_current_user] = lambda: {"sub": "u1"}
+        comm = get_peer_communicator()
+        comm.peers = ["http://test/api/v1/peer/message"]
+        comm._client = async_client
         yield async_client
+        app.dependency_overrides.clear()
 
 
-def test_peer_message_roundtrip(event_loop, client):
-    communicator = PeerCommunicator(
-        peers=["http://test/api/v1/peer/message"], client=client
-    )
+@pytest.mark.asyncio
+async def test_peer_message_roundtrip(client, monkeypatch):
+    captured = {}
+
+    original = PeerCommunicator.decode
+
+    def capture(payload: str):
+        data = original(payload)
+        captured["data"] = data
+        return data
+
+    monkeypatch.setattr(PeerCommunicator, "decode", staticmethod(capture))
+    communicator = PeerCommunicator(["http://test/api/v1/peer/message"], client)
     message = {"hello": "world"}
-    results = event_loop.run_until_complete(communicator.send(message))
+    results = await communicator.send(message)
     assert results == [True]
+    assert captured["data"] == message
+
+
+@pytest.mark.asyncio
+async def test_peer_invalid_url(monkeypatch):
+    async def failing_post(*args, **kwargs):
+        raise httpx.RequestError("fail")
+
+    client = httpx.AsyncClient()
+    monkeypatch.setattr(client, "post", failing_post)
+    communicator = PeerCommunicator(["http://bad"], client=client)
+    results = await communicator.send({"x": "y"})
+    assert results == [False]
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_peer_non_200_response(monkeypatch):
+    class MockResp:
+        status_code = 500
+
+        async def aclose(self):
+            pass
+
+    async def mock_post(*args, **kwargs):
+        return MockResp()
+
+    client = httpx.AsyncClient()
+    monkeypatch.setattr(client, "post", mock_post)
+    communicator = PeerCommunicator(["http://test"], client=client)
+    results = await communicator.send({"x": "y"})
+    assert results == [False]
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_peer_empty_message(client):
+    communicator = PeerCommunicator(["http://test/api/v1/peer/message"], client)
+    results = await communicator.send({})
+    assert results == [False]
+
+
+@pytest.mark.asyncio
+async def test_peer_missing_message(client):
+    communicator = PeerCommunicator(["http://test/api/v1/peer/message"], client)
+    results = await communicator.send(None)
+    assert results == [False]

--- a/tests/test_peer_communication.py
+++ b/tests/test_peer_communication.py
@@ -1,0 +1,26 @@
+import os
+
+import httpx
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test-peer")
+
+from monGARS.api.web_api import app, peer_comm
+from monGARS.core.peer import PeerCommunicator
+
+
+@pytest.fixture
+async def client():
+    async with httpx.AsyncClient(app=app, base_url="http://test") as async_client:
+        peer_comm.peers = ["http://test/api/v1/peer/message"]
+        peer_comm._client = async_client
+        yield async_client
+
+
+def test_peer_message_roundtrip(event_loop, client):
+    communicator = PeerCommunicator(
+        peers=["http://test/api/v1/peer/message"], client=client
+    )
+    message = {"hello": "world"}
+    results = event_loop.run_until_complete(communicator.send(message))
+    assert results == [True]


### PR DESCRIPTION
## Summary
- implement `PeerCommunicator` for encrypted peer-to-peer messages
- expose `/api/v1/peer/message` endpoint
- document peer messaging in README, ROADMAP, AGENTS
- add test for peer communication

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: opentelemetry.exporter.otlp.proto.http)*

------
https://chatgpt.com/codex/tasks/task_e_687b48322150833392222b3c0ebad9a6

## Summary by Sourcery

Implement encrypted peer-to-peer messaging with a new communicator, API endpoint, tests, and documentation updates.

New Features:
- Introduce PeerCommunicator for encrypting and broadcasting messages between nodes
- Add /api/v1/peer/message endpoint to receive and decrypt incoming peer messages

Documentation:
- Document encrypted peer-to-peer messaging in README, ROADMAP, and AGENTS

Tests:
- Add roundtrip test for PeerCommunicator send and receive functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced encrypted peer-to-peer messaging for node coordination, including a new API endpoint for receiving encrypted messages.
* **Documentation**
  * Updated user and technical documentation to describe encrypted peer-to-peer messaging features and usage.
  * Updated the roadmap to reflect progress on collaborative networking with encrypted communication.
* **Tests**
  * Added tests to verify encrypted peer message sending and receiving functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->