### PR TITLE
Fix mimicry feedback loop with raw interaction analysis

### DIFF
--- a/tests/test_mimicry.py
+++ b/tests/test_mimicry.py
@@ -1,0 +1,66 @@
+from collections import deque
+
+import pytest
+
+from monGARS.core.mimicry import MimicryModule
+
+
+@pytest.mark.asyncio
+async def test_update_profile_uses_message_and_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = MimicryModule()
+
+    async def fake_get_profile(user_id: str) -> dict:
+        return module.user_profiles.get(user_id) or {
+            "long_term": {},
+            "short_term": deque(maxlen=module.history_length),
+        }
+
+    async def fake_update_profile_db(user_id: str, profile: dict) -> None:
+        return None
+
+    monkeypatch.setattr(module, "_get_profile", fake_get_profile)
+    monkeypatch.setattr(module, "_update_profile_db", fake_update_profile_db)
+
+    interaction = {
+        "message": "Bonjour et merci pour votre aide précieuse",
+        "response": "Je suis ravi de vous assister aujourd'hui.",
+    }
+
+    profile = await module.update_profile("user-positive", interaction)
+
+    assert profile["long_term"]["sentence_length"] == 7
+    assert profile["long_term"]["positive_sentiment"] > 0.5
+    last_entry = profile["short_term"][-1]
+    assert last_entry["sentence_length"] == 7
+    assert last_entry["positive_sentiment"] > 0.5
+
+
+@pytest.mark.asyncio
+async def test_update_profile_detects_negative_sentiment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = MimicryModule()
+
+    async def fake_get_profile(user_id: str) -> dict:
+        return module.user_profiles.get(user_id) or {
+            "long_term": {},
+            "short_term": deque(maxlen=module.history_length),
+        }
+
+    async def fake_update_profile_db(user_id: str, profile: dict) -> None:
+        return None
+
+    monkeypatch.setattr(module, "_get_profile", fake_get_profile)
+    monkeypatch.setattr(module, "_update_profile_db", fake_update_profile_db)
+
+    interaction = {
+        "message": "Je suis contrarié par la situation actuelle",
+        "response": "C'est terrible et mauvais pour tout le monde.",
+    }
+
+    profile = await module.update_profile("user-negative", interaction)
+
+    assert profile["long_term"]["sentence_length"] == 7
+    assert profile["long_term"]["positive_sentiment"] < 0.5


### PR DESCRIPTION
## Summary
- update the conversational module to send the raw user query and LLM response to the mimicry profile updater
- enrich the mimicry module with lightweight word counting and sentiment heuristics driven by the provided interaction text
- add unit coverage ensuring mimicry profiles react to positive and negative conversational samples

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d8db8ce928833383b8c261ea5f33a8