### PR TITLE
Add TTL-based personality caching for adaptive responses

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,10 @@ import logging
 import uvicorn
 
 from init_db import init_db
+from monGARS.api.dependencies import (
+    get_adaptive_response_generator,
+    get_personality_engine,
+)
 from monGARS.config import get_settings
 from monGARS.core.monitor import SystemMonitor
 from monGARS.core.orchestrator import Orchestrator
@@ -20,7 +24,12 @@ async def main():
     await init_db()
     monitor = SystemMonitor()
     trainer = SelfTrainingEngine()
-    orchestrator = Orchestrator()
+    personality = get_personality_engine()
+    adaptive_response = get_adaptive_response_generator(personality)
+    orchestrator = Orchestrator(
+        personality=personality,
+        dynamic_response=adaptive_response,
+    )
     try:
         async with asyncio.TaskGroup() as tg:
             tg.create_task(monitor.get_system_stats())

--- a/monGARS/api/dependencies.py
+++ b/monGARS/api/dependencies.py
@@ -1,10 +1,25 @@
 from __future__ import annotations
 
+from weakref import WeakKeyDictionary
+
+from monGARS.core.dynamic_response import AdaptiveResponseGenerator
 from monGARS.core.hippocampus import Hippocampus
 from monGARS.core.peer import PeerCommunicator
+from monGARS.core.personality import PersonalityEngine
 
 hippocampus = Hippocampus()
 peer_communicator = PeerCommunicator()
+_personality_engine: PersonalityEngine | None = None
+_adaptive_generators: WeakKeyDictionary[
+    PersonalityEngine, AdaptiveResponseGenerator
+] = WeakKeyDictionary()
+
+
+def _resolve_personality_engine() -> PersonalityEngine:
+    global _personality_engine
+    if _personality_engine is None:
+        _personality_engine = PersonalityEngine()
+    return _personality_engine
 
 
 def get_hippocampus() -> Hippocampus:
@@ -15,3 +30,21 @@ def get_hippocampus() -> Hippocampus:
 def get_peer_communicator() -> PeerCommunicator:
     """Return the shared PeerCommunicator instance."""
     return peer_communicator
+
+
+def get_personality_engine() -> PersonalityEngine:
+    """Return the shared PersonalityEngine instance."""
+    return _resolve_personality_engine()
+
+
+def get_adaptive_response_generator(
+    personality: PersonalityEngine | None = None,
+) -> AdaptiveResponseGenerator:
+    """Return a cached AdaptiveResponseGenerator for the given engine."""
+
+    engine = personality or _resolve_personality_engine()
+    generator = _adaptive_generators.get(engine)
+    if generator is None:
+        generator = AdaptiveResponseGenerator(engine)
+        _adaptive_generators[engine] = generator
+    return generator

--- a/monGARS/api/web_api.py
+++ b/monGARS/api/web_api.py
@@ -17,7 +17,12 @@ from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel, HttpUrl, field_validator
 
 from monGARS.api.authentication import get_current_admin_user, get_current_user
-from monGARS.api.dependencies import get_hippocampus, get_peer_communicator
+from monGARS.api.dependencies import (
+    get_adaptive_response_generator,
+    get_hippocampus,
+    get_peer_communicator,
+    get_personality_engine,
+)
 from monGARS.core.conversation import ConversationalModule
 from monGARS.core.hippocampus import MemoryItem
 from monGARS.core.peer import PeerCommunicator
@@ -27,7 +32,12 @@ from .ws_manager import WebSocketManager
 
 app = FastAPI(title="monGARS API")
 sec_manager = SecurityManager()
-conversation_module = ConversationalModule()
+_shared_personality = get_personality_engine()
+_shared_dynamic = get_adaptive_response_generator(_shared_personality)
+conversation_module = ConversationalModule(
+    personality=_shared_personality,
+    dynamic=_shared_dynamic,
+)
 ws_manager = WebSocketManager()
 
 

--- a/monGARS/core/conversation.py
+++ b/monGARS/core/conversation.py
@@ -41,9 +41,9 @@ class ConversationalModule:
         self.llm = llm or LLMIntegration()
         self.reasoner = reasoner or AdvancedReasoner()
         self.curiosity = curiosity or CuriosityEngine()
-        self.dynamic = dynamic or AdaptiveResponseGenerator()
-        self.mimicry = mimicry or MimicryModule()
         self.personality = personality or PersonalityEngine()
+        self.dynamic = dynamic or AdaptiveResponseGenerator(self.personality)
+        self.mimicry = mimicry or MimicryModule()
         self.captioner = captioner or ImageCaptioning()
         self.memory = memory or MemoryService(Hippocampus())
         self.speaker = speaker or SpeakerService(Bouche())
@@ -76,7 +76,7 @@ class ConversationalModule:
         interactions: list[dict[str, str]],
         user_message: str,
     ) -> tuple[str, dict]:
-        personality = await self.personality.analyze_personality(user_id, interactions)
+        personality = await self.dynamic.get_personality_traits(user_id, interactions)
         adaptive = self.dynamic.generate_adaptive_response(text, personality)
         await self.mimicry.update_profile(
             user_id,

--- a/monGARS/core/dynamic_response.py
+++ b/monGARS/core/dynamic_response.py
@@ -1,17 +1,101 @@
 from __future__ import annotations
 
+import asyncio
+import hashlib
+import json
+import logging
 import re
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from monGARS.core.personality import PersonalityEngine
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class _CachedPersonality:
+    """Container used to keep track of cached personality traits."""
+
+    traits: dict[str, float]
+    signature: str
+    expires_at: float
 
 
 class AdaptiveResponseGenerator:
-    """Simple adaptive response generator based on personality."""
+    """Adaptive response generator with personality caching support."""
 
-    def generate_adaptive_response(self, text: str, personality: dict) -> str:
+    def __init__(
+        self,
+        personality_engine: PersonalityEngine | None = None,
+        *,
+        cache_ttl_seconds: int = 300,
+        time_provider: Callable[[], float] | None = None,
+    ) -> None:
+        self._personality_engine = personality_engine or PersonalityEngine()
+        self._cache_ttl = cache_ttl_seconds
+        self._cache: dict[str, _CachedPersonality] = {}
+        self._lock = asyncio.Lock()
+        self._time_provider = time_provider or time.monotonic
+
+    async def get_personality_traits(
+        self,
+        user_id: str,
+        interactions: Sequence[Mapping[str, Any]] | None = None,
+    ) -> dict[str, float]:
+        """Return cached personality traits or refresh them if stale.
+
+        A cached entry is reused when the interaction fingerprint has not changed
+        and the configured TTL has not expired. This avoids redundant calls to the
+        potentially expensive :class:`PersonalityEngine` analysis.
+        """
+
+        fingerprint = self._fingerprint_interactions(interactions)
+        now = self._time_provider()
+        async with self._lock:
+            cached = self._cache.get(user_id)
+            if cached and cached.signature == fingerprint:
+                if self._cache_ttl < 0:
+                    logger.debug(
+                        "Using indefinitely cached personality traits for user %s",
+                        user_id,
+                    )
+                    return dict(cached.traits)
+                if self._cache_ttl > 0 and cached.expires_at > now:
+                    logger.debug("Using cached personality traits for user %s", user_id)
+                    return dict(cached.traits)
+
+        traits = await self._personality_engine.analyze_personality(
+            user_id,
+            list(interactions or []),
+        )
+        normalized_traits = dict(traits)
+        async with self._lock:
+            expires_at = now + self._cache_ttl if self._cache_ttl > 0 else now
+            self._cache[user_id] = _CachedPersonality(
+                traits=dict(normalized_traits),
+                signature=fingerprint,
+                expires_at=expires_at,
+            )
+            logger.debug(
+                "Cached personality traits for user %s (signature=%s, ttl=%s)",
+                user_id,
+                fingerprint,
+                self._cache_ttl,
+            )
+        return dict(normalized_traits)
+
+    def generate_adaptive_response(
+        self, text: str, personality: Mapping[str, float] | None
+    ) -> str:
         """Return an adapted response based on user personality."""
 
-        formality = personality.get("formality", 0.5)
-        humor = personality.get("humor", 0.5)
-        enthusiasm = personality.get("enthusiasm", 0.5)
+        personality = personality or {}
+        formality = self._safe_float(personality.get("formality"), 0.5)
+        humor = self._safe_float(personality.get("humor"), 0.5)
+        enthusiasm = self._safe_float(personality.get("enthusiasm"), 0.5)
 
         adapted = text
 
@@ -24,8 +108,26 @@ class AdaptiveResponseGenerator:
         if enthusiasm > 0.7 and not adapted.endswith("!"):
             adapted += "!"
 
-        SMILING_EMOJI = "\U0001f603"
-        if humor > 0.7 and SMILING_EMOJI not in adapted:
-            adapted += f" {SMILING_EMOJI}"
+        smiling_emoji = "\U0001f603"
+        if humor > 0.7 and smiling_emoji not in adapted:
+            adapted += f" {smiling_emoji}"
 
         return adapted
+
+    def _fingerprint_interactions(
+        self, interactions: Sequence[Mapping[str, Any]] | None
+    ) -> str:
+        if not interactions:
+            return "no-interactions"
+        normalized: list[dict[str, Any]] = []
+        for item in interactions:
+            normalized.append({key: item.get(key) for key in sorted(item)})
+        payload = json.dumps(normalized, sort_keys=True, ensure_ascii=False)
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _safe_float(value: Any, default: float) -> float:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default

--- a/monGARS/core/dynamic_response.py
+++ b/monGARS/core/dynamic_response.py
@@ -7,21 +7,25 @@ import logging
 import re
 import time
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
 from typing import Any, Callable
+
+from cachetools import TTLCache
 
 from monGARS.core.personality import PersonalityEngine
 
 logger = logging.getLogger(__name__)
 
+_CACHE_MAXSIZE = 1024
 
-@dataclass(slots=True)
-class _CachedPersonality:
-    """Container used to keep track of cached personality traits."""
 
-    traits: dict[str, float]
-    signature: str
-    expires_at: float
+def _fingerprint_interactions(
+    interactions: Sequence[Mapping[str, Any]] | None,
+) -> str:
+    if not interactions:
+        return "no-interactions"
+    normalized = [{key: item.get(key) for key in sorted(item)} for item in interactions]
+    payload = json.dumps(normalized, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
 class AdaptiveResponseGenerator:
@@ -36,9 +40,21 @@ class AdaptiveResponseGenerator:
     ) -> None:
         self._personality_engine = personality_engine or PersonalityEngine()
         self._cache_ttl = cache_ttl_seconds
-        self._cache: dict[str, _CachedPersonality] = {}
-        self._lock = asyncio.Lock()
         self._time_provider = time_provider or time.monotonic
+        self._lock = asyncio.Lock()
+        self._pending: dict[str, asyncio.Task[dict[str, float]]] = {}
+        self._permanent_cache: dict[str, dict[str, float]] | None = (
+            {} if cache_ttl_seconds < 0 else None
+        )
+        self._ttl_cache: TTLCache[str, dict[str, float]] | None = (
+            TTLCache(
+                maxsize=_CACHE_MAXSIZE,
+                ttl=cache_ttl_seconds,
+                timer=self._time_provider,
+            )
+            if cache_ttl_seconds > 0
+            else None
+        )
 
     async def get_personality_traits(
         self,
@@ -52,39 +68,46 @@ class AdaptiveResponseGenerator:
         potentially expensive :class:`PersonalityEngine` analysis.
         """
 
-        fingerprint = self._fingerprint_interactions(interactions)
-        now = self._time_provider()
-        async with self._lock:
-            cached = self._cache.get(user_id)
-            if cached and cached.signature == fingerprint:
-                if self._cache_ttl < 0:
-                    logger.debug(
-                        "Using indefinitely cached personality traits for user %s",
-                        user_id,
-                    )
-                    return dict(cached.traits)
-                if self._cache_ttl > 0 and cached.expires_at > now:
-                    logger.debug("Using cached personality traits for user %s", user_id)
-                    return dict(cached.traits)
+        interactions_list = list(interactions or [])
+        fingerprint = _fingerprint_interactions(interactions_list)
+        cache_key = self._cache_key(user_id, fingerprint)
 
-        traits = await self._personality_engine.analyze_personality(
-            user_id,
-            list(interactions or []),
-        )
-        normalized_traits = dict(traits)
         async with self._lock:
-            expires_at = now + self._cache_ttl if self._cache_ttl > 0 else now
-            self._cache[user_id] = _CachedPersonality(
-                traits=dict(normalized_traits),
-                signature=fingerprint,
-                expires_at=expires_at,
-            )
+            cached = self._get_cached_locked(cache_key)
+            if cached is not None:
+                logger.debug("Using cached personality traits for user %s", user_id)
+                return dict(cached)
+
+            pending = self._pending.get(cache_key)
+            if pending is None:
+                pending = asyncio.create_task(
+                    self._personality_engine.analyze_personality(
+                        user_id, interactions_list
+                    )
+                )
+                self._pending[cache_key] = pending
+            else:
+                logger.debug(
+                    "Awaiting in-flight personality analysis for user %s", user_id
+                )
+
+        try:
+            traits = await pending
+        finally:
+            async with self._lock:
+                if self._pending.get(cache_key) is pending:
+                    self._pending.pop(cache_key, None)
+
+        normalized_traits = dict(traits)
+
+        async with self._lock:
+            self._store_cached_locked(cache_key, normalized_traits)
             logger.debug(
-                "Cached personality traits for user %s (signature=%s, ttl=%s)",
+                "Cached personality traits for user %s (ttl=%s)",
                 user_id,
-                fingerprint,
-                self._cache_ttl,
+                "infinite" if self._cache_ttl < 0 else self._cache_ttl,
             )
+
         return dict(normalized_traits)
 
     def generate_adaptive_response(
@@ -93,9 +116,22 @@ class AdaptiveResponseGenerator:
         """Return an adapted response based on user personality."""
 
         personality = personality or {}
-        formality = self._safe_float(personality.get("formality"), 0.5)
-        humor = self._safe_float(personality.get("humor"), 0.5)
-        enthusiasm = self._safe_float(personality.get("enthusiasm"), 0.5)
+
+        def _coerce(value: Any, default: float) -> float:
+            if value is None:
+                return default
+            if isinstance(value, str):
+                value = value.strip()
+                if not value:
+                    return default
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                return default
+
+        formality = _coerce(personality.get("formality"), 0.5)
+        humor = _coerce(personality.get("humor"), 0.5)
+        enthusiasm = _coerce(personality.get("enthusiasm"), 0.5)
 
         adapted = text
 
@@ -114,20 +150,27 @@ class AdaptiveResponseGenerator:
 
         return adapted
 
-    def _fingerprint_interactions(
-        self, interactions: Sequence[Mapping[str, Any]] | None
-    ) -> str:
-        if not interactions:
-            return "no-interactions"
-        normalized: list[dict[str, Any]] = []
-        for item in interactions:
-            normalized.append({key: item.get(key) for key in sorted(item)})
-        payload = json.dumps(normalized, sort_keys=True, ensure_ascii=False)
-        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    def _cache_key(self, user_id: str, fingerprint: str) -> str:
+        if self._cache_ttl < 0:
+            return user_id
+        if self._cache_ttl == 0:
+            return f"{user_id}:no-cache"
+        return f"{user_id}:{fingerprint}"
 
-    @staticmethod
-    def _safe_float(value: Any, default: float) -> float:
-        try:
-            return float(value)
-        except (TypeError, ValueError):
-            return default
+    def _get_cached_locked(self, cache_key: str) -> dict[str, float] | None:
+        if self._cache_ttl == 0:
+            return None
+        if self._cache_ttl < 0 and self._permanent_cache is not None:
+            return self._permanent_cache.get(cache_key)
+        if self._ttl_cache is None:
+            return None
+        return self._ttl_cache.get(cache_key)
+
+    def _store_cached_locked(self, cache_key: str, traits: dict[str, float]) -> None:
+        if self._cache_ttl == 0:
+            return
+        if self._cache_ttl < 0 and self._permanent_cache is not None:
+            self._permanent_cache[cache_key] = dict(traits)
+            return
+        if self._ttl_cache is not None:
+            self._ttl_cache[cache_key] = dict(traits)

--- a/monGARS/core/orchestrator.py
+++ b/monGARS/core/orchestrator.py
@@ -24,10 +24,10 @@ class Orchestrator:
     def __init__(self) -> None:
         self.llm = LLMIntegration()
         self.reasoner = AdvancedReasoner()
-        self.dynamic_response = AdaptiveResponseGenerator()
+        self.personality = PersonalityEngine()
+        self.dynamic_response = AdaptiveResponseGenerator(self.personality)
         self.mimicry = MimicryModule()
         self.curiosity = CuriosityEngine()
-        self.personality = PersonalityEngine()
         self.captioner = ImageCaptioning()
 
     async def process_query(
@@ -91,17 +91,15 @@ class Orchestrator:
             base_response = llm_response.get("text", "")
             try:
                 user_personality = await asyncio.wait_for(
-                    self.personality.analyze_personality(user_id, []), timeout=5
+                    self.dynamic_response.get_personality_traits(user_id, []),
+                    timeout=5,
                 )
             except Exception as exc:
                 logger.error("Personality analysis failed: %s", exc)
                 user_personality = {}
             try:
-                adapted_response = await asyncio.wait_for(
-                    self.dynamic_response.generate_adaptive_response(
-                        base_response, user_personality
-                    ),
-                    timeout=5,
+                adapted_response = self.dynamic_response.generate_adaptive_response(
+                    base_response, user_personality
                 )
             except Exception as exc:
                 logger.error("Adaptive response generation failed: %s", exc)

--- a/monGARS/core/orchestrator.py
+++ b/monGARS/core/orchestrator.py
@@ -21,14 +21,26 @@ settings = get_settings()
 class Orchestrator:
     """Coordinate modules to handle user queries."""
 
-    def __init__(self) -> None:
-        self.llm = LLMIntegration()
-        self.reasoner = AdvancedReasoner()
-        self.personality = PersonalityEngine()
-        self.dynamic_response = AdaptiveResponseGenerator(self.personality)
-        self.mimicry = MimicryModule()
-        self.curiosity = CuriosityEngine()
-        self.captioner = ImageCaptioning()
+    def __init__(
+        self,
+        *,
+        llm: LLMIntegration | None = None,
+        reasoner: AdvancedReasoner | None = None,
+        personality: PersonalityEngine | None = None,
+        dynamic_response: AdaptiveResponseGenerator | None = None,
+        mimicry: MimicryModule | None = None,
+        curiosity: CuriosityEngine | None = None,
+        captioner: ImageCaptioning | None = None,
+    ) -> None:
+        self.llm = llm or LLMIntegration()
+        self.reasoner = reasoner or AdvancedReasoner()
+        self.personality = personality or PersonalityEngine()
+        self.dynamic_response = dynamic_response or AdaptiveResponseGenerator(
+            self.personality
+        )
+        self.mimicry = mimicry or MimicryModule()
+        self.curiosity = curiosity or CuriosityEngine()
+        self.captioner = captioner or ImageCaptioning()
 
     async def process_query(
         self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ hvac>=2.3.0
 ollama>=0.5.1
 opentelemetry-sdk>=1.35.0
 opentelemetry-exporter-otlp>=1.35.0
+cachetools>=5.3.3
 passlib[bcrypt]>=1.7.4
 pgvector>=0.4.1
 celery>=5.3,<6.0

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "ollama>=0.5.1",
         "opentelemetry-sdk>=1.35.0",
         "opentelemetry-exporter-otlp>=1.35.0",
+        "cachetools>=5.3.3",
         "passlib[bcrypt]>=1.7.4",
         "pgvector>=0.4.1",
         "celery>=5.3,<6.0",

--- a/tasks.py
+++ b/tasks.py
@@ -3,13 +3,24 @@ from __future__ import annotations
 from asgiref.sync import async_to_sync
 from celery import Celery
 
+from monGARS.api.dependencies import (
+    get_adaptive_response_generator,
+    get_personality_engine,
+)
 from monGARS.core.conversation import ConversationalModule
 
 celery_app = Celery("tasks", broker="redis://redis:6379/0")
+
+_shared_personality = get_personality_engine()
+_shared_dynamic = get_adaptive_response_generator(_shared_personality)
+_conversation_module = ConversationalModule(
+    personality=_shared_personality,
+    dynamic=_shared_dynamic,
+)
 
 
 @celery_app.task
 def process_interaction(user_id: str, query: str) -> dict:
     """Run a single ConversationalModule interaction."""
-    sync_generate = async_to_sync(ConversationalModule().generate_response)
+    sync_generate = async_to_sync(_conversation_module.generate_response)
     return sync_generate(user_id, query)

--- a/tests/test_dynamic_response.py
+++ b/tests/test_dynamic_response.py
@@ -1,0 +1,96 @@
+import pytest
+
+from monGARS.core.dynamic_response import AdaptiveResponseGenerator
+
+
+class StubPersonalityEngine:
+    def __init__(self, responses: list[dict[str, float]]) -> None:
+        self._responses = responses
+        self.call_count = 0
+        self.last_user: str | None = None
+        self.last_interactions: list[dict[str, str]] | None = None
+
+    async def analyze_personality(
+        self, user_id: str, interactions: list[dict[str, str]]
+    ) -> dict[str, float]:
+        self.last_user = user_id
+        self.last_interactions = interactions
+        index = min(self.call_count, len(self._responses) - 1)
+        self.call_count += 1
+        return dict(self._responses[index])
+
+
+@pytest.mark.asyncio
+async def test_personality_traits_reused_within_ttl() -> None:
+    current_time = 0.0
+
+    def now() -> float:
+        return current_time
+
+    engine = StubPersonalityEngine(
+        responses=[{"formality": 0.8, "humor": 0.4, "enthusiasm": 0.9}]
+    )
+    generator = AdaptiveResponseGenerator(
+        engine, cache_ttl_seconds=60, time_provider=now
+    )
+    interactions = [{"message": "Bonjour", "response": "Salut"}]
+
+    first = await generator.get_personality_traits("user-1", interactions)
+    second = await generator.get_personality_traits("user-1", interactions)
+
+    assert engine.call_count == 1
+    assert first == second
+    assert engine.last_user == "user-1"
+
+
+@pytest.mark.asyncio
+async def test_personality_traits_refresh_after_ttl_expiry() -> None:
+    current_time = 0.0
+
+    def now() -> float:
+        return current_time
+
+    engine = StubPersonalityEngine(
+        responses=[
+            {"formality": 0.3, "humor": 0.5, "enthusiasm": 0.6},
+            {"formality": 0.6, "humor": 0.5, "enthusiasm": 0.6},
+        ]
+    )
+    generator = AdaptiveResponseGenerator(
+        engine, cache_ttl_seconds=5, time_provider=now
+    )
+    interactions = [{"message": "Bonjour", "response": "Salut"}]
+
+    first = await generator.get_personality_traits("user-2", interactions)
+    current_time += 10
+    second = await generator.get_personality_traits("user-2", interactions)
+
+    assert engine.call_count == 2
+    assert first != second
+
+
+@pytest.mark.asyncio
+async def test_personality_traits_refresh_on_interaction_change() -> None:
+    current_time = 0.0
+
+    def now() -> float:
+        return current_time
+
+    engine = StubPersonalityEngine(
+        responses=[
+            {"formality": 0.4, "humor": 0.4, "enthusiasm": 0.4},
+            {"formality": 0.5, "humor": 0.4, "enthusiasm": 0.4},
+        ]
+    )
+    generator = AdaptiveResponseGenerator(
+        engine, cache_ttl_seconds=60, time_provider=now
+    )
+
+    interactions_initial = [{"message": "Salut", "response": "Bonjour"}]
+    interactions_new = [{"message": "Bonsoir", "response": "Salut"}]
+
+    await generator.get_personality_traits("user-3", interactions_initial)
+    await generator.get_personality_traits("user-3", interactions_new)
+
+    assert engine.call_count == 2
+    assert engine.last_interactions == interactions_new

--- a/tests/test_dynamic_response.py
+++ b/tests/test_dynamic_response.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from monGARS.core.dynamic_response import AdaptiveResponseGenerator
@@ -18,6 +20,25 @@ class StubPersonalityEngine:
         index = min(self.call_count, len(self._responses) - 1)
         self.call_count += 1
         return dict(self._responses[index])
+
+
+class BlockingPersonalityEngine(StubPersonalityEngine):
+    def __init__(
+        self,
+        responses: list[dict[str, float]],
+        gate: asyncio.Event,
+        release: asyncio.Event,
+    ) -> None:
+        super().__init__(responses)
+        self._gate = gate
+        self._release = release
+
+    async def analyze_personality(
+        self, user_id: str, interactions: list[dict[str, str]]
+    ) -> dict[str, float]:
+        self._gate.set()
+        await self._release.wait()
+        return await super().analyze_personality(user_id, interactions)
 
 
 @pytest.mark.asyncio
@@ -94,3 +115,89 @@ async def test_personality_traits_refresh_on_interaction_change() -> None:
 
     assert engine.call_count == 2
     assert engine.last_interactions == interactions_new
+
+
+@pytest.mark.asyncio
+async def test_personality_traits_cached_indefinitely_with_negative_ttl() -> None:
+    responses = [
+        {"openness": 0.1, "conscientiousness": 0.2},
+        {"openness": 0.9, "conscientiousness": 0.8},
+    ]
+    engine = StubPersonalityEngine(responses)
+    time_holder = {"now": 100.0}
+
+    def fake_time() -> float:
+        return time_holder["now"]
+
+    generator = AdaptiveResponseGenerator(
+        personality_engine=engine,
+        cache_ttl_seconds=-1,
+        time_provider=fake_time,
+    )
+
+    user_id = "user1"
+    interactions = [{"text": "hello"}]
+
+    traits1 = await generator.get_personality_traits(user_id, interactions)
+    assert traits1 == responses[0]
+    assert engine.call_count == 1
+
+    time_holder["now"] += 1_000_000
+
+    traits2 = await generator.get_personality_traits(user_id, interactions)
+    assert traits2 == responses[0]
+    assert engine.call_count == 1
+
+    new_interactions = [{"text": "hi"}]
+    traits3 = await generator.get_personality_traits(user_id, new_interactions)
+    assert traits3 == responses[0]
+    assert engine.call_count == 1
+
+    traits4 = await generator.get_personality_traits("user2", interactions)
+    assert traits4 == responses[1]
+    assert engine.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_personality_traits_shared_across_concurrent_calls() -> None:
+    gate = asyncio.Event()
+    release = asyncio.Event()
+    engine = BlockingPersonalityEngine(
+        responses=[{"formality": 0.6, "humor": 0.4, "enthusiasm": 0.5}],
+        gate=gate,
+        release=release,
+    )
+    generator = AdaptiveResponseGenerator(engine, cache_ttl_seconds=60)
+    interactions = [{"message": "Bonjour"}]
+
+    first_task = asyncio.create_task(
+        generator.get_personality_traits("user-4", interactions)
+    )
+    await gate.wait()
+
+    second_task = asyncio.create_task(
+        generator.get_personality_traits("user-4", interactions)
+    )
+
+    await asyncio.sleep(0)
+    release.set()
+
+    results = await asyncio.gather(first_task, second_task)
+
+    assert engine.call_count == 1
+    assert results[0] == results[1]
+
+
+def test_generate_adaptive_response_handles_non_numeric_traits() -> None:
+    generator = AdaptiveResponseGenerator(cache_ttl_seconds=0)
+    personality = {
+        "formality": " 0.8 ",
+        "humor": "not-a-number",
+        "enthusiasm": None,
+    }
+
+    adapted = generator.generate_adaptive_response("Salut tu", personality)
+
+    assert adapted == "Salut vous"
+    assert "!" not in adapted
+    assert "\U0001f603" not in adapted


### PR DESCRIPTION
## Summary
- add TTL-aware caching of personality traits in `AdaptiveResponseGenerator` to avoid redundant analyses
- wire the conversational and orchestrator flows through the cached generator so they share the same personality engine instance
- cover the caching behaviour with targeted async unit tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d8e6371ac8833383cc73a7930a0376

## Summary by Sourcery

Implement TTL-based caching for personality trait analysis in AdaptiveResponseGenerator and wire the cached generator through the orchestrator and conversation flows to avoid redundant analyses.

New Features:
- Add an async get_personality_traits method with TTL-aware caching of personality traits.
- Introduce interaction fingerprinting and cache invalidation based on TTL expiry or interaction changes.

Enhancements:
- Allow injecting a shared PersonalityEngine into AdaptiveResponseGenerator and refactor its constructor to accept cache and time-provider parameters.
- Update orchestrator and conversation modules to use the cached personality generator instead of direct engine calls.
- Add safe float conversion and logging around cache operations.

Tests:
- Add async unit tests verifying cache reuse within TTL, refresh after expiry, and invalidation on interaction changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Smarter, personality-aware responses now use intelligent caching for faster replies and improved consistency. Responses gracefully adapt even when limited personality data is available.
* Refactor
  * Unified personality analysis and response generation flow, reducing async complexity to improve reliability and lower latency.
* Tests
  * Added comprehensive tests for caching behavior, including reuse within a time window, refresh after expiry, and invalidation when interactions change, ensuring accurate personalization over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->