### PR TITLE
Add WebSocket security hardening defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ pytest
 
 Code style is enforced using `black` and `isort` as outlined in `AGENTS.md`.
 
+## Security Hardening Quick Wins
+
+- **Restrict WebSocket origins.** Set the `WS_ALLOWED_ORIGINS` environment variable
+  to the exact frontend origins that should open WebSocket sessions
+  (comma-separated or JSON list), for example
+  `WS_ALLOWED_ORIGINS="https://app.example.com,https://admin.example.com"`.
+- **Terminate TLS at the edge.** Serve `wss://` traffic through your ingress
+  controller (Caddy, Nginx, Traefik, etc.) so certificates and TLS negotiation
+  stay outside of the application container.
+- **Apply rate limiting.** When a reverse proxy limit is not available, enable the
+  built-in per-user token bucket by setting
+  `WS_RATE_LIMIT_MAX_TOKENS` and `WS_RATE_LIMIT_REFILL_SECONDS` to throttle event
+  fan-out directly in `ws_manager.py`.
+
 ## Deployment
 
 Production deployments can be containerised via the provided `Dockerfile`. Kubernetes manifests live in `k8s/` for cluster environments. Adjust resource limits and RBAC rules as required for your infrastructure.

--- a/monGARS/api/ws_manager.py
+++ b/monGARS/api/ws_manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import time
 from typing import Dict, Set
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
@@ -16,6 +17,31 @@ log = logging.getLogger(__name__)
 settings = get_settings()
 
 
+class _TokenBucket:
+    """Token bucket used to throttle per-user WebSocket fan-out."""
+
+    __slots__ = ("capacity", "refill_seconds", "tokens", "updated_at")
+
+    def __init__(self, *, capacity: int, refill_seconds: float) -> None:
+        self.capacity = capacity
+        self.refill_seconds = refill_seconds
+        self.tokens = float(capacity)
+        self.updated_at = time.monotonic()
+
+    def consume(self, cost: float = 1.0) -> bool:
+        now = time.monotonic()
+        elapsed = now - self.updated_at
+        if elapsed > 0 and self.refill_seconds > 0:
+            refill = elapsed / self.refill_seconds
+            if refill > 0:
+                self.tokens = min(float(self.capacity), self.tokens + refill)
+        self.updated_at = now
+        if self.tokens >= cost:
+            self.tokens -= cost
+            return True
+        return False
+
+
 class WebSocketManager:
     """Manage active WebSocket connections and stream UI events."""
 
@@ -24,6 +50,24 @@ class WebSocketManager:
         self._reverse: Dict[WebSocket, str] = {}
         self._lock = asyncio.Lock()
         self._task: asyncio.Task[None] | None = None
+        self._buckets: Dict[str, "_TokenBucket"] = {}
+
+    @staticmethod
+    def _rate_limit_enabled() -> bool:
+        return (
+            settings.WS_RATE_LIMIT_MAX_TOKENS > 0
+            and settings.WS_RATE_LIMIT_REFILL_SECONDS > 0
+        )
+
+    def _bucket_for(self, user_id: str) -> "_TokenBucket":
+        bucket = self._buckets.get(user_id)
+        if bucket is None:
+            bucket = _TokenBucket(
+                capacity=settings.WS_RATE_LIMIT_MAX_TOKENS,
+                refill_seconds=settings.WS_RATE_LIMIT_REFILL_SECONDS,
+            )
+            self._buckets[user_id] = bucket
+        return bucket
 
     @property
     def connections(self) -> Dict[str, Set[WebSocket]]:
@@ -44,16 +88,42 @@ class WebSocketManager:
                 sockets.remove(ws)
                 if not sockets:
                     self.active.pop(user_id, None)
+                    self._buckets.pop(user_id, None)
             self._reverse.pop(ws, None)
         with contextlib.suppress(Exception):
             await ws.close()
 
     async def send_event(self, ev: Event) -> None:
+        rate_limited = self._rate_limit_enabled()
         async with self._lock:
             if ev.user is None:
-                targets = list(self._reverse.keys())
+                raw_targets = [
+                    (ws, self._reverse.get(ws)) for ws in list(self._reverse.keys())
+                ]
             else:
-                targets = list(self.active.get(ev.user, set()))
+                raw_targets = [
+                    (ws, ev.user) for ws in list(self.active.get(ev.user, set()))
+                ]
+
+            if not raw_targets:
+                targets: list[WebSocket] = []
+            elif not rate_limited:
+                targets = [ws for ws, _ in raw_targets]
+            else:
+                permitted: list[WebSocket] = []
+                for ws, user_id in raw_targets:
+                    if not user_id:
+                        permitted.append(ws)
+                        continue
+                    bucket = self._bucket_for(user_id)
+                    if bucket.consume():
+                        permitted.append(ws)
+                    else:
+                        log.warning(
+                            "ws_manager.rate_limited",
+                            extra={"user_id": user_id, "event_type": ev.type},
+                        )
+                targets = permitted
 
         if not targets:
             return
@@ -110,6 +180,7 @@ class WebSocketManager:
             sockets = list(self._reverse.keys())
             self.active.clear()
             self._reverse.clear()
+            self._buckets.clear()
         for ws in sockets:
             with contextlib.suppress(Exception):
                 await ws.close()


### PR DESCRIPTION
## Summary
- allow WS_ALLOWED_ORIGINS to be configured via comma-separated environment values and document the deployment guidance
- introduce optional per-user WebSocket token bucket throttling with cleanup handling
- add a regression test covering throttled fan-out behaviour

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68db5eea53d883339518bcdca81091a8