### PR TITLE
Harden MNTP training pipeline error handling

### DIFF
--- a/modules/evolution_engine/orchestrator.py
+++ b/modules/evolution_engine/orchestrator.py
@@ -88,13 +88,18 @@ class EvolutionOrchestrator:
                 "Trainer produced adapter artifact outside orchestrator output directory"
             ) from exc
 
-        weights_path_raw = artifacts.get("weights")
-        if weights_path_raw:
+        if weights_path_raw := artifacts.get("weights"):
             weights_path = Path(weights_path_raw)
             if not weights_path.exists():
                 raise RuntimeError(
                     f"Adapter weights path '{weights_path}' does not exist"
                 )
+            try:
+                weights_path.resolve().relative_to(unique_dir.resolve())
+            except Exception as exc:
+                raise RuntimeError(
+                    "Trainer produced adapter weights outside orchestrator output directory"
+                ) from exc
 
         try:
             manifest = update_manifest(self.model_registry_path, summary)


### PR DESCRIPTION
## Summary
- add dependency, dataset, and metric validation to the MNTPTrainer PEFT execution path and enforce adapter persistence checks
- harden EvolutionOrchestrator so non-successful trainer runs or missing artifacts raise actionable errors
- extend MNTP trainer tests with stubs to cover orchestrator failures and adapter persistence validation

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d9eb7f0c44833389ee311f099856f6

## Summary by Sourcery

Reinforce robustness of the MNTP training pipeline by adding comprehensive validation of dependencies, data, metrics, and artifacts, and by hardening the orchestrator to surface actionable errors on failures.

Enhancements:
- Validate optional PEFT training dependencies early and report missing ones
- Enforce non-empty datasets, valid average loss, completed update steps, and processed examples during training
- Require adapter configuration and weight files after model persistence and raise errors if missing
- Harden EvolutionOrchestrator to detect non-successful trainer statuses and missing or misplaced adapter artifacts and raise clear errors

Tests:
- Add tests for orchestrator to surface training failures and prevent manifest creation
- Extend MNTPTrainer tests for deterministic fallback behavior, successful and failing adapter persistence scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validate training outcomes before proceeding and block manifest updates on unsuccessful runs.
  * Verify artifact paths exist and are within the output directory; enforce presence of required model files.
  * Fail fast with clear errors for missing dependencies, empty datasets, invalid metrics, or incomplete training steps.
  * Improve robustness of model save and artifact discovery.

* **Improvements**
  * More informative logging for failures and pipeline completion.

* **Tests**
  * Added tests covering fallback behavior, artifact persistence validation, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->