### PR TITLE
Remove unused peer communicator

### DIFF
--- a/monGARS/api/web_api.py
+++ b/monGARS/api/web_api.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Annotated, Dict, List
+from typing import Annotated, Any, Dict, List
 
 from fastapi import Depends, FastAPI, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
@@ -108,9 +108,6 @@ async def chat(
         confidence=result.get("confidence", 0.0),
         processing_time=result.get("processing_time", 0.0),
     )
-
-
-peer_comm = PeerCommunicator()
 
 
 class PeerMessage(BaseModel):


### PR DESCRIPTION
## Summary
- remove redundant peer communicator instance
- rely on `get_peer_communicator` from `dependencies.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c47316700833397d6d65539a00a3a