### PR TITLE
Add no-op driver for embedding system

### DIFF
--- a/monGARS/core/neurones.py
+++ b/monGARS/core/neurones.py
@@ -4,5 +4,33 @@ from __future__ import annotations
 
 
 class EmbeddingSystem:
+    """Simple embedding system with a no-op database driver."""
+
+    class _NoOpResult:
+        async def single(self) -> dict:
+            return {"exists": False}
+
+    class _NoOpSession:
+        async def __aenter__(self) -> "EmbeddingSystem._NoOpSession":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: type | None,
+            exc: Exception | None,
+            tb: object | None,
+        ) -> None:
+            return None
+
+        async def run(self, *args, **kwargs) -> "EmbeddingSystem._NoOpResult":
+            return EmbeddingSystem._NoOpResult()
+
+    class _NoOpDriver:
+        def session(self) -> "EmbeddingSystem._NoOpSession":
+            return EmbeddingSystem._NoOpSession()
+
+    def __init__(self) -> None:
+        self.driver = EmbeddingSystem._NoOpDriver()
+
     async def encode(self, text: str) -> list[float]:
         return [0.0]

--- a/monGARS/core/neurones.py
+++ b/monGARS/core/neurones.py
@@ -6,28 +6,23 @@ from __future__ import annotations
 class EmbeddingSystem:
     """Simple embedding system with a no-op database driver."""
 
-    class _NoOpResult:
-        async def single(self) -> dict:
-            return {"exists": False}
+    class _NoOpDriver:
+        def session(self) -> "EmbeddingSystem._NoOpDriver":
+            return self
 
-    class _NoOpSession:
-        async def __aenter__(self) -> "EmbeddingSystem._NoOpSession":
+        async def __aenter__(self) -> "EmbeddingSystem._NoOpDriver":
             return self
 
         async def __aexit__(
-            self,
-            exc_type: type | None,
-            exc: Exception | None,
-            tb: object | None,
+            self, exc_type: type | None, exc: Exception | None, tb: object | None
         ) -> None:
-            return None
+            pass
 
-        async def run(self, *args, **kwargs) -> "EmbeddingSystem._NoOpResult":
-            return EmbeddingSystem._NoOpResult()
+        async def run(self, *args, **kwargs) -> "EmbeddingSystem._NoOpDriver":
+            return self
 
-    class _NoOpDriver:
-        def session(self) -> "EmbeddingSystem._NoOpSession":
-            return EmbeddingSystem._NoOpSession()
+        async def single(self) -> dict:
+            return {"exists": False}
 
     def __init__(self) -> None:
         self.driver = EmbeddingSystem._NoOpDriver()


### PR DESCRIPTION
## Summary
- implement a minimal driver in `EmbeddingSystem`
- driver exposes an async `session()` context manager returning no-op methods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c5c5485ac83339378e40798e41b18

## Summary by Sourcery

Add a minimal no-op driver to EmbeddingSystem to stub database interactions via an async session context manager.

New Features:
- Implement _NoOpDriver, _NoOpSession, and _NoOpResult classes inside EmbeddingSystem
- Expose an async session() context manager returning no-op results
- Initialize EmbeddingSystem.driver with the no-op driver

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified internal driver structure within the embedding system for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->