### PR TITLE
Enhance WebSocket manager resilience

### DIFF
--- a/monGARS/api/web_api.py
+++ b/monGARS/api/web_api.py
@@ -160,6 +160,7 @@ async def websocket_chat(websocket: WebSocket, token: str = Query(...)) -> None:
                     "timestamp": datetime.now(UTC).isoformat(),
                 }
             )
+        await ws_manager.flush_offline(user_id)
         while True:
             try:
                 await websocket.receive_text()

--- a/monGARS/api/ws_manager.py
+++ b/monGARS/api/ws_manager.py
@@ -1,39 +1,178 @@
+from __future__ import annotations
+
 import asyncio
-from typing import Any, Dict, Set
+import logging
+from collections import deque
+from datetime import UTC, datetime
+from typing import Any, Deque, Dict, List, Set
 
 from fastapi import WebSocket, WebSocketDisconnect
+
+logger = logging.getLogger(__name__)
 
 
 class WebSocketManager:
     """Manage WebSocket connections per user."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        heartbeat_interval: float = 30.0,
+        max_offline_messages: int = 100,
+    ) -> None:
         self.connections: Dict[str, Set[WebSocket]] = {}
         self._lock = asyncio.Lock()
+        self._heartbeat_interval = heartbeat_interval
+        self._max_offline_messages = max_offline_messages
+        self._heartbeat_tasks: Dict[WebSocket, asyncio.Task[None]] = {}
+        self._offline_queues: Dict[str, Deque[Dict[str, Any]]] = {}
 
     async def connect(self, user_id: str, ws: WebSocket) -> None:
         await ws.accept()
         async with self._lock:
             self.connections.setdefault(user_id, set()).add(ws)
+        heartbeat = asyncio.create_task(self._heartbeat(user_id, ws))
+        self._heartbeat_tasks[ws] = heartbeat
 
     async def disconnect(self, user_id: str, ws: WebSocket) -> None:
+        await self._remove_connection(user_id, ws)
+        task = self._heartbeat_tasks.pop(ws, None)
+        current = asyncio.current_task()
+        if task and task is not current:
+            task.cancel()
+        try:
+            await ws.close()
+        except RuntimeError:
+            # The WebSocket might already be closed by the caller or the client.
+            pass
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.debug("Failed to close websocket", exc_info=exc)
+
+    async def broadcast(self, user_id: str, message: Dict[str, Any]) -> None:
+        await self._send_message(user_id, message, queue_if_offline=True)
+
+    async def flush_offline(self, user_id: str) -> None:
+        await self._flush_offline_queue(user_id)
+
+    def reset(self) -> None:
+        for task in self._heartbeat_tasks.values():
+            task.cancel()
+        self._heartbeat_tasks.clear()
+        self.connections.clear()
+        self._offline_queues.clear()
+
+    async def _remove_connection(self, user_id: str, ws: WebSocket) -> None:
         async with self._lock:
             conns = self.connections.get(user_id)
-            if conns:
-                conns.discard(ws)
+            if conns and ws in conns:
+                conns.remove(ws)
                 if not conns:
                     self.connections.pop(user_id, None)
 
-    async def broadcast(self, user_id: str, message: Dict[str, Any]) -> None:
+    async def _heartbeat(self, user_id: str, ws: WebSocket) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self._heartbeat_interval)
+                try:
+                    await ws.send_json(
+                        {
+                            "type": "ping",
+                            "timestamp": datetime.now(UTC).isoformat(),
+                        }
+                    )
+                except WebSocketDisconnect:
+                    logger.info(
+                        "WebSocket disconnected during heartbeat",
+                        extra={"user_id": user_id},
+                    )
+                    break
+                except Exception as exc:
+                    logger.warning(
+                        "Heartbeat ping failed; scheduling disconnect",
+                        exc_info=exc,
+                        extra={"user_id": user_id},
+                    )
+                    break
+        except asyncio.CancelledError:
+            logger.debug(
+                "Heartbeat cancelled for websocket", extra={"user_id": user_id}
+            )
+            raise
+        finally:
+            self._heartbeat_tasks.pop(ws, None)
+            await self._remove_connection(user_id, ws)
+
+    async def _send_message(
+        self,
+        user_id: str,
+        message: Dict[str, Any],
+        *,
+        queue_if_offline: bool,
+    ) -> bool:
         async with self._lock:
-            conns = list(self.connections.get(user_id, set()))
-        to_remove: Set[WebSocket] = set()
+            conns: List[WebSocket] = list(self.connections.get(user_id, set()))
+        if not conns:
+            if queue_if_offline:
+                await self._queue_message(user_id, message)
+            return False
+
+        failures: Set[WebSocket] = set()
+        delivered = False
         for ws in conns:
             try:
                 await ws.send_json(message)
+                delivered = True
             except WebSocketDisconnect:
-                to_remove.add(ws)
-            except Exception:
-                to_remove.add(ws)
-        for ws in to_remove:
+                failures.add(ws)
+            except Exception as exc:
+                failures.add(ws)
+                logger.warning(
+                    "Failed to deliver websocket message",
+                    exc_info=exc,
+                    extra={"user_id": user_id},
+                )
+
+        for ws in failures:
             await self.disconnect(user_id, ws)
+
+        if not delivered and queue_if_offline:
+            await self._queue_message(user_id, message)
+
+        return delivered
+
+    async def _queue_message(
+        self, user_id: str, message: Dict[str, Any], *, to_left: bool = False
+    ) -> None:
+        async with self._lock:
+            queue = self._offline_queues.setdefault(
+                user_id, deque(maxlen=self._max_offline_messages)
+            )
+            if len(queue) >= self._max_offline_messages:
+                dropped = queue.popleft()
+                logger.warning(
+                    "Dropping oldest queued message due to capacity",
+                    extra={"user_id": user_id, "dropped": dropped},
+                )
+            if to_left:
+                queue.appendleft(dict(message))
+            else:
+                queue.append(dict(message))
+
+    async def _flush_offline_queue(self, user_id: str) -> None:
+        queued_messages = await self._drain_offline_queue(user_id)
+        if not queued_messages:
+            return
+        for message in queued_messages:
+            delivered = await self._send_message(
+                user_id, message, queue_if_offline=False
+            )
+            if not delivered:
+                await self._queue_message(user_id, message, to_left=True)
+                break
+
+    async def _drain_offline_queue(self, user_id: str) -> List[Dict[str, Any]]:
+        async with self._lock:
+            queue = self._offline_queues.pop(user_id, None)
+            if not queue:
+                return []
+            return list(queue)

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -15,6 +15,7 @@ from monGARS.core.conversation import ConversationalModule
 def client(monkeypatch):
     hippocampus._memory.clear()
     hippocampus._locks.clear()
+    ws_manager.reset()
 
     async def fake_generate_response(
         self, user_id, query, session_id=None, image_data=None
@@ -32,7 +33,7 @@ def client(monkeypatch):
         client.close()
         hippocampus._memory.clear()
         hippocampus._locks.clear()
-        ws_manager.connections.clear()
+        ws_manager.reset()
 
 
 @pytest.mark.asyncio

--- a/tests/test_ws_manager.py
+++ b/tests/test_ws_manager.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List
+
+import pytest
+from fastapi import WebSocketDisconnect
+
+from monGARS.api.ws_manager import WebSocketManager
+
+
+class DummyWebSocket:
+    def __init__(
+        self,
+        *,
+        fail_after: int | None = None,
+        fail_with_disconnect: bool = False,
+    ) -> None:
+        self.accepted = False
+        self.closed = False
+        self.sent: List[Dict[str, Any]] = []
+        self.fail_after = fail_after
+        self.fail_with_disconnect = fail_with_disconnect
+        self.close_code: int | None = None
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def send_json(self, message: Dict[str, Any]) -> None:
+        if self.fail_after is not None and len(self.sent) >= self.fail_after:
+            if self.fail_with_disconnect:
+                raise WebSocketDisconnect()
+            raise RuntimeError("send failure")
+        self.sent.append(message)
+
+    async def close(self, code: int | None = None) -> None:
+        self.closed = True
+        self.close_code = code
+
+
+@pytest.mark.asyncio
+async def test_broadcast_queue_and_replay_on_reconnect() -> None:
+    manager = WebSocketManager(heartbeat_interval=0.1, max_offline_messages=10)
+
+    message = {"payload": "data"}
+    await manager.broadcast("user", message)
+
+    reconnect_ws = DummyWebSocket()
+    await manager.connect("user", reconnect_ws)
+    await manager.flush_offline("user")
+
+    assert reconnect_ws.sent[0]["payload"] == "data"
+
+    await manager.disconnect("user", reconnect_ws)
+
+
+@pytest.mark.asyncio
+async def test_disconnect_and_queue_on_subsequent_broadcast() -> None:
+    manager = WebSocketManager(heartbeat_interval=0.1)
+    active_ws = DummyWebSocket()
+    await manager.connect("user", active_ws)
+
+    await manager.broadcast("user", {"payload": "online"})
+    assert any(msg["payload"] == "online" for msg in active_ws.sent)
+
+    await manager.disconnect("user", active_ws)
+
+    await manager.broadcast("user", {"payload": "queued"})
+
+    new_ws = DummyWebSocket()
+    await manager.connect("user", new_ws)
+    await manager.flush_offline("user")
+    assert any(msg["payload"] == "queued" for msg in new_ws.sent)
+
+    await manager.disconnect("user", new_ws)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_detects_stale_connection() -> None:
+    manager = WebSocketManager(heartbeat_interval=0.05)
+    failing_ws = DummyWebSocket(fail_after=0)
+
+    await manager.connect("user", failing_ws)
+
+    await asyncio.sleep(0.15)
+
+    async with manager._lock:  # noqa: SLF001 - accessing for assertion in tests
+        assert "user" not in manager.connections or not manager.connections["user"]


### PR DESCRIPTION
## Summary
- add heartbeat-driven connection supervision and offline message queues to `WebSocketManager`
- expose helpers for flushing/resetting state and flush queued payloads during websocket handshakes
- cover the new behaviour with websocket manager tests and update existing websocket fixtures

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68db27e0d07c83339c7e7c2bd6ec5913