### PR TITLE
Implement resilient embedding system with caching

### DIFF
--- a/docs/repo_memory_alignment.md
+++ b/docs/repo_memory_alignment.md
@@ -1,0 +1,55 @@
+# monGARS Repository vs Memory Alignment
+
+This document captures the relationship between the modules present in the
+`monGARS` repository and the architectural components referenced in the
+assistant's long-term project memory. Use it as an onboarding aid when mapping
+historical design notes to the current codebase.
+
+## API Layer
+- `api/authentication.py` ←→ **Security model** (HMAC tokens with planned JWT
+  support).
+- `api/dependencies.py` ←→ **Backend scaffolding** utilities for FastAPI.
+- `api/web_api.py` ←→ **Bouche** (dialogue engine), `APIService.swift`
+  integration points, and browser speech clients.
+
+## Core Services
+- `core/conversation.py` ←→ **Bouche + Cortex** orchestration for dialogue
+  flows.
+- `core/evolution_engine.py` ←→ **Evolution Engine** and Sommeil Paradoxal
+  testing loops.
+- `core/llm_integration.py` ←→ **monGARS LLM bucket** (currently unpopulated in
+  memory).
+- `core/logging.py` ←→ **Mémoire Autobiographique** (structured logging and
+  historical traceability).
+- `core/monitor.py` ←→ **Sommeil Paradoxal diagnostics** and Evolution Engine
+  validation checks.
+- `core/caching/tiered_cache.py` ←→ **Hippocampus** (short-term cache layered on
+  vector embeddings).
+- `core/neuro_symbolic/advanced_reasoning.py` ←→ **Tronc** (neuro-symbolic
+  curiosity engine experiments).
+
+## Testing Infrastructure
+- `tests/integration_test.py` ←→ Phase 1 validation workflows.
+- `tests/self_training_test.py` ←→ Sommeil Paradoxal + Evolution Engine
+  self-optimization routines.
+- `tests/property_test.py` ←→ Cortex + Mimicry behaviour consistency checks.
+- `tests/chaos_test.py` ←→ Robustness testing for autonomy and offline-first
+  guarantees.
+
+## Platform & Operations
+- `init_db.py` ←→ **Hippocampus** semantic memory database provisioning
+  (Postgres + pgvector).
+- `tasks.py` ←→ **Sommeil Paradoxal** background job scheduling.
+- `docker-compose.yml` ←→ Local orchestration for Cortex, Hippocampus, and
+  auxiliary services.
+- `Dockerfile` ←→ Baseline container specification.
+- `k8s/deployment.yaml` ←→ Future distributed deployment plans.
+- `k8s/prometheus.yaml` ←→ Monitoring hooks for Sommeil Paradoxal diagnostics.
+- `k8s/secrets.yaml` ←→ Runtime secrets (align with planned AES-256 storage).
+- `.github/workflows/ci-cd.yml` ←→ Automated validation via Evolution Engine
+  pipelines.
+
+## Related Documentation
+- `monGARS_structure.txt` and `ROADMAP.md` carry historical notes referenced in
+  the memory archive. Update this mapping whenever major architectural changes
+  land to keep the knowledge base synchronized.

--- a/monGARS/core/neurones.py
+++ b/monGARS/core/neurones.py
@@ -1,31 +1,196 @@
-"""Minimal embedding system placeholder."""
+"""Neural utilities used by the cognition stack."""
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
+import inspect
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+try:  # pragma: no cover - optional dependency
+    from neo4j.async_driver import AsyncGraphDatabase
+except ImportError:  # pragma: no cover - driver not installed in tests
+    AsyncGraphDatabase = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency
+    from sentence_transformers import SentenceTransformer
+except ImportError:  # pragma: no cover - tests run without the heavy model
+    SentenceTransformer = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+class _NoOpResult:
+    async def single(self) -> dict[str, Any]:
+        return {"exists": False}
+
+
+class _NoOpSession:
+    async def __aenter__(self) -> "_NoOpSession":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: Any,
+    ) -> None:
+        return None
+
+    async def run(self, *args: Any, **kwargs: Any) -> _NoOpResult:
+        return _NoOpResult()
+
+
+class _NoOpDriver:
+    def session(self) -> _NoOpSession:
+        return _NoOpSession()
+
+    async def close(self) -> None:
+        return None
+
+
+@dataclass(slots=True)
+class _CacheEntry:
+    expires_at: float
+    vector: list[float]
+
 
 class EmbeddingSystem:
-    """Simple embedding system with a no-op database driver."""
+    """Encode text and provide an optional knowledge-graph driver.
 
-    class _NoOpDriver:
-        def session(self) -> "EmbeddingSystem._NoOpDriver":
-            return self
+    The production configuration loads a :class:`SentenceTransformer` model and a
+    Neo4j driver when the required dependencies are available. Both dependencies
+    are optional to keep test environments lightweight; deterministic fallbacks
+    are used otherwise.
+    """
 
-        async def __aenter__(self) -> "EmbeddingSystem._NoOpDriver":
-            return self
+    def __init__(
+        self,
+        model_name: str | None = None,
+        *,
+        cache_ttl: int = 900,
+        driver: Any | None = None,
+        fallback_dimensions: int = 32,
+    ) -> None:
+        self._model_name = model_name or os.getenv(
+            "EMBEDDING_MODEL_NAME", _DEFAULT_MODEL
+        )
+        self._model: SentenceTransformer | None = None
+        self._model_lock = asyncio.Lock()
+        self._cache: dict[str, _CacheEntry] = {}
+        self._cache_lock = asyncio.Lock()
+        self._cache_ttl = cache_ttl
+        self._fallback_dimensions = max(1, fallback_dimensions)
+        self._now = time.monotonic
+        self.driver = driver or self._create_driver()
 
-        async def __aexit__(
-            self, exc_type: type | None, exc: Exception | None, tb: object | None
-        ) -> None:
-            pass
-
-        async def run(self, *args, **kwargs) -> "EmbeddingSystem._NoOpDriver":
-            return self
-
-        async def single(self) -> dict:
-            return {"exists": False}
-
-    def __init__(self) -> None:
-        self.driver = EmbeddingSystem._NoOpDriver()
+    async def close(self) -> None:
+        close_callable = getattr(self.driver, "close", None)
+        if not close_callable:
+            return
+        try:
+            result = close_callable()
+        except TypeError:
+            # The driver may expose ``close`` as an async method defined on the
+            # class rather than a bound coroutine function.
+            result = close_callable(self.driver)  # type: ignore[misc]
+        if inspect.isawaitable(result):
+            await result
 
     async def encode(self, text: str) -> list[float]:
-        return [0.0]
+        """Return an embedding for *text* with caching and graceful fallbacks."""
+
+        normalized = text.strip()
+        if not normalized:
+            return [0.0] * self._fallback_dimensions
+
+        cached = await self._get_cached(normalized)
+        if cached is not None:
+            return cached
+
+        vector: list[float]
+        if SentenceTransformer is None:
+            logger.debug(
+                "SentenceTransformer not available; using fallback embedding for '%s'",
+                normalized,
+            )
+            vector = self._fallback_embedding(normalized)
+        else:
+            model = await self._ensure_model()
+            try:
+                encoded = await asyncio.to_thread(
+                    model.encode,
+                    normalized,
+                    normalize_embeddings=True,
+                )
+                if isinstance(encoded, Iterable):
+                    vector = [float(value) for value in encoded]
+                else:
+                    raise TypeError("Model returned non-iterable embedding")
+            except Exception as exc:  # pragma: no cover - model failures are rare
+                logger.warning("Embedding failed for '%s': %s", normalized, exc)
+                vector = self._fallback_embedding(normalized)
+
+        await self._store_cache(normalized, vector)
+        return vector
+
+    async def _ensure_model(self) -> SentenceTransformer:
+        if self._model is not None:
+            return self._model
+        if SentenceTransformer is None:  # pragma: no cover - safeguarded by caller
+            raise RuntimeError("SentenceTransformer dependency missing")
+        async with self._model_lock:
+            if self._model is None:
+                logger.info("Loading embedding model '%s'", self._model_name)
+                self._model = await asyncio.to_thread(
+                    SentenceTransformer, self._model_name
+                )
+        return self._model
+
+    async def _get_cached(self, text: str) -> list[float] | None:
+        async with self._cache_lock:
+            entry = self._cache.get(text)
+            if entry and entry.expires_at > self._now():
+                logger.debug("Embedding cache hit for '%s'", text)
+                return entry.vector
+            if entry:
+                del self._cache[text]
+        return None
+
+    async def _store_cache(self, text: str, vector: list[float]) -> None:
+        async with self._cache_lock:
+            self._cache[text] = _CacheEntry(
+                expires_at=self._now() + self._cache_ttl,
+                vector=list(vector),
+            )
+
+    def _create_driver(self) -> Any:
+        if AsyncGraphDatabase is None:
+            logger.debug("Neo4j driver not installed; using no-op driver")
+            return _NoOpDriver()
+
+        uri = os.getenv("NEO4J_URI")
+        user = os.getenv("NEO4J_USER")
+        password = os.getenv("NEO4J_PASSWORD")
+        if not (uri and user and password):
+            logger.debug("Neo4j credentials missing; using no-op driver")
+            return _NoOpDriver()
+        try:
+            driver = AsyncGraphDatabase.driver(uri, auth=(user, password))
+            logger.info("Connected to Neo4j at %s", uri)
+            return driver
+        except Exception as exc:  # pragma: no cover - driver not present in tests
+            logger.warning("Failed to initialise Neo4j driver: %s", exc)
+            return _NoOpDriver()
+
+    def _fallback_embedding(self, text: str) -> list[float]:
+        digest = hashlib.sha256(text.encode("utf-8")).digest()
+        required = self._fallback_dimensions
+        repeated = (digest * ((required // len(digest)) + 1))[:required]
+        return [(byte / 255.0) * 2 - 1 for byte in repeated]

--- a/tests/test_neurones.py
+++ b/tests/test_neurones.py
@@ -1,0 +1,80 @@
+import pytest
+
+from monGARS.core import neurones
+
+
+@pytest.mark.asyncio
+async def test_encode_uses_fallback_when_model_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(neurones, "SentenceTransformer", None, raising=False)
+
+    calls = []
+
+    def fake_fallback(self: neurones.EmbeddingSystem, text: str) -> list[float]:
+        calls.append(text)
+        return [0.1, 0.2, 0.3]
+
+    monkeypatch.setattr(neurones.EmbeddingSystem, "_fallback_embedding", fake_fallback)
+
+    system = neurones.EmbeddingSystem(cache_ttl=60)
+
+    first = await system.encode("bonjour monde")
+    second = await system.encode("bonjour monde")
+
+    assert first == [0.1, 0.2, 0.3]
+    assert second == first
+    assert calls == ["bonjour monde"]
+
+
+@pytest.mark.asyncio
+async def test_encode_with_sentence_transformer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class DummyModel:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.calls: list[tuple[str, bool]] = []
+
+        def encode(self, text: str, normalize_embeddings: bool = True) -> list[float]:
+            self.calls.append((text, normalize_embeddings))
+            return [0.4, -0.6]
+
+    dummy_model = DummyModel("dummy")
+
+    async def fake_to_thread(func, *args, **kwargs):  # type: ignore[no-untyped-def]
+        return func(*args, **kwargs)
+
+    def fake_sentence_transformer(name: str) -> DummyModel:
+        return dummy_model
+
+    def fail_fallback(self: neurones.EmbeddingSystem, text: str) -> list[float]:
+        raise AssertionError("Fallback should not be used when model is available")
+
+    monkeypatch.setattr(neurones, "SentenceTransformer", fake_sentence_transformer)
+    monkeypatch.setattr(neurones.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(neurones.EmbeddingSystem, "_fallback_embedding", fail_fallback)
+
+    system = neurones.EmbeddingSystem()
+    vector = await system.encode("Salut")
+
+    assert vector == [0.4, -0.6]
+    assert dummy_model.calls == [("Salut", True)]
+
+
+@pytest.mark.asyncio
+async def test_noop_driver_returns_safe_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(neurones, "AsyncGraphDatabase", None, raising=False)
+    monkeypatch.delenv("NEO4J_URI", raising=False)
+    monkeypatch.delenv("NEO4J_USER", raising=False)
+    monkeypatch.delenv("NEO4J_PASSWORD", raising=False)
+
+    system = neurones.EmbeddingSystem()
+
+    async with system.driver.session() as session:
+        result = await session.run("RETURN 1 AS exists")
+        record = await result.single()
+
+    assert record == {"exists": False}


### PR DESCRIPTION
## Summary
- replace the placeholder EmbeddingSystem with a SentenceTransformer-backed encoder that supports async caching and optional Neo4j connectivity
- add deterministic fallback embeddings and graceful teardown paths so cognition modules keep working when heavy dependencies are unavailable
- introduce dedicated tests covering fallback behaviour, model-backed encoding, and the no-op knowledge-graph driver

## Testing
- pytest tests/test_neurones.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d864fe2d848333a1baf38e4c23d516