### PR TITLE
Filter low-confidence samples in self-training

### DIFF
--- a/tests/self_training_test.py
+++ b/tests/self_training_test.py
@@ -22,7 +22,8 @@ def stub_embedding_system(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.mark.asyncio
 async def test_run_training_cycle_creates_version():
     engine = SelfTrainingEngine()
-    await engine.training_queue.put({"data": 1})
+    await engine.training_queue.put({"data": 1, "confidence": 0.95})
+    await engine.training_queue.put({"data": 2, "confidence": 0.4})
     await engine._run_training_cycle()
     assert "v1" in engine.model_versions
     assert engine.model_versions["v1"]["data_count"] == 1
@@ -31,5 +32,14 @@ async def test_run_training_cycle_creates_version():
 @pytest.mark.asyncio
 async def test_run_training_cycle_no_data():
     engine = SelfTrainingEngine()
+    await engine._run_training_cycle()
+    assert engine.model_versions == {}
+
+
+@pytest.mark.asyncio
+async def test_run_training_cycle_skips_low_confidence_only():
+    engine = SelfTrainingEngine(training_threshold=0.9)
+    await engine.training_queue.put({"data": "low", "confidence": 0.1})
+    await engine.training_queue.put({"data": "unknown"})
     await engine._run_training_cycle()
     assert engine.model_versions == {}

--- a/tests/self_training_test.py
+++ b/tests/self_training_test.py
@@ -43,3 +43,12 @@ async def test_run_training_cycle_skips_low_confidence_only():
     await engine.training_queue.put({"data": "unknown"})
     await engine._run_training_cycle()
     assert engine.model_versions == {}
+
+
+@pytest.mark.asyncio
+async def test_run_training_cycle_handles_non_numeric_confidence():
+    engine = SelfTrainingEngine(training_threshold=0.5)
+    await engine.training_queue.put({"data": "valid", "confidence": 0.8})
+    await engine.training_queue.put({"data": "bad", "confidence": "not-a-number"})
+    await engine._run_training_cycle()
+    assert engine.model_versions["v1"]["data_count"] == 1


### PR DESCRIPTION
## Summary
- filter queued self-training records using the configured confidence threshold
- log skipped batches and update timing metadata via the running loop
- expand self-training tests to cover mixed and low-confidence batches

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d8df2622a88333b6f501090e79bc26

## Summary by Sourcery

Introduce confidence-based filtering in the self-training cycle with skipped-batch logging and updated timing metadata, and expand tests to cover low-confidence scenarios.

New Features:
- Filter queued self-training records using a configurable confidence threshold.

Enhancements:
- Log skipped low-confidence batches with count and threshold details.
- Use asyncio.get_running_loop() for consistent timing metadata updates.

Tests:
- Add tests for mixed-confidence batches and batches with only low-confidence or missing confidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Self-training now filters inputs by confidence and only trains on data meeting the configured threshold.
  - When all candidates are below threshold, the training cycle is skipped and a log entry records discarded items and the threshold.
- Refactor
  - Improved timing consistency for training events and version timestamps.
- Tests
  - Added tests covering confidence-threshold behavior, including skipping cycles when only low-confidence or missing-confidence data is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->