### PR TITLE
Optimize concurrent knowledge graph lookups

### DIFF
--- a/monGARS/core/neurones.py
+++ b/monGARS/core/neurones.py
@@ -35,6 +35,15 @@ class _NoOpResult:
     async def single(self) -> dict[str, Any]:
         return {"exists": False}
 
+    async def data(self) -> list[dict[str, Any]]:
+        return []
+
+    def __aiter__(self) -> "_NoOpResult":
+        return self
+
+    async def __anext__(self) -> dict[str, Any]:
+        raise StopAsyncIteration
+
 
 class _NoOpSession:
     async def __aenter__(self) -> "_NoOpSession":

--- a/monGARS/core/neurones.py
+++ b/monGARS/core/neurones.py
@@ -32,10 +32,21 @@ _EMPTY_CACHE_KEY = "<EMPTY>"
 
 
 class _NoOpResult:
+    """Minimal async-compatible result used when the Neo4j driver is absent.
+
+    The curiosity engine exercises ``data()``, ``records()`` and async iteration
+    when normalising query responses. These stubs mirror that interface so tests
+    can run without the optional driver dependency. Extend this class if new
+    result helpers are accessed in the future.
+    """
+
     async def single(self) -> dict[str, Any]:
         return {"exists": False}
 
     async def data(self) -> list[dict[str, Any]]:
+        return []
+
+    def records(self) -> list[dict[str, Any]]:
         return []
 
     def __aiter__(self) -> "_NoOpResult":


### PR DESCRIPTION
## Summary
- add an in-flight coordination map to CuriosityEngine so concurrent entity checks share the same Neo4j batch
- extract a dedicated _query_kg_entities helper to encapsulate driver handling and fallback behaviour
- cover the concurrent batching path with a regression test alongside existing cache coverage

## Testing
- pytest tests/test_curiosity_engine.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d9c416a9a08333bcb82e35b1fe07ac

## Summary by Sourcery

Optimize entity presence checks against the knowledge graph by batching concurrent requests, adding a coordinated in-flight map and LRU cache with TTL, extracting a reusable query helper, and covering the new paths with regression tests.

New Features:
- Add concurrent batched knowledge graph lookup with in-flight request coordination to dedupe parallel requests
- Introduce a dedicated async helper for querying multiple entities in the knowledge graph

Enhancements:
- Implement an LRU cache with TTL and max-entry eviction for KG presence checks
- Extract async entity extraction logic and unify single-entity lookups to use the batch interface
- Extend NoOp result/session stubs to support async iteration and data() for testing

Tests:
- Add regression tests for cache behavior and sharing in-flight batch queries
- Update existing gap detection tests to rely on the new batched lookup method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Asynchronous entity extraction for smoother, non-blocking interactions.
  - Improved async compatibility: internal no-op results now support async iteration.

- Refactor
  - Migrated to batched, cached knowledge lookups to reduce latency and avoid duplicate requests.
  - Enhanced result normalization for more robust knowledge-graph interactions.

- Tests
  - Added tests verifying cache reuse and shared in-flight lookups for batch requests.
  - Updated gap-detection tests to cover the new batched lookup path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->