### PR TITLE
Improve persistence reliability and hippocampus durability

### DIFF
--- a/monGARS/core/hippocampus.py
+++ b/monGARS/core/hippocampus.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Deque, Dict, List
+from typing import Deque, Dict, List, Set
+
+from monGARS.core.persistence import PersistenceRepository
 
 logger = logging.getLogger(__name__)
 
@@ -17,31 +21,88 @@ class MemoryItem:
 
 
 class Hippocampus:
-    """Simple in-memory store for conversation history."""
+    """Hybrid in-memory/persistent store for conversation history."""
 
     MAX_HISTORY = 100
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        persistence: PersistenceRepository | None = None,
+        *,
+        persist_on_store: bool = False,
+    ) -> None:
         self._memory: Dict[str, Deque[MemoryItem]] = {}
         self._locks: Dict[str, asyncio.Lock] = {}
+        self._hydrated_users: Set[str] = set()
+        self._persistence = persistence or PersistenceRepository()
+        self._persist_on_store = persist_on_store and self._persistence is not None
 
     def _get_lock(self, user_id: str) -> asyncio.Lock:
         if user_id not in self._locks:
             self._locks[user_id] = asyncio.Lock()
         return self._locks[user_id]
 
+    @staticmethod
+    def _normalise_timestamp(value: datetime) -> datetime:
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+    async def _hydrate_from_persistence(self, user_id: str) -> None:
+        if user_id in self._hydrated_users:
+            return
+        if self._persistence is None:
+            return
+
+        records = await self._persistence.get_history(user_id, limit=self.MAX_HISTORY)
+        if not records:
+            async with self._get_lock(user_id):
+                self._hydrated_users.add(user_id)
+            return
+
+        items = [
+            MemoryItem(
+                user_id=record.user_id,
+                query=record.query,
+                response=record.response,
+                timestamp=self._normalise_timestamp(record.timestamp),
+            )
+            for record in reversed(records)
+        ]
+
+        async with self._get_lock(user_id):
+            if user_id in self._hydrated_users:
+                return
+            history = self._memory.setdefault(user_id, deque(maxlen=self.MAX_HISTORY))
+            history.clear()
+            history.extend(items)
+            self._hydrated_users.add(user_id)
+
     async def store(self, user_id: str, query: str, response: str) -> None:
         """Persist a query/response pair for a user."""
         logger.debug("Storing interaction for %s", user_id)
+        item = MemoryItem(user_id=user_id, query=query, response=response)
         async with self._get_lock(user_id):
             history = self._memory.setdefault(user_id, deque(maxlen=self.MAX_HISTORY))
-            history.append(MemoryItem(user_id=user_id, query=query, response=response))
+            history.append(item)
+            self._hydrated_users.add(user_id)
+        if self._persist_on_store and self._persistence is not None:
+            try:
+                await self._persistence.save_history_entry(
+                    user_id=user_id, query=query, response=response
+                )
+            except Exception:
+                logger.exception(
+                    "hippocampus.persistence_failed",
+                    extra={"user_id": user_id},
+                )
 
     async def history(self, user_id: str, limit: int = 10) -> List[MemoryItem]:
         """Return recent conversation history."""
         if limit <= 0:
             return []
         limit = min(limit, self.MAX_HISTORY)
+        await self._hydrate_from_persistence(user_id)
         async with self._get_lock(user_id):
             history = self._memory.get(user_id, deque())
             items = list(history)[-limit:]

--- a/monGARS/core/persistence.py
+++ b/monGARS/core/persistence.py
@@ -1,15 +1,67 @@
+from __future__ import annotations
+
 import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 from sqlalchemy import desc, select
+from sqlalchemy.exc import DBAPIError, InterfaceError, OperationalError
+from tenacity import (
+    AsyncRetrying,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from ..init_db import ConversationHistory, Interaction, async_session_factory
 
 logger = logging.getLogger(__name__)
 
 
+SessionCallable = Callable[[Any], Awaitable[Any]]
+
+
 class PersistenceRepository:
     def __init__(self, session_factory=async_session_factory):
         self._session_factory = session_factory
+
+    async def _execute_with_retry(
+        self, operation: SessionCallable, *, operation_name: str
+    ) -> Any:
+        retrying = AsyncRetrying(
+            stop=stop_after_attempt(3),
+            wait=wait_exponential(multiplier=0.5, min=0.5, max=5),
+            retry=retry_if_exception_type(
+                (OperationalError, InterfaceError, DBAPIError)
+            ),
+            reraise=True,
+        )
+        try:
+            async for attempt in retrying:
+                with attempt:
+                    async with self._session_factory() as session:
+                        try:
+                            return await operation(session)
+                        except Exception as exc:  # pragma: no cover - defensive
+                            in_tx = getattr(session, "in_transaction", None)
+                            if callable(in_tx) and in_tx():
+                                await session.rollback()
+                            max_attempts = getattr(
+                                attempt.retry_state.retry_object.stop,
+                                "max_attempt_number",
+                                None,
+                            )
+                            if (
+                                max_attempts is None
+                                or attempt.retry_state.attempt_number < max_attempts
+                            ):
+                                logger.warning(
+                                    "persistence.%s.retry", operation_name, exc_info=exc
+                                )
+                            raise
+        except Exception:
+            logger.exception("persistence.%s.failed", operation_name)
+            raise
 
     async def save_interaction(
         self,
@@ -17,10 +69,10 @@ class PersistenceRepository:
         *,
         history_query: str | None = None,
         history_response: str | None = None,
-    ):
-        async with self._session_factory() as session:
-            try:
-                session.add(interaction)
+    ) -> None:
+        async def operation(session) -> None:
+            async with session.begin():
+                await session.merge(interaction)
                 if interaction.user_id and (interaction.message or history_query):
                     session.add(
                         ConversationHistory(
@@ -29,14 +81,26 @@ class PersistenceRepository:
                             response=history_response or interaction.response,
                         )
                     )
-                await session.commit()
-            except Exception:
-                logger.exception("Exception occurred while saving interaction")
-                await session.rollback()
-                raise
+
+        await self._execute_with_retry(operation, operation_name="save_interaction")
+
+    async def save_history_entry(
+        self, *, user_id: str, query: str, response: str
+    ) -> None:
+        async def operation(session) -> None:
+            async with session.begin():
+                session.add(
+                    ConversationHistory(
+                        user_id=user_id,
+                        query=query,
+                        response=response,
+                    )
+                )
+
+        await self._execute_with_retry(operation, operation_name="save_history_entry")
 
     async def get_history(self, user_id: str, limit: int = 10):
-        async with self._session_factory() as session:
+        async def operation(session):
             result = await session.execute(
                 select(ConversationHistory)
                 .where(ConversationHistory.user_id == user_id)
@@ -44,3 +108,5 @@ class PersistenceRepository:
                 .limit(limit)
             )
             return result.scalars().all()
+
+        return await self._execute_with_retry(operation, operation_name="get_history")


### PR DESCRIPTION
## Summary
- add retry-protected transaction helper to `PersistenceRepository` and expose a history-only persistence path
- hydrate the hippocampus cache from the durable store with optional write-through support to prevent data loss after restarts
- extend the synchronous session proxy used in tests to support transactional contexts and cover the new behaviour with an async test

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68da1a64a10883338c2b41ce22645c81

## Summary by Sourcery

Introduce robust retry logic for database operations in PersistenceRepository, extend Hippocampus with durable storage support and optional write-through, enhance session proxy with async transaction contexts, and cover persistence behavior with an integration test

New Features:
- Add retry-protected transaction helper in PersistenceRepository
- Add save_history_entry method to PersistenceRepository
- Enable optional write-through persistence and hydration from durable store in Hippocampus
- Extend init_db session proxy with async transaction support and in_transaction check

Enhancements:
- Refactor save_interaction and get_history to use centralized retry logic

Tests:
- Add async test to verify persistent history across Hippocampus instances

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional persistent conversation history that seamlessly hydrates across sessions/devices.
  * Configurable setting to persist new messages as they are stored.
* **Refactor**
  * Standardized all timestamps to UTC for consistent history timelines.
  * Enhanced data storage reliability with automatic retries on transient failures.
  * Improved async transaction handling for greater stability during save and load operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->