### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ A high level component overview can be found in `monGARS_structure.txt`.
    ```bash
    pip install -r requirements.txt
    ```
+   Or run the helper script:
+   ```bash
+   ./setup.sh
+   ```
 2. Copy `.env.example` to `.env` and adjust configuration values.
 3. Initialize the database:
    ```bash

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Simple helper to install Python dependencies.
+# Usage: ./setup.sh
+
+if [ ! -f requirements.txt ]; then
+  echo "requirements.txt not found" >&2
+  exit 1
+fi
+
+python3 -m pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- add a helper script to install Python requirements
- mention setup script in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'opentelemetry.exporter.otlp.proto.http')*

------
https://chatgpt.com/codex/tasks/task_e_687c11235ab8833391947b113cb7f7fc

## Summary by Sourcery

Add a setup.sh helper script for installing Python dependencies and update the README to reference it

New Features:
- Add setup.sh script to install Python dependencies

Documentation:
- Add instructions for running setup.sh to the README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setup script to automate the installation of Python dependencies.
* **Documentation**
  * Updated installation instructions to include the new setup script as an alternative method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->