### PR TITLE
Add UI event model and in-memory/Redis event bus

### DIFF
--- a/monGARS/config.py
+++ b/monGARS/config.py
@@ -131,6 +131,11 @@ class Settings(BaseSettings):
         default=None,
         description="Optional override for the Redis connection string, e.g. redis://localhost:6379/0.",
     )
+    EVENTBUS_MEMORY_QUEUE_MAXSIZE: int = Field(
+        default=1000,
+        ge=1,
+        description="Maximum number of events buffered per in-memory subscriber before backpressure is applied.",
+    )
 
     VAULT_URL: str = Field(default="")
     VAULT_TOKEN: str = Field(default="")

--- a/tests/test_ui_events.py
+++ b/tests/test_ui_events.py
@@ -15,8 +15,62 @@ async def test_in_memory_bus_publish_and_receive() -> None:
     await bus.publish(ev)
 
     received = await asyncio.wait_for(subscriber.__anext__(), timeout=1)
+    await subscriber.aclose()
 
     assert received == ev
+
+
+@pytest.mark.asyncio
+async def test_in_memory_bus_broadcasts_to_all_subscribers() -> None:
+    bus = EventBus()
+    ev = make_event("ai_model.response_chunk", "user-2", {"text": "bonjour"})
+
+    first = bus.subscribe()
+    second = bus.subscribe()
+
+    await bus.publish(ev)
+
+    first_result = await asyncio.wait_for(first.__anext__(), timeout=1)
+    second_result = await asyncio.wait_for(second.__anext__(), timeout=1)
+
+    await first.aclose()
+    await second.aclose()
+
+    assert first_result == ev
+    assert second_result == ev
+
+
+@pytest.mark.asyncio
+async def test_in_memory_bus_applies_backpressure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from monGARS.core import ui_events
+
+    custom_settings = ui_events.settings.model_copy(
+        update={"EVENTBUS_MEMORY_QUEUE_MAXSIZE": 1}
+    )
+    monkeypatch.setattr(ui_events, "settings", custom_settings)
+
+    bus = EventBus()
+    subscriber = bus.subscribe()
+
+    first = make_event("demo.first", None, {})
+    second = make_event("demo.second", None, {})
+
+    await bus.publish(first)
+
+    publish_task = asyncio.create_task(bus.publish(second))
+    await asyncio.sleep(0)
+
+    assert not publish_task.done()
+
+    await asyncio.wait_for(subscriber.__anext__(), timeout=1)
+    await asyncio.sleep(0)
+
+    assert publish_task.done()
+    await publish_task
+
+    await subscriber.aclose()
 
 
 def test_make_event_populates_fields() -> None:


### PR DESCRIPTION
## Summary
- introduce a typed UI event model and pluggable event bus with optional Redis backend
- expose a shared event bus singleton and helper for generating events
- cover the event bus behaviour with asynchronous unit tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68db4040ad8483338e29cf275605f150

## Summary by Sourcery

Introduce a typed UI event model and a pluggable event bus with optional Redis backend to enable in-memory or Redis-backed publish/subscribe for UI streaming.

New Features:
- Implement Event dataclass with JSON serialization
- Add EventBus class supporting in-memory queue and optional Redis pub/sub
- Provide a process-wide EventBus singleton via event_bus()
- Add make_event helper to create standardized Event instances

Tests:
- Add async tests for in-memory publish/subscribe behavior
- Add test for make_event field population
- Add test for event_bus singleton reset behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time UI event streaming with standardized events, in-memory delivery, and automatic upgrade to Redis pub/sub when available.
  * Broadcasting to multiple subscribers and graceful handling of subscriber queues.

* **Configuration**
  * New setting to control per-subscriber in-memory queue size (enables backpressure tuning).

* **Tests**
  * Added tests for broadcast behavior, backpressure, event fields/IDs, publish/subscribe flow, and singleton behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->