### PR TITLE
Default LLM integration to Ray Serve

### DIFF
--- a/monGARS/core/llm_integration.py
+++ b/monGARS/core/llm_integration.py
@@ -180,8 +180,12 @@ class LLMIntegration:
                 self._adapter_manifest_mtime
                 and stat.st_mtime <= self._adapter_manifest_mtime
             ):
+                self._update_adapter_version(
+                    self._adapter_metadata.get("version")
+                    if self._adapter_metadata
+                    else None
+                )
                 return self._adapter_metadata
-
             try:
                 manifest = await asyncio.to_thread(
                     load_manifest, self.adapter_registry_path


### PR DESCRIPTION
## Summary
- default the core LLM integration to route traffic through Ray Serve unless explicitly disabled

## Testing
- pytest tests/test_llm_ray.py

------
https://chatgpt.com/codex/tasks/task_e_68d9de8846d08333a08a2d8c3cfff800

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/monGARS/71)
<!-- GitContextEnd -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Distributed inference backend (Ray Serve) is enabled by default when not explicitly configured.

* **Bug Fixes**
  * Detects and surfaces malformed backend responses with clearer errors to prevent silent failures.
  * Ensures adapter version/state is refreshed sooner when manifest hasn’t changed.

* **Refactor**
  * More consistent request formatting and logging across backends; retains retry/circuit-breaker behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->