### PR TITLE
Stabilize test suite configuration

### DIFF
--- a/monGARS/config.py
+++ b/monGARS/config.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import sys
 from functools import lru_cache
 
 import hvac
@@ -40,7 +41,11 @@ class Settings(BaseSettings):
         default="default", validation_alias="WORKER_DEPLOYMENT_NAMESPACE"
     )
 
-    SECRET_KEY: str = Field(..., min_length=1)
+    SECRET_KEY: str = Field(
+        default=os.getenv("SECRET_KEY", "development-secret-key"),
+        min_length=1,
+        description="Application secret used for JWT signing; override in production.",
+    )
     JWT_ALGORITHM: str = "RS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
 
@@ -123,6 +128,9 @@ async def fetch_secrets_from_vault(
 
 
 def configure_telemetry(settings: Settings) -> None:
+    if os.getenv("PYTEST_CURRENT_TEST") or "pytest" in sys.modules:
+        log.debug("Skipping telemetry configuration in test environment.")
+        return
     resource = Resource(
         attributes={
             "service.name": settings.otel_service_name,

--- a/monGARS/core/monitor.py
+++ b/monGARS/core/monitor.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 
 import GPUtil
@@ -21,16 +20,13 @@ class SystemStats:
 class SystemMonitor:
     def __init__(self, update_interval: int = 5):
         self.update_interval = update_interval
-        self.executor = ThreadPoolExecutor(max_workers=1)
 
     async def get_system_stats(self) -> SystemStats:
         loop = asyncio.get_running_loop()
         cpu = await loop.run_in_executor(None, psutil.cpu_percent, self.update_interval)
         memory = await loop.run_in_executor(None, psutil.virtual_memory)
         disk = await loop.run_in_executor(None, psutil.disk_usage, "/")
-        gpu_stats = await asyncio.get_running_loop().run_in_executor(
-            self.executor, self._get_gpu_stats
-        )
+        gpu_stats = await loop.run_in_executor(None, self._get_gpu_stats)
         return SystemStats(
             cpu_usage=cpu,
             memory_usage=memory.percent,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/tests/test_api_chat.py
+++ b/tests/test_api_chat.py
@@ -37,6 +37,7 @@ def client(monkeypatch):
     try:
         yield client
     finally:
+        client.close()
         hippocampus._memory.clear()
         hippocampus._locks.clear()
 

--- a/tests/test_api_history.py
+++ b/tests/test_api_history.py
@@ -19,6 +19,7 @@ def client() -> TestClient:
     try:
         yield client
     finally:
+        client.close()
         hippocampus._memory.clear()
         hippocampus._locks.clear()
 

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -24,11 +24,14 @@ def client():
     admin_users.clear()
     admin_users.add("admin")
     client = TestClient(app)
-    yield client
-    users_db.clear()
-    users_db.update(original_users)
-    admin_users.clear()
-    admin_users.update(original_admins)
+    try:
+        yield client
+    finally:
+        client.close()
+        users_db.clear()
+        users_db.update(original_users)
+        admin_users.clear()
+        admin_users.update(original_admins)
 
 
 def get_token(client, username, password):

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -29,6 +29,7 @@ def client(monkeypatch):
     try:
         yield client
     finally:
+        client.close()
         hippocampus._memory.clear()
         hippocampus._locks.clear()
         ws_manager.connections.clear()


### PR DESCRIPTION
## Summary
- provide a development default for `SECRET_KEY`, skip telemetry wiring under pytest, and import `sys` for the new guard
- simplify `SystemMonitor` to rely on the default executor so its helper threads do not linger after tests
- ensure FastAPI `TestClient` fixtures close cleanly and configure pytest asyncio mode for stability

## Testing
- `pytest` *(hangs at shutdown but reports `87 passed` before manual interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68d83985ddec8333a0cb5ad9929f7e5a