### PR TITLE
Expand failure coverage for core services

### DIFF
--- a/tests/test_evolution_engine.py
+++ b/tests/test_evolution_engine.py
@@ -1,4 +1,9 @@
+import os
+from types import SimpleNamespace
+
 import pytest
+
+os.environ.setdefault("SECRET_KEY", "test")
 
 from monGARS.core.evolution_engine import EvolutionEngine
 
@@ -26,3 +31,28 @@ async def test_safe_apply_failure(monkeypatch):
     monkeypatch.setattr(engine, "apply_optimizations", fail)
     result = await engine.safe_apply_optimizations()
     assert result is False
+
+
+@pytest.mark.asyncio
+async def test_apply_optimizations_clears_cache_on_memory_spike(monkeypatch):
+    engine = EvolutionEngine()
+
+    async def fake_stats():
+        return SimpleNamespace(cpu_usage=20.0, memory_usage=95.0, gpu_usage=None)
+
+    calls: dict[str, object] = {}
+
+    async def fake_clear() -> None:
+        calls["cleared"] = True
+
+    async def fake_scale(_delta: int) -> None:
+        calls.setdefault("scaled", True)
+
+    monkeypatch.setattr(engine.monitor, "get_system_stats", fake_stats)
+    monkeypatch.setattr(engine, "_clear_caches", fake_clear)
+    monkeypatch.setattr(engine, "_scale_workers", fake_scale)
+
+    await engine.apply_optimizations()
+
+    assert calls.get("cleared") is True
+    assert "scaled" not in calls

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import pytest
+from sqlalchemy.exc import OperationalError
+
+from monGARS.core.persistence import PersistenceRepository
+
+
+class _DummySession:
+    async def __aenter__(self) -> "_DummySession":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    def in_transaction(self) -> bool:
+        return False
+
+
+@pytest.mark.asyncio
+async def test_persistence_retries_and_surfaces_connection_failure():
+    attempts: list[int] = []
+
+    @asynccontextmanager
+    async def failing_session_factory():
+        yield _DummySession()
+
+    repo = PersistenceRepository(session_factory=failing_session_factory)
+
+    async def failing_operation(_session):
+        attempts.append(1)
+        raise OperationalError("SELECT 1", {}, RuntimeError("db down"))
+
+    with pytest.raises(OperationalError):
+        await repo._execute_with_retry(
+            failing_operation, operation_name="failing_operation"
+        )
+
+    assert len(attempts) == 3

--- a/tests/test_ray_service.py
+++ b/tests/test_ray_service.py
@@ -49,6 +49,18 @@ def test_ray_service_encode_prompt_error(monkeypatch):
         deployment._encode_prompt("prompt")
 
 
+def test_deploy_ray_service_raises_when_ray_missing(monkeypatch):
+    from modules import ray_service
+
+    monkeypatch.setattr(ray_service, "serve", None)
+    monkeypatch.setattr(ray_service, "ray", None)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        ray_service.deploy_ray_service()
+
+    assert "Ray Serve is not available" in str(excinfo.value)
+
+
 @pytest.mark.asyncio
 async def test_llm_integration_balances_ray_endpoints(monkeypatch):
     monkeypatch.setenv("SECRET_KEY", "test")


### PR DESCRIPTION
## Summary
- add regression coverage for Ray Serve deployment failures when dependencies are missing
- verify the persistence retry loop surfaces database connection failures after exhausting attempts
- ensure MNTP trainer and evolution engine handle training exceptions and memory spikes with the expected fallbacks

## Testing
- pytest tests/test_ray_service.py -k deploy_ray_service -q
- pytest tests/test_persistence.py -q
- pytest tests/test_mntp_trainer.py -k recovers_from_training_failure -q
- pytest tests/test_evolution_engine.py -k memory_spike -q

------
https://chatgpt.com/codex/tasks/task_e_68db259fb718833382543d77622b6aa2

## Summary by Sourcery

Expand failure coverage for core services by adding regression tests for Ray Serve deployment, persistence retry exhaustion, MNTP trainer fallback, and EvolutionEngine memory spike handling

Tests:
- Add test to verify Ray Serve deployment raises an error when Ray or Serve dependencies are missing
- Add test to confirm PersistenceRepository retries three times and surfaces a database connection failure afterwards
- Add test to ensure MNTPTrainer recovers from training exceptions by using a fallback and reporting status and details
- Add test to verify EvolutionEngine apply_optimizations clears caches on memory spikes without scaling workers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added coverage to ensure cache clearing behavior during high-memory conditions.
  - Verified trainer gracefully falls back and produces expected artifacts after a simulated training failure.
  - Confirmed persistence layer surfaces errors after configured retry attempts.
  - Ensured deployment reports a clear error when a required serving backend is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->