### PR TITLE
Implement active self-training pipeline

### DIFF
--- a/modules/neurons/training/mntp_trainer.py
+++ b/modules/neurons/training/mntp_trainer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Any, Iterable, Sequence
@@ -18,6 +19,123 @@ except Exception:  # pragma: no cover - fallback if unavailable
     LLM2Vec = None
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CuratedSample:
+    embedding: list[float]
+    target: float
+    metadata: dict[str, Any]
+
+
+class CuratedDatasetBuilder:
+    """Normalise curated records into a dataset suitable for adapter training."""
+
+    def __init__(self, records: Sequence[dict[str, Any]]) -> None:
+        self._records = records
+
+    def build(self) -> list[CuratedSample]:
+        samples: list[CuratedSample] = []
+        for index, record in enumerate(self._records):
+            sample = normalize_curated_record(record, index)
+            if sample is not None:
+                samples.append(sample)
+
+        if not samples:
+            raise ValueError("No valid curated records supplied for training")
+
+        return samples
+
+
+def normalize_curated_record(
+    record: dict[str, Any], index: int
+) -> CuratedSample | None:
+    embedding_raw = record.get("embedding") or record.get("vector")
+    if not isinstance(embedding_raw, Iterable):
+        logger.debug("Skipping curated record %s without embedding", index)
+        return None
+
+    embedding: list[float] = []
+    for value in embedding_raw:
+        try:
+            embedding.append(float(value))
+        except (TypeError, ValueError):
+            logger.debug(
+                "Dropping non-numeric embedding value '%s' in record %s",
+                value,
+                index,
+            )
+            continue
+
+    if not embedding:
+        logger.debug("Skipping curated record %s with empty embedding", index)
+        return None
+
+    target_raw = record.get("target", record.get("score"))
+    if target_raw is None:
+        logger.debug("Skipping curated record %s without target", index)
+        return None
+
+    try:
+        target = float(target_raw)
+    except (TypeError, ValueError):
+        logger.debug("Skipping curated record %s with invalid target", index)
+        return None
+
+    metadata = {
+        "source_id": record.get("source_id"),
+        "confidence": record.get("confidence", target),
+        "text_preview": record.get("text_preview"),
+        "used_fallback_embedding": record.get("used_fallback_embedding", False),
+    }
+    return CuratedSample(embedding=embedding, target=target, metadata=metadata)
+
+
+class LinearAdapterTrainer:
+    """Train a lightweight linear adapter from curated embedding samples."""
+
+    def __init__(self, *, learning_rate: float, epochs: int, gradient_clip: float) -> None:
+        if epochs < 1:
+            raise ValueError(f"Number of epochs must be at least 1. Got: {epochs}")
+        self.learning_rate = learning_rate
+        self.epochs = epochs
+        self.gradient_clip = gradient_clip
+
+    def train(
+        self, dataset: Sequence[CuratedSample]
+    ) -> tuple[list[float], float, dict[str, Any]]:
+        feature_dim = len(dataset[0].embedding)
+        weights = [0.0 for _ in range(feature_dim)]
+        bias = 0.0
+        losses: list[float] = []
+
+        for _ in range(self.epochs):
+            total_loss = 0.0
+            for sample in dataset:
+                prediction = bias + sum(
+                    weight * feature for weight, feature in zip(weights, sample.embedding)
+                )
+                error = prediction - sample.target
+                total_loss += error * error
+
+                clipped_error = max(
+                    -self.gradient_clip, min(self.gradient_clip, error)
+                )
+
+                for i, feature in enumerate(sample.embedding):
+                    weights[i] -= self.learning_rate * clipped_error * feature
+
+                bias -= self.learning_rate * clipped_error
+
+            losses.append(total_loss / len(dataset))
+
+        metrics = {
+            "loss": losses[-1],
+            "initial_loss": losses[0],
+            "epochs": self.epochs,
+            "learning_rate": self.learning_rate,
+        }
+        return weights, bias, metrics
 
 
 class TrainingStatus(str, Enum):
@@ -133,25 +251,18 @@ class MNTPTrainer:
     def _run_curated_training(
         self, curated_records: Sequence[dict[str, Any]]
     ) -> dict[str, Any]:
-        dataset: list[tuple[list[float], float, dict[str, Any]]] = []
-        feature_dim = 0
-
-        for index, record in enumerate(curated_records):
-            normalised = self._normalise_curated_record(record, index)
-            if normalised is None:
-                continue
-
-            embedding, target, metadata = normalised
-            feature_dim = max(feature_dim, len(embedding))
-            dataset.append((embedding, target, metadata))
-
-        if not dataset:
-            raise ValueError("No valid curated records supplied for training")
+        dataset = CuratedDatasetBuilder(curated_records).build()
+        feature_dim = max(len(sample.embedding) for sample in dataset)
 
         adapter_dir = self.output_dir / "adapter"
         adapter_dir.mkdir(parents=True, exist_ok=True)
 
-        weights, bias, metrics = self._train_linear_adapter(dataset)
+        trainer = LinearAdapterTrainer(
+            learning_rate=float(self.config.get("curated_learning_rate", 0.05)),
+            epochs=int(self.config.get("curated_epochs", 15)),
+            gradient_clip=float(self.config.get("curated_gradient_clip", 1.0)),
+        )
+        weights, bias, metrics = trainer.train(dataset)
         artifact_path = adapter_dir / "curated_linear_adapter.json"
         payload = {
             "schema_version": 1,
@@ -159,7 +270,7 @@ class MNTPTrainer:
             "bias": bias,
             "feature_dimension": feature_dim,
             "metrics": metrics,
-            "records": [item[2] for item in dataset],
+            "records": [sample.metadata for sample in dataset],
         }
         artifact_path.write_text(json.dumps(payload, indent=2, sort_keys=True))
 
@@ -182,93 +293,6 @@ class MNTPTrainer:
                 "feature_dimension": feature_dim,
             },
         }
-
-    def _normalise_curated_record(
-        self, record: dict[str, Any], index: int
-    ) -> tuple[list[float], float, dict[str, Any]] | None:
-        embedding_raw = record.get("embedding")
-        if embedding_raw is None:
-            embedding_raw = record.get("vector")
-        if not isinstance(embedding_raw, Iterable):
-            logger.debug("Skipping curated record %s without embedding", index)
-            return None
-
-        embedding: list[float] = []
-        for value in embedding_raw:
-            try:
-                embedding.append(float(value))
-            except (TypeError, ValueError):
-                logger.debug("Dropping non-numeric embedding value in record %s", index)
-                return None
-
-        if not embedding:
-            logger.debug("Skipping curated record %s with empty embedding", index)
-            return None
-
-        if "target" in record:
-            target_raw = record["target"]
-        elif "score" in record:
-            target_raw = record["score"]
-        else:
-            target_raw = None
-
-        if target_raw is None:
-            logger.debug("Skipping curated record %s without target", index)
-            return None
-
-        try:
-            target = float(target_raw)
-        except (TypeError, ValueError):
-            logger.debug("Skipping curated record %s with invalid target", index)
-            return None
-
-        metadata = {
-            "source_id": record.get("source_id"),
-            "confidence": record.get("confidence", target),
-            "text_preview": record.get("text_preview"),
-            "used_fallback_embedding": record.get("used_fallback_embedding", False),
-        }
-        return embedding, target, metadata
-
-    def _train_linear_adapter(
-        self, dataset: Sequence[tuple[list[float], float, dict[str, Any]]]
-    ) -> tuple[list[float], float, dict[str, Any]]:
-        learning_rate = float(self.config.get("curated_learning_rate", 0.05))
-        epochs = int(self.config.get("curated_epochs", 15))
-        gradient_clip = float(self.config.get("curated_gradient_clip", 1.0))
-
-        feature_dim = len(dataset[0][0])
-        weights = [0.0 for _ in range(feature_dim)]
-        bias = 0.0
-        losses: list[float] = []
-
-        for epoch in range(max(1, epochs)):
-            total_loss = 0.0
-            for embedding, target, _ in dataset:
-                prediction = bias
-                for weight, feature in zip(weights, embedding):
-                    prediction += weight * feature
-
-                error = prediction - target
-                total_loss += error * error
-
-                clipped_error = max(-gradient_clip, min(gradient_clip, error))
-
-                for i, feature in enumerate(embedding):
-                    weights[i] -= learning_rate * clipped_error * feature
-
-                bias -= learning_rate * clipped_error
-
-            loss = total_loss / len(dataset)
-            losses.append(loss)
-
-        metrics = {
-            "loss": losses[-1],
-            "initial_loss": losses[0],
-            "epochs": max(1, epochs),
-            "learning_rate": learning_rate,
-        }
-        return weights, bias, metrics
 
     def _save_config(self) -> None:
         try:

--- a/monGARS/core/self_training.py
+++ b/monGARS/core/self_training.py
@@ -182,10 +182,14 @@ class SelfTrainingEngine:
             record.get("content"),
             record.get("data"),
         )
-        for value in candidates:
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-        return None
+        return next(
+            (
+                value.strip()
+                for value in candidates
+                if isinstance(value, str) and value.strip()
+            ),
+            None,
+        )
 
     def _trim_embedding(self, embedding: Sequence[Any]) -> list[float]:
         trimmed: list[float] = []
@@ -195,7 +199,7 @@ class SelfTrainingEngine:
             try:
                 trimmed.append(float(value))
             except (TypeError, ValueError):
-                break
+                continue
         return trimmed
 
     def _persist_curated_dataset(

--- a/monGARS/core/self_training.py
+++ b/monGARS/core/self_training.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
-from typing import Any, Dict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, Sequence
+from uuid import uuid4
 
 from monGARS.core.neurones import EmbeddingSystem
 
@@ -10,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class SelfTrainingEngine:
-    """Simplified self-training engine that batches data and records model versions."""
+    """Batch curated records and trigger incremental training updates."""
 
     DEFAULT_BATCH_LIMIT = 100
 
@@ -19,6 +23,12 @@ class SelfTrainingEngine:
         training_threshold: float = 0.8,
         retrain_interval: int = 3600,
         batch_limit: int = DEFAULT_BATCH_LIMIT,
+        *,
+        trainer_cls: type | None = None,
+        training_config_path: str | None = None,
+        dataset_root: str | None = None,
+        model_registry_path: str | None = None,
+        curated_feature_limit: int = 128,
     ) -> None:
         self.training_threshold = training_threshold
         self.retrain_interval = retrain_interval
@@ -29,10 +39,25 @@ class SelfTrainingEngine:
         self._embedding_model = EmbeddingSystem()
         self.lock = asyncio.Lock()
         self._shutdown_event = asyncio.Event()
+        if trainer_cls is None:
+            from modules.neurons.training.mntp_trainer import MNTPTrainer
+
+            self._trainer_cls = MNTPTrainer
+        else:
+            self._trainer_cls = trainer_cls
+        self.training_config_path = Path(
+            training_config_path or "configs/training/mntp_mistral_config.json"
+        )
+        self.dataset_root = Path(dataset_root or "models/datasets/curated")
+        self.model_registry_path = Path(
+            model_registry_path or "models/encoders/self_training"
+        )
+        self.curated_feature_limit = max(1, curated_feature_limit)
         logger.info("SelfTrainingEngine initialized.")
 
     async def auto_improve(self) -> None:
         """Periodically trigger training cycles until shutdown."""
+
         while not self._shutdown_event.is_set():
             try:
                 await asyncio.wait_for(
@@ -42,13 +67,13 @@ class SelfTrainingEngine:
                 await self._run_training_cycle()
 
     async def _run_training_cycle(self) -> None:
-        batch: list[Dict[str, Any]] = []
+        batch: list[tuple[Dict[str, Any], float]] = []
         discarded = 0
         while not self.training_queue.empty() and len(batch) < self.batch_limit:
             record = await self.training_queue.get()
-            _, accepted = self._assess_record_confidence(record)
+            confidence, accepted = self._assess_record_confidence(record)
             if accepted:
-                batch.append(record)
+                batch.append((record, confidence))
             else:
                 discarded += 1
 
@@ -63,27 +88,45 @@ class SelfTrainingEngine:
 
         if not batch:
             return
+
         async with self.lock:
+            curated_batch, fallback_count = await self._prepare_curated_batch(batch)
+            if not curated_batch:
+                logger.info("No curated samples available; skipping training run")
+                return
+
+            dataset_metadata = await asyncio.to_thread(
+                self._persist_curated_dataset, curated_batch
+            )
+
+            try:
+                summary = await asyncio.to_thread(
+                    self._launch_trainer, curated_batch, dataset_metadata
+                )
+            except Exception as exc:  # pragma: no cover - unexpected training error
+                logger.error("Self-training run failed: %s", exc, exc_info=True)
+                return
+
             new_version = len(self.model_versions) + 1
             loop = asyncio.get_running_loop()
-            self.model_versions[f"v{new_version}"] = {
+            version_key = f"v{new_version}"
+            self.model_versions[version_key] = {
                 "trained_at": loop.time(),
-                "data_count": len(batch),
+                "data_count": len(curated_batch),
+                "dataset": dataset_metadata,
+                "summary": summary,
+                "fallback_embeddings": fallback_count,
             }
-            logger.info("Training complete. New model version: v%s", new_version)
+            logger.info("Training complete. New model version: %s", version_key)
             self.last_retrain_time = loop.time()
 
     def shutdown(self) -> None:
         """Signal the auto improvement loop to stop."""
+
         self._shutdown_event.set()
 
     def _assess_record_confidence(self, record: Dict[str, Any]) -> tuple[float, bool]:
-        """Return the parsed confidence value and whether it meets the threshold.
-
-        Missing or malformed confidence values are treated as ``0.0`` to ensure
-        they are excluded unless the threshold is configured to accept such
-        entries explicitly.
-        """
+        """Return the parsed confidence value and whether it meets the threshold."""
 
         confidence_raw = record.get("confidence")
         try:
@@ -93,3 +136,103 @@ class SelfTrainingEngine:
         except (TypeError, ValueError):
             confidence_value = 0.0
         return confidence_value, confidence_value >= self.training_threshold
+
+    async def _prepare_curated_batch(
+        self, batch: Sequence[tuple[Dict[str, Any], float]]
+    ) -> tuple[list[dict[str, Any]], int]:
+        curated: list[dict[str, Any]] = []
+        fallback_count = 0
+
+        for record, confidence in batch:
+            text = self._extract_training_text(record)
+            if not text:
+                logger.debug("Skipping record without trainable text")
+                continue
+
+            try:
+                embedding, used_fallback = await self._embedding_model.encode(text)
+            except Exception as exc:  # pragma: no cover - unexpected embedding error
+                logger.warning("Embedding failed for curated record: %s", exc)
+                continue
+
+            fallback_count += 1 if used_fallback else 0
+            trimmed_embedding = self._trim_embedding(embedding)
+            if not trimmed_embedding:
+                logger.debug("Trimmed embedding empty; skipping record")
+                continue
+
+            curated.append(
+                {
+                    "embedding": trimmed_embedding,
+                    "target": confidence,
+                    "confidence": confidence,
+                    "source_id": record.get("id") or record.get("message_id"),
+                    "text_preview": text[:200],
+                    "used_fallback_embedding": used_fallback,
+                }
+            )
+
+        return curated, fallback_count
+
+    def _extract_training_text(self, record: Dict[str, Any]) -> str | None:
+        candidates: Iterable[str] = (
+            record.get("text"),
+            record.get("response"),
+            record.get("prompt"),
+            record.get("content"),
+            record.get("data"),
+        )
+        for value in candidates:
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+
+    def _trim_embedding(self, embedding: Sequence[Any]) -> list[float]:
+        trimmed: list[float] = []
+        for index, value in enumerate(embedding):
+            if index >= self.curated_feature_limit:
+                break
+            try:
+                trimmed.append(float(value))
+            except (TypeError, ValueError):
+                break
+        return trimmed
+
+    def _persist_curated_dataset(
+        self, curated_batch: Sequence[dict[str, Any]]
+    ) -> Dict[str, Any]:
+        timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
+        run_id = f"self-training-{timestamp}-{uuid4().hex[:6]}"
+        dataset_dir = self.dataset_root / run_id
+        dataset_dir.mkdir(parents=True, exist_ok=True)
+        dataset_file = dataset_dir / "curated_batch.jsonl"
+
+        with dataset_file.open("w", encoding="utf-8") as handle:
+            for record in curated_batch:
+                handle.write(json.dumps(record, sort_keys=True))
+                handle.write("\n")
+
+        return {
+            "run_id": run_id,
+            "dataset_dir": str(dataset_dir),
+            "dataset_file": str(dataset_file),
+            "records": len(curated_batch),
+        }
+
+    def _launch_trainer(
+        self,
+        curated_batch: Sequence[dict[str, Any]],
+        dataset_metadata: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        output_dir = self.model_registry_path / dataset_metadata["run_id"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        trainer = self._trainer_cls(
+            training_config_path=str(self.training_config_path),
+            output_dir=str(output_dir),
+        )
+        summary = trainer.train(curated_records=curated_batch)
+        summary.setdefault("dataset", dataset_metadata)
+        summary.setdefault("artifacts", {})
+        summary["artifacts"].setdefault("training_output", str(output_dir))
+        return summary

--- a/tests/self_training_test.py
+++ b/tests/self_training_test.py
@@ -1,3 +1,6 @@
+import json
+from pathlib import Path
+
 import pytest
 
 from monGARS.core.self_training import SelfTrainingEngine
@@ -11,7 +14,7 @@ def stub_embedding_system(monkeypatch: pytest.MonkeyPatch) -> None:
 
         async def encode(self, text: str) -> tuple[list[float], bool]:
             self.encodes.append(text)
-            return [0.0], False
+            return [float(len(text))], False
 
     monkeypatch.setattr(
         "monGARS.core.self_training.EmbeddingSystem",
@@ -19,36 +22,98 @@ def stub_embedding_system(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+@pytest.fixture()
+def trainer_stub() -> type:
+    class DummyTrainer:
+        runs: list[list[dict[str, object]]] = []
+
+        def __init__(self, training_config_path: str, output_dir: str) -> None:
+            self.training_config_path = training_config_path
+            self.output_dir = Path(output_dir)
+
+        def train(self, curated_records=None):  # type: ignore[override]
+            records = list(curated_records or [])
+            DummyTrainer.runs.append(records)
+            self.output_dir.mkdir(parents=True, exist_ok=True)
+            weights_path = self.output_dir / "weights.json"
+            weights_path.write_text(json.dumps({"records": len(records)}))
+            summary = {
+                "status": "success",
+                "metrics": {
+                    "training_examples": len(records),
+                    "loss": 0.05,
+                },
+                "artifacts": {
+                    "weights": str(weights_path),
+                },
+            }
+            return summary
+
+    DummyTrainer.runs = []
+    return DummyTrainer
+
+
 @pytest.mark.asyncio
-async def test_run_training_cycle_creates_version():
-    engine = SelfTrainingEngine()
-    await engine.training_queue.put({"data": 1, "confidence": 0.95})
-    await engine.training_queue.put({"data": 2, "confidence": 0.4})
+async def test_run_training_cycle_creates_version(
+    tmp_path: Path, trainer_stub: type
+) -> None:
+    engine = SelfTrainingEngine(
+        trainer_cls=trainer_stub,
+        dataset_root=str(tmp_path / "datasets"),
+        model_registry_path=str(tmp_path / "models"),
+    )
+    await engine.training_queue.put(
+        {"text": "trainable", "confidence": 0.95, "id": "row-1"}
+    )
+    await engine.training_queue.put({"text": "ignored", "confidence": 0.4})
     await engine._run_training_cycle()
     assert "v1" in engine.model_versions
-    assert engine.model_versions["v1"]["data_count"] == 1
+    version = engine.model_versions["v1"]
+    assert version["data_count"] == 1
+    assert version["summary"]["metrics"]["training_examples"] == 1
+    dataset_file = version["dataset"]["dataset_file"]
+    assert Path(dataset_file).exists()
+    assert trainer_stub.runs and trainer_stub.runs[0][0]["text_preview"] == "trainable"
 
 
 @pytest.mark.asyncio
-async def test_run_training_cycle_no_data():
-    engine = SelfTrainingEngine()
+async def test_run_training_cycle_no_data(tmp_path: Path, trainer_stub: type) -> None:
+    engine = SelfTrainingEngine(
+        trainer_cls=trainer_stub,
+        dataset_root=str(tmp_path / "datasets"),
+        model_registry_path=str(tmp_path / "models"),
+    )
     await engine._run_training_cycle()
     assert engine.model_versions == {}
 
 
 @pytest.mark.asyncio
-async def test_run_training_cycle_skips_low_confidence_only():
-    engine = SelfTrainingEngine(training_threshold=0.9)
-    await engine.training_queue.put({"data": "low", "confidence": 0.1})
-    await engine.training_queue.put({"data": "unknown"})
+async def test_run_training_cycle_skips_low_confidence_only(
+    tmp_path: Path, trainer_stub: type
+) -> None:
+    engine = SelfTrainingEngine(
+        training_threshold=0.9,
+        trainer_cls=trainer_stub,
+        dataset_root=str(tmp_path / "datasets"),
+        model_registry_path=str(tmp_path / "models"),
+    )
+    await engine.training_queue.put({"text": "low", "confidence": 0.1})
+    await engine.training_queue.put({"text": "unknown"})
     await engine._run_training_cycle()
     assert engine.model_versions == {}
 
 
 @pytest.mark.asyncio
-async def test_run_training_cycle_handles_non_numeric_confidence():
-    engine = SelfTrainingEngine(training_threshold=0.5)
-    await engine.training_queue.put({"data": "valid", "confidence": 0.8})
-    await engine.training_queue.put({"data": "bad", "confidence": "not-a-number"})
+async def test_run_training_cycle_handles_non_numeric_confidence(
+    tmp_path: Path, trainer_stub: type
+) -> None:
+    engine = SelfTrainingEngine(
+        training_threshold=0.5,
+        trainer_cls=trainer_stub,
+        dataset_root=str(tmp_path / "datasets"),
+        model_registry_path=str(tmp_path / "models"),
+    )
+    await engine.training_queue.put({"text": "valid", "confidence": 0.8})
+    await engine.training_queue.put({"text": "bad", "confidence": "not-a-number"})
     await engine._run_training_cycle()
     assert engine.model_versions["v1"]["data_count"] == 1


### PR DESCRIPTION
## Summary
- add an optional curated-data training path to `MNTPTrainer` that learns a lightweight linear adapter and persists metrics and artifacts
- upgrade `SelfTrainingEngine` to build curated batches, persist JSONL datasets, and invoke the trainer for real model updates
- extend self-training tests with deterministic trainer/embedding stubs covering the new pipeline and metadata

## Testing
- pytest tests/self_training_test.py
- pytest tests/test_mntp_trainer.py

------
https://chatgpt.com/codex/tasks/task_e_68d8f0fbfcc88333a83083c1d4d9face

## Summary by Sourcery

Implement an active self-training pipeline by extending the self-training engine to build and persist curated JSONL datasets of trimmed embeddings, invoke an optional MNTPTrainer adapter for incremental updates, and record metrics, artifacts, and fallback statistics in the model registry.

New Features:
- Add optional curated-data training path in MNTPTrainer for lightweight linear adapter updates from supplied embeddings.
- Extend SelfTrainingEngine to batch high-confidence records, extract and trim embeddings, persist JSONL datasets, and launch incremental training runs.

Enhancements:
- Allow injection of custom trainer class, training config path, dataset root, model registry path, and curated feature limit in SelfTrainingEngine.
- Record dataset metadata, training summaries, artifacts, and fallback embedding counts in model version history.
- Update MNTPTrainer.train to dispatch curated records through a dedicated linear-adapter training routine and output adapter artifacts and metrics.

Tests:
- Introduce deterministic embedding and trainer stub fixtures.
- Enhance self-training tests to verify dataset file creation, trainer invocation, summary metrics, and skip logic for low or invalid confidence records.