### PR TITLE
Fix pip requirement typo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ trafilatura
 uvicorn
 llm2vec
 textblob>=0.18.0
-textblob-fr>=0.4.3
+textblob-fr==0.2.0
 pytest
 pytest-asyncio
 cryptography


### PR DESCRIPTION
## Summary
- set `textblob-fr` to valid version to avoid pip install errors

## Testing
- `isort .`
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687d932457fc83339bcb69a8f975f444