### PR TITLE
Add WebSocket ticket issuance endpoint

### DIFF
--- a/monGARS/api/authentication.py
+++ b/monGARS/api/authentication.py
@@ -1,11 +1,23 @@
-from fastapi import Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
+from itsdangerous import BadSignature, SignatureExpired, TimestampSigner
+from pydantic import BaseModel
 
 from monGARS.config import get_settings
 from monGARS.core.security import SecurityManager
 
 settings = get_settings()
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+router = APIRouter(prefix="/api/v1/auth", tags=["auth"])
+
+
+class WSTicketResponse(BaseModel):
+    ticket: str
+    ttl: int
+
+
+def _ticket_signer() -> TimestampSigner:
+    return TimestampSigner(settings.SECRET_KEY)
 
 
 def get_current_user(token: str = Depends(oauth2_scheme)) -> dict:
@@ -26,3 +38,26 @@ def get_current_admin_user(current_user: dict = Depends(get_current_user)) -> di
             status_code=status.HTTP_403_FORBIDDEN, detail="Admin required"
         )
     return current_user
+
+
+@router.post("/ws/ticket", response_model=WSTicketResponse)
+async def issue_ws_ticket(
+    current: dict = Depends(get_current_user),
+) -> WSTicketResponse:
+    uid = current.get("sub")
+    if uid is None:
+        raise HTTPException(status_code=401, detail="Invalid token payload")
+    signer = _ticket_signer()
+    token = signer.sign(uid.encode()).decode()
+    return WSTicketResponse(ticket=token, ttl=settings.WS_TICKET_TTL_SECONDS)
+
+
+def verify_ws_ticket(token: str) -> str:
+    signer = _ticket_signer()
+    try:
+        uid = signer.unsign(token, max_age=settings.WS_TICKET_TTL_SECONDS).decode()
+        return uid
+    except SignatureExpired as exc:  # pragma: no cover - simple pass-through
+        raise HTTPException(status_code=401, detail="Ticket expired") from exc
+    except BadSignature as exc:  # pragma: no cover - simple pass-through
+        raise HTTPException(status_code=401, detail="Invalid ticket") from exc

--- a/monGARS/api/web_api.py
+++ b/monGARS/api/web_api.py
@@ -16,7 +16,11 @@ from fastapi import (
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel, HttpUrl, field_validator
 
-from monGARS.api.authentication import get_current_admin_user, get_current_user
+from monGARS.api.authentication import (
+    get_current_admin_user,
+    get_current_user,
+)
+from monGARS.api.authentication import router as auth_router
 from monGARS.api.dependencies import (
     get_adaptive_response_generator,
     get_hippocampus,
@@ -31,6 +35,7 @@ from monGARS.core.security import SecurityManager, validate_user_input
 from .ws_manager import WebSocketManager
 
 app = FastAPI(title="monGARS API")
+app.include_router(auth_router)
 sec_manager = SecurityManager()
 _shared_personality = get_personality_engine()
 _shared_dynamic = get_adaptive_response_generator(_shared_personality)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ python-multipart>=0.0.20
 GPUtil>=1.4.0
 httpx>=0.28.1
 hvac>=2.3.0
+itsdangerous>=2.2.0
 ollama>=0.5.1
 opentelemetry-sdk>=1.35.0
 opentelemetry-exporter-otlp>=1.35.0

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         "GPUtil>=1.4.0",
         "httpx>=0.28.1",
         "hvac>=2.3.0",
+        "itsdangerous>=2.2.0",
         "ollama>=0.5.1",
         "opentelemetry-sdk>=1.35.0",
         "opentelemetry-exporter-otlp>=1.35.0",


### PR DESCRIPTION
## Summary
- add an authentication router that issues short-lived WebSocket tickets and expose a verification helper
- include the auth router in the FastAPI app factory
- add the itsdangerous dependency for ticket signing

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68db50bfc3308333bb2389c4ef7b27eb