### PR TITLE
Add event-driven WebSocket manager with origin validation

### DIFF
--- a/monGARS/api/ws_manager.py
+++ b/monGARS/api/ws_manager.py
@@ -1,184 +1,176 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
-from collections import deque
-from datetime import datetime, timezone
-from typing import Any, Deque, Dict, List, Set
+from typing import Dict, Set
 
-from fastapi import WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 
-logger = logging.getLogger(__name__)
+from monGARS.api.dependencies import get_hippocampus
+from monGARS.api.ws_ticket import verify_ws_ticket
+from monGARS.config import get_settings
+from monGARS.core.ui_events import Event, event_bus, make_event
+
+log = logging.getLogger(__name__)
+settings = get_settings()
 
 
 class WebSocketManager:
-    """Manage WebSocket connections per user."""
+    """Manage active WebSocket connections and stream UI events."""
 
-    def __init__(
-        self,
-        *,
-        heartbeat_interval: float = 30.0,
-        max_offline_messages: int = 100,
-    ) -> None:
-        if heartbeat_interval <= 0:
-            raise ValueError("heartbeat_interval must be positive")
-        if max_offline_messages <= 0:
-            raise ValueError("max_offline_messages must be positive")
-        self.connections: Dict[str, Set[WebSocket]] = {}
+    def __init__(self) -> None:
+        self.active: Dict[str, Set[WebSocket]] = {}
+        self._reverse: Dict[WebSocket, str] = {}
         self._lock = asyncio.Lock()
-        self._heartbeat_interval = heartbeat_interval
-        self._max_offline_messages = max_offline_messages
-        self._heartbeat_tasks: Dict[WebSocket, asyncio.Task[None]] = {}
-        self._offline_queues: Dict[str, Deque[Dict[str, Any]]] = {}
+        self._task: asyncio.Task[None] | None = None
 
-    async def connect(self, user_id: str, ws: WebSocket) -> None:
+    @property
+    def connections(self) -> Dict[str, Set[WebSocket]]:
+        """Backwards compatible alias for tests importing ``connections``."""
+
+        return self.active
+
+    async def connect(self, ws: WebSocket, user_id: str) -> None:
         await ws.accept()
         async with self._lock:
-            self.connections.setdefault(user_id, set()).add(ws)
-        heartbeat = asyncio.create_task(self._heartbeat(user_id, ws))
-        self._heartbeat_tasks[ws] = heartbeat
+            self.active.setdefault(user_id, set()).add(ws)
+            self._reverse[ws] = user_id
 
-    async def disconnect(self, user_id: str, ws: WebSocket) -> None:
-        await self._remove_connection(user_id, ws)
-        task = self._heartbeat_tasks.pop(ws, None)
-        current = asyncio.current_task()
-        if task and task is not current:
-            task.cancel()
-            await asyncio.gather(task, return_exceptions=True)
-        try:
+    async def disconnect(self, ws: WebSocket, user_id: str) -> None:
+        async with self._lock:
+            sockets = self.active.get(user_id)
+            if sockets and ws in sockets:
+                sockets.remove(ws)
+                if not sockets:
+                    self.active.pop(user_id, None)
+            self._reverse.pop(ws, None)
+        with contextlib.suppress(Exception):
             await ws.close()
-        except RuntimeError:
-            # The WebSocket might already be closed by the caller or the client.
-            pass
-        except Exception as exc:  # pragma: no cover - defensive logging
-            logger.debug("Failed to close websocket", exc_info=exc)
 
-    async def broadcast(self, user_id: str, message: Dict[str, Any]) -> None:
-        await self._send_message(user_id, message, queue_if_offline=True)
+    async def send_event(self, ev: Event) -> None:
+        async with self._lock:
+            if ev.user is None:
+                targets = list(self._reverse.keys())
+            else:
+                targets = list(self.active.get(ev.user, set()))
 
-    async def flush_offline(self, user_id: str) -> None:
-        await self._flush_offline_queue(user_id)
+        if not targets:
+            return
+
+        payload = ev.to_json()
+        stale: list[WebSocket] = []
+        for ws in targets:
+            try:
+                await ws.send_text(payload)
+            except Exception:
+                stale.append(ws)
+
+        if not stale:
+            return
+
+        async with self._lock:
+            for ws in stale:
+                uid = self._reverse.pop(ws, None)
+                if uid is None:
+                    continue
+                sockets = self.active.get(uid)
+                if sockets and ws in sockets:
+                    sockets.remove(ws)
+                    if not sockets:
+                        self.active.pop(uid, None)
+        for ws in stale:
+            with contextlib.suppress(Exception):
+                await ws.close()
+
+    def ensure_background_fanout(self) -> None:
+        if self._task and not self._task.done():
+            return
+
+        async def _run() -> None:
+            try:
+                async for ev in event_bus().subscribe():
+                    await self.send_event(ev)
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # pragma: no cover - defensive logging
+                log.exception("ws_manager.background_failed")
+            finally:
+                self._task = None
+
+        self._task = asyncio.create_task(_run())
 
     async def reset(self) -> None:
-        tasks = list(self._heartbeat_tasks.values())
-        for task in tasks:
+        task = self._task
+        if task:
             task.cancel()
-        if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
-        self._heartbeat_tasks.clear()
-        self.connections.clear()
-        self._offline_queues.clear()
-
-    async def _remove_connection(self, user_id: str, ws: WebSocket) -> None:
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
         async with self._lock:
-            conns = self.connections.get(user_id)
-            if conns and ws in conns:
-                conns.remove(ws)
-                if not conns:
-                    self.connections.pop(user_id, None)
+            sockets = list(self._reverse.keys())
+            self.active.clear()
+            self._reverse.clear()
+        for ws in sockets:
+            with contextlib.suppress(Exception):
+                await ws.close()
 
-    async def _heartbeat(self, user_id: str, ws: WebSocket) -> None:
-        try:
-            while True:
-                await asyncio.sleep(self._heartbeat_interval)
-                try:
-                    await ws.send_json(
-                        {
-                            "type": "ping",
-                            "timestamp": datetime.now(timezone.utc).isoformat(),
-                        }
-                    )
-                except WebSocketDisconnect:
-                    logger.info(
-                        "WebSocket disconnected during heartbeat",
-                        extra={"user_id": user_id},
-                    )
-                    break
-                except Exception as exc:
-                    logger.warning(
-                        "Heartbeat ping failed; scheduling disconnect",
-                        exc_info=exc,
-                        extra={"user_id": user_id},
-                    )
-                    break
-        except asyncio.CancelledError:
-            logger.debug(
-                "Heartbeat cancelled for websocket", extra={"user_id": user_id}
-            )
-            raise
-        finally:
-            self._heartbeat_tasks.pop(ws, None)
-            await self._remove_connection(user_id, ws)
 
-    async def _send_message(
-        self,
-        user_id: str,
-        message: Dict[str, Any],
-        *,
-        queue_if_offline: bool,
-    ) -> bool:
-        async with self._lock:
-            conns: List[WebSocket] = list(self.connections.get(user_id, set()))
-        if not conns:
-            if queue_if_offline:
-                await self._queue_message(user_id, message)
-            return False
+ws_manager = WebSocketManager()
+router = APIRouter()
 
-        failures: Set[WebSocket] = set()
-        delivered = False
-        for ws in conns:
-            try:
-                await ws.send_json(message)
-                delivered = True
-            except WebSocketDisconnect:
-                failures.add(ws)
-            except Exception as exc:
-                failures.add(ws)
-                logger.warning(
-                    "Failed to deliver websocket message",
-                    exc_info=exc,
-                    extra={"user_id": user_id},
-                )
 
-        for ws in failures:
-            await self.disconnect(user_id, ws)
+@router.websocket("/ws/chat/")
+async def ws_chat(ws: WebSocket, ticket: str = Query(..., alias="t")) -> None:
+    allowed = {str(origin) for origin in settings.WS_ALLOWED_ORIGINS}
+    origin = ws.headers.get("origin", "")
+    if allowed and origin not in allowed:
+        await ws.close(code=4403)
+        return
 
-        if not delivered and queue_if_offline:
-            await self._queue_message(user_id, message)
+    if not settings.WS_ENABLE_EVENTS:
+        await ws.close(code=4403)
+        return
 
-        return delivered
+    try:
+        user_id = verify_ws_ticket(ticket)
+    except Exception:
+        await ws.close(code=4401)
+        return
 
-    async def _queue_message(self, user_id: str, message: Dict[str, Any]) -> None:
-        payload = dict(message)
-        async with self._lock:
-            queue = self._offline_queues.setdefault(
-                user_id, deque(maxlen=self._max_offline_messages)
-            )
-            dropped = queue[0] if len(queue) == queue.maxlen else None
-            queue.append(payload)
-        if dropped is not None:
-            logger.warning(
-                "Dropping oldest queued message due to capacity",
-                extra={"user_id": user_id, "dropped": dropped},
-            )
+    await ws_manager.connect(ws, user_id)
+    ws_manager.ensure_background_fanout()
 
-    async def _flush_offline_queue(self, user_id: str) -> None:
+    connected_event = make_event(
+        "ws.connected",
+        user_id,
+        {"origin": origin},
+    )
+    await ws.send_text(connected_event.to_json())
+
+    try:
+        store = get_hippocampus()
+        history = await store.history(user_id, limit=10)
+        payload = [
+            {
+                "query": item.query,
+                "response": item.response,
+                "timestamp": item.timestamp.isoformat(),
+            }
+            for item in history
+        ]
+        snapshot = make_event(
+            "history.snapshot",
+            user_id,
+            {"items": payload},
+        )
+        await ws.send_text(snapshot.to_json())
+    except Exception:  # pragma: no cover - defensive logging
+        log.exception("ws_manager.history_failed", extra={"user_id": user_id})
+
+    try:
         while True:
-            async with self._lock:
-                queue = self._offline_queues.get(user_id)
-                if not queue:
-                    return
-                message = dict(queue[0])
-            delivered = await self._send_message(
-                user_id, message, queue_if_offline=False
-            )
-            if not delivered:
-                return
-            async with self._lock:
-                queue = self._offline_queues.get(user_id)
-                if not queue:
-                    continue
-                if queue:
-                    queue.popleft()
-                if not queue:
-                    self._offline_queues.pop(user_id, None)
+            await ws.receive_text()
+    except WebSocketDisconnect:
+        pass
+    finally:
+        await ws_manager.disconnect(ws, user_id)

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 
 from monGARS.api.dependencies import hippocampus
 from monGARS.api.web_api import app, ws_manager
+from monGARS.config import get_settings
 from monGARS.core.conversation import ConversationalModule
 
 
@@ -37,17 +38,41 @@ async def client(monkeypatch):
         await ws_manager.reset()
 
 
+def _issue_ws_ticket(client: TestClient, token: str) -> str:
+    response = client.post(
+        "/api/v1/auth/ws/ticket",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    response.raise_for_status()
+    return response.json()["ticket"]
+
+
+def _connect_ws(client: TestClient, ticket: str):
+    settings = get_settings()
+    origin = str(settings.WS_ALLOWED_ORIGINS[0]) if settings.WS_ALLOWED_ORIGINS else ""
+    return client.websocket_connect(
+        f"/ws/chat/?t={ticket}",
+        headers={"origin": origin},
+    )
+
+
 @pytest.mark.asyncio
 async def test_websocket_sends_history_and_updates(client):
     await hippocampus.store("u1", "hello", "hi")
     token = client.post("/token", data={"username": "u1", "password": "x"}).json()[
         "access_token"
     ]
+    ticket = _issue_ws_ticket(client, token)
 
-    with client.websocket_connect(f"/ws/chat/?token={token}") as ws:
-        first = ws.receive_json()
-        assert first["query"] == "hello"
-        assert first["response"] == "hi"
+    with _connect_ws(client, ticket) as ws:
+        connected = ws.receive_json()
+        assert connected["type"] == "ws.connected"
+
+        snapshot = ws.receive_json()
+        assert snapshot["type"] == "history.snapshot"
+        items = snapshot["data"]["items"]
+        assert items[0]["query"] == "hello"
+        assert items[0]["response"] == "hi"
 
         client.post(
             "/api/v1/conversation/chat",
@@ -55,8 +80,9 @@ async def test_websocket_sends_history_and_updates(client):
             headers={"Authorization": f"Bearer {token}"},
         )
         second = ws.receive_json()
-        assert second["query"] == "new"
-        assert second["response"] == "resp"
+        assert second["type"] == "chat.message"
+        assert second["data"]["query"] == "new"
+        assert second["data"]["response"] == "resp"
 
 
 @pytest.mark.asyncio
@@ -64,19 +90,23 @@ async def test_websocket_multiple_clients_receive_updates(client):
     token = client.post("/token", data={"username": "u1", "password": "x"}).json()[
         "access_token"
     ]
+    ticket = _issue_ws_ticket(client, token)
+    ticket_two = _issue_ws_ticket(client, token)
     await hippocampus.store("u1", "old", "resp")
 
-    with client.websocket_connect(f"/ws/chat/?token={token}") as ws1:
+    with _connect_ws(client, ticket) as ws1:
         ws1.receive_json()
-        with client.websocket_connect(f"/ws/chat/?token={token}") as ws2:
+        ws1.receive_json()
+        with _connect_ws(client, ticket_two) as ws2:
+            ws2.receive_json()
             ws2.receive_json()
             client.post(
                 "/api/v1/conversation/chat",
                 json={"message": "m"},
                 headers={"Authorization": f"Bearer {token}"},
             )
-            assert ws1.receive_json()["query"] == "m"
-            assert ws2.receive_json()["query"] == "m"
+            assert ws1.receive_json()["data"]["query"] == "m"
+            assert ws2.receive_json()["data"]["query"] == "m"
 
 
 @pytest.mark.asyncio
@@ -84,8 +114,10 @@ async def test_websocket_disconnect_removes_connection(client):
     token = client.post("/token", data={"username": "u1", "password": "x"}).json()[
         "access_token"
     ]
+    ticket = _issue_ws_ticket(client, token)
 
-    with client.websocket_connect(f"/ws/chat/?token={token}") as ws:
+    with _connect_ws(client, ticket) as ws:
+        ws.receive_json()
         ws.receive_json()
         assert ws_manager.connections
     assert not ws_manager.connections


### PR DESCRIPTION
## Summary
- replace the websocket manager with an event-bus powered implementation that validates origin headers and tickets, replays history, and cleans up failed sockets
- mount the websocket router on the FastAPI app and publish typed chat events via the shared event bus
- refresh websocket unit tests to use tickets, typed events, and cover background fan-out behaviour

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68db55365c188333be50c07d4dee1c55

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/monGARS/83)
<!-- GitContextEnd -->