### PR TITLE
Add telemetry metrics to distributed scheduler

### DIFF
--- a/monGARS/core/distributed_scheduler.py
+++ b/monGARS/core/distributed_scheduler.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 import time
 import uuid
 from collections.abc import Callable, Coroutine, Iterable
-from threading import Lock
 from typing import Any
 from weakref import WeakSet
 
@@ -24,46 +24,58 @@ _scheduler_registry: "WeakSet[DistributedScheduler]" = WeakSet()
 _settings: Any | None = None
 _metrics_registered = False
 _metrics_enabled = False
+_metrics_registration_lock = threading.Lock()
+
+
+def _load_settings() -> Any | None:
+    try:
+        return get_settings()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Failed to load settings for metrics: %s", exc, exc_info=True)
+        return None
+
+
+def _disable_metrics() -> bool:
+    global _metrics_registered, _metrics_enabled
+    _metrics_registered = True
+    _metrics_enabled = False
+    return False
 
 
 def _ensure_metrics_registered() -> bool:
     """Initialise OpenTelemetry instruments if metrics are enabled."""
 
     global _metrics_registered, _metrics_enabled, _settings
-    if _metrics_registered:
-        return _metrics_enabled
+    with _metrics_registration_lock:
+        if _metrics_registered:
+            return _metrics_enabled
 
-    try:
-        _settings = get_settings()
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.warning("Failed to load settings for metrics: %s", exc, exc_info=True)
+        settings = _load_settings()
+        if settings is None:
+            return _disable_metrics()
+
+        _settings = settings
+        if not getattr(settings, "otel_metrics_enabled", False):
+            return _disable_metrics()
+
+        meter.create_observable_gauge(
+            "distributed_scheduler_queue_depth",
+            callbacks=[_observe_queue_depth],
+            description="Current number of pending tasks per scheduler instance.",
+        )
+        meter.create_observable_gauge(
+            "distributed_scheduler_worker_uptime_seconds",
+            callbacks=[_observe_worker_uptime],
+            description="Aggregate uptime in seconds for active scheduler workers.",
+        )
+        meter.create_observable_gauge(
+            "distributed_scheduler_task_failure_rate",
+            callbacks=[_observe_failure_rate],
+            description="Rolling task failure rate for scheduler instances.",
+        )
         _metrics_registered = True
-        _metrics_enabled = False
-        return False
-
-    if not getattr(_settings, "otel_metrics_enabled", False):
-        _metrics_registered = True
-        _metrics_enabled = False
-        return False
-
-    meter.create_observable_gauge(
-        "distributed_scheduler_queue_depth",
-        callbacks=[_observe_queue_depth],
-        description="Current number of pending tasks per scheduler instance.",
-    )
-    meter.create_observable_gauge(
-        "distributed_scheduler_worker_uptime_seconds",
-        callbacks=[_observe_worker_uptime],
-        description="Aggregate uptime in seconds for active scheduler workers.",
-    )
-    meter.create_observable_gauge(
-        "distributed_scheduler_task_failure_rate",
-        callbacks=[_observe_failure_rate],
-        description="Rolling task failure rate for scheduler instances.",
-    )
-    _metrics_registered = True
-    _metrics_enabled = True
-    return True
+        _metrics_enabled = True
+        return True
 
 
 def _observe_queue_depth(options: CallbackOptions) -> Iterable[Observation]:
@@ -104,7 +116,7 @@ class DistributedScheduler:
         self._workers: list[asyncio.Task[Any]] = []
         self._running: bool = False
         self._stopping: bool = False
-        self._metrics_lock = Lock()
+        self._metrics_lock: asyncio.Lock | None = None
         self._worker_start_times: dict[int, float] = {}
         self._worker_uptime_total: float = 0.0
         self._processed_tasks: int = 0
@@ -116,8 +128,17 @@ class DistributedScheduler:
             "scheduler_id": self.instance_id,
             "concurrency": self.concurrency,
         }
-        if _ensure_metrics_registered():
-            _scheduler_registry.add(self)
+        self._metrics_cache = {
+            "queue_depth": 0,
+            "active_workers": 0,
+            "concurrency": self.concurrency,
+            "worker_uptime_seconds": 0.0,
+            "tasks_processed": 0,
+            "tasks_failed": 0,
+            "task_failure_rate": 0.0,
+        }
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._metrics_registered_with_meter = False
 
     @property
     def metric_attributes(self) -> dict[str, int | str]:
@@ -125,53 +146,44 @@ class DistributedScheduler:
 
     @property
     def queue_depth(self) -> int:
-        return self.queue.qsize()
+        return self._metrics_cache["queue_depth"]
 
     @property
     def worker_uptime_seconds(self) -> float:
-        with self._metrics_lock:
-            now = time.monotonic()
-            uptime = self._worker_uptime_total
-            for start_time in self._worker_start_times.values():
-                uptime += now - start_time
-            return uptime
+        if self._in_event_loop_thread():
+            return self._compute_worker_uptime(time.monotonic())
+        loop = self._loop
+        if not loop or not loop.is_running():
+            return self._metrics_cache["worker_uptime_seconds"]
+        future = asyncio.run_coroutine_threadsafe(self._update_metrics(), loop)
+        return future.result()["worker_uptime_seconds"]
 
     @property
     def task_failure_rate(self) -> float:
-        with self._metrics_lock:
-            if self._processed_tasks == 0:
-                return 0.0
-            return self._failed_tasks / self._processed_tasks
+        if self._in_event_loop_thread():
+            return self._compute_failure_rate()
+        loop = self._loop
+        if not loop or not loop.is_running():
+            return self._metrics_cache["task_failure_rate"]
+        future = asyncio.run_coroutine_threadsafe(self._update_metrics(), loop)
+        return future.result()["task_failure_rate"]
 
-    def get_metrics_snapshot(self) -> dict[str, float | int]:
+    async def get_metrics_snapshot(self) -> dict[str, float | int]:
         """Return a point-in-time view of scheduler health metrics."""
 
-        with self._metrics_lock:
-            processed = self._processed_tasks
-            failed = self._failed_tasks
-            now = time.monotonic()
-            uptime = self._worker_uptime_total
-            for start_time in self._worker_start_times.values():
-                uptime += now - start_time
-            return {
-                "queue_depth": self.queue.qsize(),
-                "active_workers": len(self._worker_start_times),
-                "concurrency": self.concurrency,
-                "worker_uptime_seconds": uptime,
-                "tasks_processed": processed,
-                "tasks_failed": failed,
-                "task_failure_rate": 0.0 if processed == 0 else failed / processed,
-            }
+        return await self._update_metrics()
 
     async def add_task(self, task: Callable[[], Coroutine[Any, Any, Any]]) -> None:
         """Queue a coroutine factory for execution."""
         if self._stopping:
             raise RuntimeError("Scheduler is stopping")
         await self.queue.put(task)
+        await self._update_metrics()
 
     async def _worker(self, worker_id: int) -> None:
-        with self._metrics_lock:
-            self._worker_start_times[worker_id] = time.monotonic()
+        await self._update_metrics(
+            lambda: self._worker_start_times.__setitem__(worker_id, time.monotonic())
+        )
         try:
             while self._running or not self.queue.empty():
                 try:
@@ -183,9 +195,7 @@ class DistributedScheduler:
                 try:
                     result = await factory()
                 except Exception as exc:  # pragma: no cover - unexpected errors
-                    with self._metrics_lock:
-                        self._processed_tasks += 1
-                        self._failed_tasks += 1
+                    await self._update_metrics(self._mark_task_failure)
                     logger.error(
                         "scheduler.task_failure",
                         extra={
@@ -195,22 +205,21 @@ class DistributedScheduler:
                         exc_info=True,
                     )
                 else:
-                    with self._metrics_lock:
-                        self._processed_tasks += 1
+                    await self._update_metrics(self._mark_task_success)
                     await self.communicator.send({"result": result})
                 finally:
                     self.queue.task_done()
+                    await self._update_metrics()
+        except asyncio.CancelledError:
+            pass
         finally:
-            with self._metrics_lock:
-                start_time = self._worker_start_times.pop(worker_id, None)
-                if start_time is not None:
-                    self._worker_uptime_total += time.monotonic() - start_time
+            await self._update_metrics(lambda: self._finalise_worker(worker_id))
 
-    def _emit_metrics_log(self, force: bool = False) -> None:
+    async def _emit_metrics_log(self, force: bool = False) -> None:
         now = time.monotonic()
         if not force and now - self._last_metrics_emit < self.metrics_interval:
             return
-        snapshot = self.get_metrics_snapshot()
+        snapshot = await self.get_metrics_snapshot()
         logger.info(
             "scheduler.metrics",
             extra={"scheduler_id": self.instance_id, **snapshot},
@@ -222,6 +231,10 @@ class DistributedScheduler:
             return
         self._stopping = False
         self._running = True
+        self._loop = asyncio.get_running_loop()
+        self._metrics_registered_with_meter = self.configure_metrics()
+        if self._metrics_registered_with_meter:
+            _scheduler_registry.add(self)
         self._last_metrics_emit = time.monotonic()
         self._workers = [
             asyncio.create_task(self._worker(index))
@@ -230,14 +243,90 @@ class DistributedScheduler:
         try:
             while self._running:
                 await asyncio.sleep(0.1)
-                self._emit_metrics_log()
+                await self._update_metrics()
+                await self._emit_metrics_log()
         finally:
             await self.queue.join()
             for worker in self._workers:
                 worker.cancel()
             await asyncio.gather(*self._workers, return_exceptions=True)
-            self._emit_metrics_log(force=True)
+            await self._update_metrics()
+            await self._emit_metrics_log(force=True)
+            if self._metrics_registered_with_meter:
+                _scheduler_registry.discard(self)
+            self._metrics_registered_with_meter = False
+            self._loop = None
 
     def stop(self) -> None:
         self._stopping = True
-        self._running = False
+        if self._running:
+            self._running = False
+            for worker in list(self._workers):
+                worker.cancel()
+
+    @classmethod
+    def configure_metrics(cls) -> bool:
+        return _ensure_metrics_registered()
+
+    def _in_event_loop_thread(self) -> bool:
+        loop = self._loop
+        if loop is None:
+            return False
+        try:
+            return asyncio.get_running_loop() is loop
+        except RuntimeError:
+            return False
+
+    def _get_metrics_lock(self) -> asyncio.Lock:
+        if self._metrics_lock is None:
+            self._metrics_lock = asyncio.Lock()
+        return self._metrics_lock
+
+    async def _update_metrics(
+        self, mutate: Callable[[], None] | None = None
+    ) -> dict[str, float | int]:
+        lock = self._get_metrics_lock()
+        async with lock:
+            if mutate:
+                mutate()
+            snapshot = self._compute_metrics_snapshot(time.monotonic())
+            self._metrics_cache = snapshot
+            return snapshot
+
+    def _compute_metrics_snapshot(self, now: float) -> dict[str, float | int]:
+        uptime = self._compute_worker_uptime(now)
+        processed = self._processed_tasks
+        failed = self._failed_tasks
+        failure_rate = 0.0 if processed == 0 else failed / processed
+        return {
+            "queue_depth": self.queue.qsize(),
+            "active_workers": len(self._worker_start_times),
+            "concurrency": self.concurrency,
+            "worker_uptime_seconds": uptime,
+            "tasks_processed": processed,
+            "tasks_failed": failed,
+            "task_failure_rate": failure_rate,
+        }
+
+    def _compute_worker_uptime(self, now: float) -> float:
+        uptime = self._worker_uptime_total
+        for start_time in self._worker_start_times.values():
+            uptime += now - start_time
+        return uptime
+
+    def _compute_failure_rate(self) -> float:
+        processed = self._metrics_cache["tasks_processed"]
+        failed = self._metrics_cache["tasks_failed"]
+        return 0.0 if processed == 0 else failed / processed
+
+    def _mark_task_success(self) -> None:
+        self._processed_tasks += 1
+
+    def _mark_task_failure(self) -> None:
+        self._processed_tasks += 1
+        self._failed_tasks += 1
+
+    def _finalise_worker(self, worker_id: int) -> None:
+        start_time = self._worker_start_times.pop(worker_id, None)
+        if start_time is not None:
+            self._worker_uptime_total += time.monotonic() - start_time

--- a/monGARS/core/distributed_scheduler.py
+++ b/monGARS/core/distributed_scheduler.py
@@ -2,11 +2,89 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, Callable, Coroutine
+import time
+import uuid
+from collections.abc import Callable, Coroutine, Iterable
+from threading import Lock
+from typing import Any
+from weakref import WeakSet
+
+from opentelemetry import metrics
+from opentelemetry.metrics import CallbackOptions, Observation
+
+from monGARS.config import get_settings
 
 from .peer import PeerCommunicator
 
 logger = logging.getLogger(__name__)
+
+meter = metrics.get_meter(__name__)
+
+_scheduler_registry: "WeakSet[DistributedScheduler]" = WeakSet()
+_settings: Any | None = None
+_metrics_registered = False
+_metrics_enabled = False
+
+
+def _ensure_metrics_registered() -> bool:
+    """Initialise OpenTelemetry instruments if metrics are enabled."""
+
+    global _metrics_registered, _metrics_enabled, _settings
+    if _metrics_registered:
+        return _metrics_enabled
+
+    try:
+        _settings = get_settings()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Failed to load settings for metrics: %s", exc, exc_info=True)
+        _metrics_registered = True
+        _metrics_enabled = False
+        return False
+
+    if not getattr(_settings, "otel_metrics_enabled", False):
+        _metrics_registered = True
+        _metrics_enabled = False
+        return False
+
+    meter.create_observable_gauge(
+        "distributed_scheduler_queue_depth",
+        callbacks=[_observe_queue_depth],
+        description="Current number of pending tasks per scheduler instance.",
+    )
+    meter.create_observable_gauge(
+        "distributed_scheduler_worker_uptime_seconds",
+        callbacks=[_observe_worker_uptime],
+        description="Aggregate uptime in seconds for active scheduler workers.",
+    )
+    meter.create_observable_gauge(
+        "distributed_scheduler_task_failure_rate",
+        callbacks=[_observe_failure_rate],
+        description="Rolling task failure rate for scheduler instances.",
+    )
+    _metrics_registered = True
+    _metrics_enabled = True
+    return True
+
+
+def _observe_queue_depth(options: CallbackOptions) -> Iterable[Observation]:
+    return tuple(
+        Observation(scheduler.queue_depth, scheduler.metric_attributes)
+        for scheduler in list(_scheduler_registry)
+    )
+
+
+def _observe_worker_uptime(options: CallbackOptions) -> Iterable[Observation]:
+    return tuple(
+        Observation(scheduler.worker_uptime_seconds, scheduler.metric_attributes)
+        for scheduler in list(_scheduler_registry)
+    )
+
+
+def _observe_failure_rate(options: CallbackOptions) -> Iterable[Observation]:
+    return tuple(
+        Observation(scheduler.task_failure_rate, scheduler.metric_attributes)
+        for scheduler in list(_scheduler_registry)
+    )
 
 
 class DistributedScheduler:
@@ -16,6 +94,7 @@ class DistributedScheduler:
         self,
         communicator: PeerCommunicator,
         concurrency: int = 1,
+        metrics_interval: float = 5.0,
     ) -> None:
         self.communicator = communicator
         self.concurrency = max(1, concurrency)
@@ -25,6 +104,64 @@ class DistributedScheduler:
         self._workers: list[asyncio.Task[Any]] = []
         self._running: bool = False
         self._stopping: bool = False
+        self._metrics_lock = Lock()
+        self._worker_start_times: dict[int, float] = {}
+        self._worker_uptime_total: float = 0.0
+        self._processed_tasks: int = 0
+        self._failed_tasks: int = 0
+        self._last_metrics_emit: float = 0.0
+        self.metrics_interval = max(0.5, metrics_interval)
+        self.instance_id = uuid.uuid4().hex
+        self._metric_attributes = {
+            "scheduler_id": self.instance_id,
+            "concurrency": self.concurrency,
+        }
+        if _ensure_metrics_registered():
+            _scheduler_registry.add(self)
+
+    @property
+    def metric_attributes(self) -> dict[str, int | str]:
+        return self._metric_attributes
+
+    @property
+    def queue_depth(self) -> int:
+        return self.queue.qsize()
+
+    @property
+    def worker_uptime_seconds(self) -> float:
+        with self._metrics_lock:
+            now = time.monotonic()
+            uptime = self._worker_uptime_total
+            for start_time in self._worker_start_times.values():
+                uptime += now - start_time
+            return uptime
+
+    @property
+    def task_failure_rate(self) -> float:
+        with self._metrics_lock:
+            if self._processed_tasks == 0:
+                return 0.0
+            return self._failed_tasks / self._processed_tasks
+
+    def get_metrics_snapshot(self) -> dict[str, float | int]:
+        """Return a point-in-time view of scheduler health metrics."""
+
+        with self._metrics_lock:
+            processed = self._processed_tasks
+            failed = self._failed_tasks
+            now = time.monotonic()
+            uptime = self._worker_uptime_total
+            for start_time in self._worker_start_times.values():
+                uptime += now - start_time
+            return {
+                "queue_depth": self.queue.qsize(),
+                "active_workers": len(self._worker_start_times),
+                "concurrency": self.concurrency,
+                "worker_uptime_seconds": uptime,
+                "tasks_processed": processed,
+                "tasks_failed": failed,
+                "task_failure_rate": 0.0 if processed == 0 else failed / processed,
+            }
 
     async def add_task(self, task: Callable[[], Coroutine[Any, Any, Any]]) -> None:
         """Queue a coroutine factory for execution."""
@@ -32,36 +169,74 @@ class DistributedScheduler:
             raise RuntimeError("Scheduler is stopping")
         await self.queue.put(task)
 
-    async def _worker(self) -> None:
-        while self._running or not self.queue.empty():
-            try:
-                factory = await asyncio.wait_for(self.queue.get(), timeout=1)
-            except asyncio.TimeoutError:
-                if not self._running and self.queue.empty():
-                    break
-                continue
-            try:
-                result = await factory()
-                await self.communicator.send({"result": result})
-            except Exception as exc:  # pragma: no cover - unexpected errors
-                logger.error("Task failed: %s", exc)
-            finally:
-                self.queue.task_done()
+    async def _worker(self, worker_id: int) -> None:
+        with self._metrics_lock:
+            self._worker_start_times[worker_id] = time.monotonic()
+        try:
+            while self._running or not self.queue.empty():
+                try:
+                    factory = await asyncio.wait_for(self.queue.get(), timeout=1)
+                except asyncio.TimeoutError:
+                    if not self._running and self.queue.empty():
+                        break
+                    continue
+                try:
+                    result = await factory()
+                except Exception as exc:  # pragma: no cover - unexpected errors
+                    with self._metrics_lock:
+                        self._processed_tasks += 1
+                        self._failed_tasks += 1
+                    logger.error(
+                        "scheduler.task_failure",
+                        extra={
+                            "scheduler_id": self.instance_id,
+                            "worker_id": worker_id,
+                        },
+                        exc_info=True,
+                    )
+                else:
+                    with self._metrics_lock:
+                        self._processed_tasks += 1
+                    await self.communicator.send({"result": result})
+                finally:
+                    self.queue.task_done()
+        finally:
+            with self._metrics_lock:
+                start_time = self._worker_start_times.pop(worker_id, None)
+                if start_time is not None:
+                    self._worker_uptime_total += time.monotonic() - start_time
+
+    def _emit_metrics_log(self, force: bool = False) -> None:
+        now = time.monotonic()
+        if not force and now - self._last_metrics_emit < self.metrics_interval:
+            return
+        snapshot = self.get_metrics_snapshot()
+        logger.info(
+            "scheduler.metrics",
+            extra={"scheduler_id": self.instance_id, **snapshot},
+        )
+        self._last_metrics_emit = now
 
     async def run(self) -> None:
         if self._running:
             return
         self._stopping = False
         self._running = True
+        self._last_metrics_emit = time.monotonic()
         self._workers = [
-            asyncio.create_task(self._worker()) for _ in range(self.concurrency)
+            asyncio.create_task(self._worker(index))
+            for index in range(self.concurrency)
         ]
-        while self._running:
-            await asyncio.sleep(0.1)
-        await self.queue.join()
-        for w in self._workers:
-            w.cancel()
-        await asyncio.gather(*self._workers, return_exceptions=True)
+        try:
+            while self._running:
+                await asyncio.sleep(0.1)
+                self._emit_metrics_log()
+        finally:
+            await self.queue.join()
+            for worker in self._workers:
+                worker.cancel()
+            await asyncio.gather(*self._workers, return_exceptions=True)
+            self._emit_metrics_log(force=True)
 
     def stop(self) -> None:
         self._stopping = True

--- a/tests/test_distributed_scheduler.py
+++ b/tests/test_distributed_scheduler.py
@@ -1,8 +1,10 @@
 import asyncio
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
+from monGARS.core import distributed_scheduler
 from monGARS.core.distributed_scheduler import DistributedScheduler
 from monGARS.core.peer import PeerCommunicator
 
@@ -80,7 +82,7 @@ async def test_scheduler_metrics_snapshot(monkeypatch):
     scheduler.stop()
     await runner
 
-    snapshot = scheduler.get_metrics_snapshot()
+    snapshot = await scheduler.get_metrics_snapshot()
     assert sent == [{"result": "payload"}]
     assert snapshot["queue_depth"] == 0
     assert snapshot["tasks_processed"] == 1
@@ -115,8 +117,59 @@ async def test_scheduler_failure_metrics(monkeypatch):
     scheduler.stop()
     await runner
 
-    snapshot = scheduler.get_metrics_snapshot()
+    snapshot = await scheduler.get_metrics_snapshot()
     assert sent == [{"result": "ok"}]
     assert snapshot["tasks_processed"] == 2
     assert snapshot["tasks_failed"] == 1
     assert snapshot["task_failure_rate"] == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_scheduler_metrics_logging(monkeypatch):
+    communicator = PeerCommunicator([])
+    sent: list[dict[str, Any]] = []
+
+    async def fake_send(msg):
+        sent.append(msg)
+        return [True]
+
+    monkeypatch.setattr(communicator, "send", fake_send)
+    scheduler = DistributedScheduler(communicator, concurrency=1, metrics_interval=0.1)
+
+    async def success():
+        return "ok"
+
+    async def failure():
+        raise RuntimeError("boom")
+
+    await scheduler.add_task(success)
+    await scheduler.add_task(failure)
+
+    metrics_logs: list[dict[str, Any]] = []
+
+    def capture_metrics_log(*args, **kwargs):
+        extra = kwargs.get("extra")
+        if extra is not None:
+            metrics_logs.append(extra)
+
+    with patch.object(
+        distributed_scheduler.logger, "info", side_effect=capture_metrics_log
+    ):
+        runner = asyncio.create_task(scheduler.run())
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + 1.0
+        while len(metrics_logs) < 2 and loop.time() < deadline:
+            await asyncio.sleep(0.05)
+        assert len(metrics_logs) >= 2
+        scheduler.stop()
+        await runner
+
+    snapshot = await scheduler.get_metrics_snapshot()
+    assert sent == [{"result": "ok"}]
+    assert snapshot["tasks_processed"] == 2
+    assert snapshot["tasks_failed"] == 1
+    assert snapshot["task_failure_rate"] == pytest.approx(0.5)
+
+    assert len(metrics_logs) >= 3
+    assert "tasks_processed" in metrics_logs[-1]
+    assert metrics_logs[-1]["tasks_processed"] == 2


### PR DESCRIPTION
## Summary
- instrument the DistributedScheduler with OpenTelemetry gauges for queue depth, worker uptime, and task failure rate
- expose scheduler health snapshots and structured metrics logs to aid correlation with latency diagnostics
- add unit tests covering metrics snapshots and failure tracking for the scheduler

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d903c1eb288333b8f416e10ccd52db

## Summary by Sourcery

Instrument DistributedScheduler with OpenTelemetry metrics, expose health snapshots and periodic structured logs for telemetry, and add unit tests for metrics and failure tracking.

New Features:
- Add observable OpenTelemetry gauges for scheduler queue depth, worker uptime, and task failure rate
- Introduce get_metrics_snapshot method to capture point-in-time scheduler health metrics
- Implement periodic structured logging of scheduler metrics with unique instance identifiers

Tests:
- Add unit tests for metrics snapshot correctness and task failure rate tracking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added OpenTelemetry-based metrics for the distributed scheduler, including queue depth, worker uptime, and task failure rate.
  - Introduced periodic metrics emission/logging and a snapshot view of current metrics.
  - Added a configurable metrics interval and per-instance metric attributes.
  - Improved graceful shutdown to ensure metrics reflect final state.

- Tests
  - Added comprehensive tests covering metrics snapshots, failure counts, uptime, run/stop lifecycle, and logged metrics output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->