### PR TITLE
Add login flow and token-based chat

### DIFF
--- a/webapp/chat/decorators.py
+++ b/webapp/chat/decorators.py
@@ -1,0 +1,17 @@
+from functools import wraps
+
+from django.shortcuts import redirect
+
+
+def require_token(view_func):
+    @wraps(view_func)
+    async def _wrapped(request, *args, **kwargs):
+        token = request.session.get("token")
+        uid = request.session.get("user_id")
+        if not token or not uid:
+            return redirect("login")
+        request.token = token
+        request.user_id = uid
+        return await view_func(request, *args, **kwargs)
+
+    return _wrapped

--- a/webapp/chat/services.py
+++ b/webapp/chat/services.py
@@ -1,0 +1,38 @@
+import logging
+import os
+
+import httpx
+
+logger = logging.getLogger(__name__)
+FASTAPI_URL = os.getenv("FASTAPI_URL", "http://localhost:8000")
+
+
+async def fetch_history(user_id: str, token: str) -> dict:
+    headers = {"Authorization": f"Bearer {token}"}
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{FASTAPI_URL}/api/v1/conversation/history",
+                params={"user_id": user_id},
+                headers=headers,
+            )
+        if resp.status_code == 200:
+            return resp.json()
+        return {"error": f"Erreur: {resp.status_code}"}
+    except Exception as e:  # pragma: no cover - network failure
+        logger.error("fetch_history failed: %s", e)
+        return {"error": f"Impossible de se connecter: {e}"}
+
+
+async def authenticate_user(username: str, password: str) -> str | None:
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{FASTAPI_URL}/token",
+                data={"username": username, "password": password},
+            )
+        if resp.status_code == 200:
+            return resp.json().get("access_token")
+    except Exception as e:  # pragma: no cover - network failure
+        logger.error("authenticate_user failed: %s", e)
+    return None

--- a/webapp/chat/templates/chat/index.html
+++ b/webapp/chat/templates/chat/index.html
@@ -44,6 +44,7 @@
     window.chatConfig = {
       fastapiUrl: "{{ fastapi_url }}",
       userId: "{{ user_id }}",
+      token: "{{ token }}",
     };
   </script>
   <script src="{% static 'js/chat.js' %}"></script>

--- a/webapp/chat/templates/chat/login.html
+++ b/webapp/chat/templates/chat/login.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login</title>
+    {% load static %}
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <div class="container mt-5" style="max-width: 400px;">
+    <h3 class="mb-3">Login</h3>
+    {% if error %}
+      <div class="alert alert-danger">{{ error }}</div>
+    {% endif %}
+    <form method="post">
+      {% csrf_token %}
+      <div class="mb-3">
+        <label for="username" class="form-label">Username</label>
+        <input type="text" class="form-control" id="username" name="username" required>
+      </div>
+      <div class="mb-3">
+        <label for="password" class="form-label">Password</label>
+        <input type="password" class="form-control" id="password" name="password" required>
+      </div>
+      <button type="submit" class="btn btn-primary">Login</button>
+    </form>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/webapp/chat/urls.py
+++ b/webapp/chat/urls.py
@@ -4,4 +4,5 @@ from . import views
 
 urlpatterns = [
     path("", views.index, name="index"),
+    path("login/", views.login_view, name="login"),
 ]

--- a/webapp/chat/views.py
+++ b/webapp/chat/views.py
@@ -2,20 +2,24 @@ import logging
 import os
 
 import httpx
-from django.shortcuts import render
+from django.shortcuts import redirect, render
 
 logger = logging.getLogger(__name__)
 
 
 async def index(request):
     fastapi_url = os.environ.get("FASTAPI_URL", "http://localhost:8000")
-    user_id = request.session.get("user_id") or (
-        request.user.username if request.user.is_authenticated else "anonymous"
-    )
+    token = request.session.get("token")
+    user_id = request.session.get("user_id")
+    if not token or not user_id:
+        return redirect("login")
+
+    headers = {"Authorization": f"Bearer {token}"}
     try:
         async with httpx.AsyncClient() as client:
             response = await client.get(
-                f"{fastapi_url}/api/v1/conversation/history?user_id={user_id}"
+                f"{fastapi_url}/api/v1/conversation/history?user_id={user_id}",
+                headers=headers,
             )
             if response.status_code == 200:
                 data = response.json()
@@ -29,5 +33,37 @@ async def index(request):
     return render(
         request,
         "chat/index.html",
-        {"data": data, "fastapi_url": fastapi_url, "user_id": user_id},
+        {
+            "data": data,
+            "fastapi_url": fastapi_url,
+            "user_id": user_id,
+            "token": token,
+        },
     )
+
+
+async def login_view(request):
+    fastapi_url = os.environ.get("FASTAPI_URL", "http://localhost:8000")
+    if request.method == "POST":
+        username = request.POST.get("username", "").strip()
+        password = request.POST.get("password", "")
+        if not username or not password:
+            return render(request, "chat/login.html", {"error": "Credentials required"})
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    f"{fastapi_url}/token",
+                    data={"username": username, "password": password},
+                )
+            if resp.status_code == 200:
+                token = resp.json().get("access_token")
+                request.session["token"] = token
+                request.session["user_id"] = username
+                return redirect("index")
+            error = "Invalid credentials"
+        except Exception as exc:  # pragma: no cover - network failure
+            logger.error("Login failed: %s", exc)
+            error = f"Connexion impossible: {exc}"
+        return render(request, "chat/login.html", {"error": error})
+
+    return render(request, "chat/login.html")


### PR DESCRIPTION
## Summary
- implement login view to fetch token from FastAPI
- store token in session and use it for chat requests
- update frontend to include token and authenticate WebSocket
- add login template and URL route

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687dc522d67c83338637e0ebbc7987e2

## Summary by Sourcery

Add a token-based login flow that authenticates users against FastAPI, stores the access token and user ID in the session, and protects chat endpoints and WebSocket connections.

New Features:
- Add login view with template and URL route to obtain access token from FastAPI
- Store access token and user ID in session and redirect unauthenticated users to the login page

Enhancements:
- Require session token in chat index view and include it in the template context
- Update WebSocket connection to use token query parameter instead of user ID
- Change chat message requests to JSON body with Authorization header carrying the Bearer token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a login page with username and password authentication.
  * Added token-based authentication for accessing the chat interface.

* **Improvements**
  * Enhanced security by requiring login before accessing chat features.
  * Chat now uses tokens for authentication in both WebSocket and HTTP requests.

* **Bug Fixes**
  * Improved error handling and messaging during the login process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->