### PR TITLE
Improve orchestrator typing for isort compliance

### DIFF
--- a/modules/evolution_engine/orchestrator.py
+++ b/modules/evolution_engine/orchestrator.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 from uuid import uuid4
@@ -15,11 +14,10 @@ logger = logging.getLogger(__name__)
 class TrainerProtocol(Protocol):
     """Protocol describing the trainer expected by the orchestrator."""
 
-    def __init__(
-        self, training_config_path: str, output_dir: str
-    ) -> None:
+    def __init__(self, training_config_path: str, output_dir: str) -> None:
         """Construct a trainer bound to the provided config and output path."""
-    def train(self) -> Mapping[str, object]:
+
+    def train(self) -> dict[str, object]:
         """Execute the training pipeline and return a summary payload."""
 
 

--- a/modules/evolution_engine/orchestrator.py
+++ b/modules/evolution_engine/orchestrator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 from uuid import uuid4
@@ -18,7 +19,7 @@ class TrainerProtocol(Protocol):
         self, training_config_path: str, output_dir: str
     ) -> None:
         """Construct a trainer bound to the provided config and output path."""
-    def train(self) -> dict[str, object]:
+    def train(self) -> Mapping[str, object]:
         """Execute the training pipeline and return a summary payload."""
 
 


### PR DESCRIPTION
## Summary
- import `Mapping` from `collections.abc` so the orchestrator protocol returns a more precise mapping type
- update `TrainerProtocol.train` to advertise a mapping return value, keeping typing consistent while satisfying isort

## Testing
- isort --check --diff .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d89d8f9bac83339b738cdae9ca02ce

## Summary by Sourcery

Update orchestrator protocol to use a generic Mapping return type and adjust imports for isort compliance

Enhancements:
- Change TrainerProtocol.train return type from dict[str, object] to Mapping[str, object]
- Import Mapping from collections.abc to support the updated typing and satisfy isort ordering