### PR TITLE
Wire chat UI to websocket event stream

### DIFF
--- a/webapp/chat/templates/chat/index.html
+++ b/webapp/chat/templates/chat/index.html
@@ -18,22 +18,34 @@
   </nav>
   <div class="container mt-4">
     <div class="row">
-      <div class="col-md-8 offset-md-2">
-        <div class="d-flex justify-content-between mb-2">
-          <h4>Historique du Chat</h4>
-          <span id="status-indicator">Connecting...</span>
+      <div class="col-lg-8 offset-lg-2">
+        <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+          <h4 class="mb-0">Historique du Chat</h4>
+          <span id="ws-status" class="badge ws-badge offline" aria-live="polite">Hors ligne</span>
         </div>
-        <div id="chat-box" class="mb-3"></div>
-        <form id="chat-form">
-          <div class="input-group">
-            <input type="text" id="message-input" class="form-control" placeholder="Entrez votre message..." required>
-            <button class="btn btn-primary" type="submit">Envoyer</button>
+        <section id="connection" class="visually-hidden" aria-live="polite"></section>
+        <main id="chat" class="card shadow-sm">
+          <div class="card-body p-0">
+            <div id="transcript" class="chat-transcript" aria-live="polite" aria-busy="false"></div>
+            <div id="error-alert" class="alert alert-danger m-3 d-none alert-dismissible fade show" role="alert">
+              <span id="error-message"></span>
+              <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
+            </div>
+            <aside id="actions" class="chat-actions px-3 pb-3">
+              <div class="chat-actions-row" id="quick-actions" role="list">
+                <button role="listitem" class="qa btn btn-outline-secondary" data-action="summarize">Résumer</button>
+                <button role="listitem" class="qa btn btn-outline-secondary" data-action="code">Code</button>
+                <button role="listitem" class="qa btn btn-outline-secondary" data-action="explain">Expliquer</button>
+              </div>
+            </aside>
+            <form id="composer" class="p-3 border-top" autocomplete="off">
+              <div class="input-group">
+                <input id="prompt" name="prompt" class="form-control" placeholder="Entrez votre message…" autocomplete="off" />
+                <button id="send" type="submit" class="btn btn-primary">Envoyer</button>
+              </div>
+            </form>
           </div>
-        </form>
-        <div id="error-alert" class="alert alert-danger mt-3 d-none alert-dismissible fade show" role="alert">
-          <span id="error-message"></span>
-          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-        </div>
+        </main>
       </div>
     </div>
   </div>

--- a/webapp/static/css/chat.css
+++ b/webapp/static/css/chat.css
@@ -2,32 +2,162 @@ body.dark-mode {
   background-color: #121212;
   color: #e0e0e0;
 }
-#chat-box {
-  height: 500px;
+
+.chat-transcript {
+  min-height: 320px;
+  max-height: 65vh;
   overflow-y: auto;
-  background-color: #fff;
-  border: 1px solid #dee2e6;
-  border-radius: 0.25rem;
-  padding: 1rem;
+  background-color: #ffffff;
+  border-bottom: 1px solid #dee2e6;
+  padding: 1.5rem;
   transition: background-color 0.3s ease;
 }
-body.dark-mode #chat-box {
+
+body.dark-mode .chat-transcript {
   background-color: #1e1e1e;
-  border-color: #333;
+  border-color: #333333;
 }
-.message {
+
+.chat-row {
+  display: flex;
   margin-bottom: 1rem;
-  opacity: 0;
-  animation: fadeIn 0.5s forwards;
 }
-.message .time {
-  font-size: 0.8rem;
+
+.chat-row.chat-user {
+  justify-content: flex-end;
+}
+
+.chat-row.chat-system {
+  justify-content: center;
+  opacity: 0.85;
+}
+
+.chat-row.chat-assistant {
+  justify-content: flex-start;
+}
+
+.chat-bubble {
+  max-width: 70ch;
+  padding: 0.85rem 1rem;
+  border-radius: 1rem;
+  background-color: #f5f5f5;
+  line-height: 1.4;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.chat-row.chat-user .chat-bubble {
+  background-color: #e8f0fe;
+}
+
+.chat-row.chat-system .chat-bubble {
+  background-color: #fafafa;
+  font-size: 0.92rem;
+}
+
+body.dark-mode .chat-bubble {
+  background-color: #2b2b2b;
+  color: #f1f1f1;
+}
+
+body.dark-mode .chat-row.chat-user .chat-bubble {
+  background-color: #3b4a5a;
+}
+
+body.dark-mode .chat-row.chat-system .chat-bubble {
+  background-color: #262626;
+}
+
+.chat-bubble-ok {
+  background-color: #e6ffed;
+}
+
+.chat-bubble-error {
+  background-color: #ffecec;
+  color: #8a1c1c;
+}
+
+.chat-bubble-warn {
+  background-color: #fff6e5;
+}
+
+.chat-bubble-hint {
+  background-color: #eef6ff;
+}
+
+.chat-meta {
+  font-size: 0.75rem;
   color: #6c757d;
+  margin-top: 0.4rem;
 }
-@keyframes fadeIn {
-  to { opacity: 1; }
+
+body.dark-mode .chat-meta {
+  color: #b0b0b0;
 }
-#status-indicator {
-  font-size: 0.9rem;
-  color: #0d6efd;
+
+.ws-badge {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.ws-badge.online {
+  background-color: #e6ffed;
+  color: #057a3b;
+}
+
+.ws-badge.offline {
+  background-color: #ffecec;
+  color: #a10000;
+}
+
+.ws-badge.connecting {
+  background-color: #fff6e5;
+  color: #8a5a00;
+}
+
+.ws-badge.error {
+  background-color: #ffecec;
+  color: #8a1c1c;
+}
+
+.chat-actions {
+  background-color: #f8f9fa;
+}
+
+body.dark-mode .chat-actions {
+  background-color: #1a1a1a;
+}
+
+.chat-actions-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.chat-actions-row .qa {
+  border-radius: 999px;
+  padding-inline: 0.9rem;
+  padding-block: 0.35rem;
+  border: 1px solid #ced4da;
+  transition: transform 0.2s ease;
+}
+
+.chat-actions-row .qa:hover,
+.chat-actions-row .qa:focus {
+  transform: translateY(-1px);
+}
+
+.chat-cursor {
+  display: inline-block;
+  margin-left: 0.25rem;
+  opacity: 0.5;
+  animation: blink 1s steps(2, start) infinite;
+}
+
+@keyframes blink {
+  to {
+    visibility: hidden;
+  }
 }

--- a/webapp/static/js/chat.js
+++ b/webapp/static/js/chat.js
@@ -173,7 +173,8 @@
       bubble.textContent = streamBuf;
       const meta = document.createElement("div");
       meta.className = "chat-meta";
-      meta.textContent = formatTimestamp(nowISO());
+      const ts = data && data.timestamp ? data.timestamp : nowISO();
+      meta.textContent = formatTimestamp(ts);
       if (data && data.error) {
         meta.classList.add("text-danger");
         meta.textContent = `${meta.textContent} • ${data.error}`;
@@ -316,6 +317,17 @@
             `<div class="chat-bubble chat-bubble-error">${escapeHTML(data.error)}</div>`,
           );
         }
+        break;
+      }
+      case "chat.message": {
+        if (!streamRow) {
+          startStream();
+        }
+        if (data && typeof data.response === "string" && !streamBuf) {
+          appendStream(data.response);
+        }
+        endStream(data);
+        setBusy(false);
         break;
       }
       case "evolution_engine.training_complete": {

--- a/webapp/static/js/chat.js
+++ b/webapp/static/js/chat.js
@@ -1,121 +1,503 @@
-const { fastapiUrl, userId, token } = window.chatConfig || {};
-if (!fastapiUrl || !userId || !token) {
-  alert('Configuration missing.');
-  throw new Error('Missing fastapiUrl, userId or token');
-}
-const historyElement = document.getElementById('chat-history');
-let chatHistory = [];
-const seenMessages = new Set();
-if (historyElement) {
-  try {
-    chatHistory = JSON.parse(historyElement.textContent);
-    if (chatHistory.error) {
-      showError(chatHistory.error);
-      chatHistory = [];
-    }
-  } catch (e) {
-    console.error('Failed to parse history', e);
-  }
-  historyElement.remove();
-}
-let socket;
-function addMessage(message) {
-  const chatBox = document.getElementById("chat-box");
-  const msgDiv = document.createElement("div");
-  msgDiv.className = "message";
-  msgDiv.textContent = `Query: ${message.query} | Response: ${message.response} | ${new Date(message.timestamp).toLocaleString('fr-CA')}`;
-  chatBox.appendChild(msgDiv);
-  chatBox.scroll({ top: chatBox.scrollHeight, behavior: 'smooth' });
-}
+/* monGARS chat frontend: event-driven UI wired to typed backend events */
 
-function addMessageIfUnique(message) {
-  const key = message.id ?? message.timestamp ?? `${message.query}|${message.response}`;
-  if (seenMessages.has(key)) {
+(function () {
+  const config = window.chatConfig || {};
+  const els = {
+    transcript: document.getElementById("transcript"),
+    composer: document.getElementById("composer"),
+    prompt: document.getElementById("prompt"),
+    send: document.getElementById("send"),
+    wsStatus: document.getElementById("ws-status"),
+    quickActions: document.getElementById("quick-actions"),
+    errorAlert: document.getElementById("error-alert"),
+    errorMessage: document.getElementById("error-message"),
+  };
+
+  if (!els.transcript || !els.composer || !els.prompt) {
     return;
   }
-  seenMessages.add(key);
-  addMessage(message);
-}
-function showError(message) {
-  const errorAlert = document.getElementById("error-alert");
-  document.getElementById("error-message").textContent = message;
-  errorAlert.classList.remove("d-none");
-}
-let failureCount = 0;
-function connectWebSocket() {
-  const base = new URL(fastapiUrl);
-  const wsProtocol = base.protocol === 'https:' ? 'wss:' : 'ws:';
-  const wsUrl = `${wsProtocol}//${base.host}/ws/chat/?token=${encodeURIComponent(token)}`;
-  socket = new WebSocket(wsUrl);
-  socket.onopen = () => {
-    document.getElementById("status-indicator").textContent = "Connecté";
-    failureCount = 0;
-    console.log("WebSocket connected");
-  };
-  socket.onmessage = (event) => {
-    const data = JSON.parse(event.data);
-    if (data && data.query && data.response) {
-      addMessageIfUnique(data);
+
+  const baseUrl = (() => {
+    const candidate = config.fastapiUrl || window.location.origin;
+    try {
+      return new URL(candidate);
+    } catch (err) {
+      console.error("Invalid FASTAPI URL", err, candidate);
+      return new URL(window.location.origin);
     }
+  })();
+
+  const apiUrl = (path) => new URL(path, baseUrl).toString();
+
+  try {
+    if (config.token) {
+      window.localStorage.setItem("jwt", config.token);
+    }
+  } catch (err) {
+    console.warn("Unable to persist JWT in localStorage", err);
+  }
+
+  const historyElement = document.getElementById("chat-history");
+  let chatHistory = [];
+  if (historyElement) {
+    try {
+      const parsed = JSON.parse(historyElement.textContent || "null");
+      if (Array.isArray(parsed)) {
+        chatHistory = parsed;
+      } else if (parsed && parsed.error) {
+        showError(parsed.error);
+      }
+    } catch (err) {
+      console.error("Unable to parse chat history", err);
+    }
+    historyElement.remove();
+  }
+
+  // ---- UX helpers ---------------------------------------------------------
+  const nowISO = () => new Date().toISOString();
+  const statusLabels = {
+    offline: "Hors ligne",
+    connecting: "Connexion…",
+    online: "En ligne",
+    error: "Erreur",
   };
-  socket.onerror = (error) => {
-    console.error("WebSocket error:", error);
-    showError("Erreur de connexion WebSocket");
-  };
-  socket.onclose = (event) => {
-    failureCount += 1;
-    const delay = Math.min(30000, 1000 * 2 ** failureCount);
-    if (failureCount > 5) {
-      document.getElementById("status-indicator").textContent = "Connexion échouée";
-      console.error("WebSocket closed too many times:", event);
+
+  function setBusy(busy) {
+    els.transcript.setAttribute("aria-busy", busy ? "true" : "false");
+  }
+
+  function hideError() {
+    if (!els.errorAlert) return;
+    els.errorAlert.classList.add("d-none");
+    if (els.errorMessage) {
+      els.errorMessage.textContent = "";
+    }
+  }
+
+  function showError(message) {
+    if (!els.errorAlert || !els.errorMessage) return;
+    els.errorMessage.textContent = message;
+    els.errorAlert.classList.remove("d-none");
+  }
+
+  function line(role, html) {
+    const row = document.createElement("div");
+    row.className = `chat-row chat-${role}`;
+    row.innerHTML = html;
+    els.transcript.appendChild(row);
+    els.transcript.scrollTop = els.transcript.scrollHeight;
+    return row;
+  }
+
+  function escapeHTML(str) {
+    return String(str).replace(/[&<>"']/g, (ch) => ({
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#39;",
+    })[ch]);
+  }
+
+  function formatTimestamp(ts) {
+    if (!ts) return "";
+    try {
+      return new Date(ts).toLocaleString("fr-CA");
+    } catch (err) {
+      return String(ts);
+    }
+  }
+
+  function renderHistory(entries) {
+    if (!Array.isArray(entries) || entries.length === 0) {
       return;
     }
-    document.getElementById("status-indicator").textContent = `Déconnecté. Reconnexion dans ${delay / 1000}s...`;
-    console.warn("WebSocket closed:", event);
-    setTimeout(connectWebSocket, delay);
-  };
-}
-connectWebSocket();
-chatHistory.forEach(addMessageIfUnique);
-const darkModeKey = 'dark-mode';
-const toggleBtn = document.getElementById("toggle-dark-mode");
-function applyDarkMode(enabled) {
-  document.body.classList.toggle("dark-mode", enabled);
-  if (toggleBtn) {
-    toggleBtn.textContent = enabled ? "Mode Clair" : "Mode Sombre";
+    entries
+      .slice()
+      .reverse()
+      .forEach((item) => {
+        if (item.query) {
+          line(
+            "user",
+            `<div class="chat-bubble">${escapeHTML(item.query)}<div class="chat-meta">${escapeHTML(
+              formatTimestamp(item.timestamp),
+            )}</div></div>`,
+          );
+        }
+        if (item.response) {
+          line(
+            "assistant",
+            `<div class="chat-bubble">${escapeHTML(item.response)}<div class="chat-meta">${escapeHTML(
+              formatTimestamp(item.timestamp),
+            )}</div></div>`,
+          );
+        }
+      });
   }
-}
-applyDarkMode(localStorage.getItem(darkModeKey) === '1');
-if (toggleBtn) {
-  toggleBtn.addEventListener("click", () => {
-    const enabled = !document.body.classList.contains("dark-mode");
-    applyDarkMode(enabled);
-    localStorage.setItem(darkModeKey, enabled ? '1' : '0');
-  });
-}
-document.getElementById("chat-form").addEventListener("submit", async (event) => {
-  event.preventDefault();
-  const input = document.getElementById("message-input");
-  const message = input.value.trim();
-  if (!message) return;
-  try {
-    const response = await fetch(`${fastapiUrl}/api/v1/conversation/chat`, {
+
+  renderHistory(chatHistory);
+
+  // Streaming buffer for the current assistant message
+  let streamRow = null;
+  let streamBuf = "";
+
+  function startStream() {
+    streamBuf = "";
+    streamRow = line(
+      "assistant",
+      '<div class="chat-bubble"><span class="chat-cursor">▍</span></div>',
+    );
+  }
+
+  function appendStream(delta) {
+    if (!streamRow) {
+      startStream();
+    }
+    streamBuf += delta || "";
+    const bubble = streamRow.querySelector(".chat-bubble");
+    if (bubble) {
+      bubble.textContent = streamBuf;
+      const cursor = document.createElement("span");
+      cursor.className = "chat-cursor";
+      cursor.textContent = "▍";
+      bubble.appendChild(cursor);
+    }
+  }
+
+  function endStream(data) {
+    if (!streamRow) {
+      return;
+    }
+    const bubble = streamRow.querySelector(".chat-bubble");
+    if (bubble) {
+      bubble.textContent = streamBuf;
+      const meta = document.createElement("div");
+      meta.className = "chat-meta";
+      meta.textContent = formatTimestamp(nowISO());
+      if (data && data.error) {
+        meta.classList.add("text-danger");
+        meta.textContent = `${meta.textContent} • ${data.error}`;
+      }
+      bubble.appendChild(meta);
+    }
+    streamRow = null;
+    streamBuf = "";
+  }
+
+  // ---- WS ticket + socket -------------------------------------------------
+  async function getJwt() {
+    try {
+      const stored = window.localStorage.getItem("jwt");
+      if (stored) {
+        return stored;
+      }
+    } catch (err) {
+      console.warn("Unable to read JWT from localStorage", err);
+    }
+    if (config.token) {
+      return config.token;
+    }
+    throw new Error("Missing JWT (store it in localStorage as 'jwt').");
+  }
+
+  async function fetchTicket() {
+    const jwt = await getJwt();
+    const resp = await fetch(apiUrl("/api/v1/auth/ws/ticket"), {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${token}`
-      },
-      body: JSON.stringify({ message: message, session_id: "session1" })
+      headers: { Authorization: `Bearer ${jwt}` },
     });
-    if (!response.ok) throw new Error("Erreur lors de l'envoi du message");
-    const data = await response.json();
-    addMessageIfUnique({
-      query: message,
-      response: data.response,
-      timestamp: Date.now()
-    });
-    input.value = "";
-  } catch (error) {
-    showError(error.message);
+    if (!resp.ok) {
+      throw new Error(`Ticket error: ${resp.status}`);
+    }
+    const body = await resp.json();
+    if (!body || !body.ticket) {
+      throw new Error("Ticket response invalide");
+    }
+    return body.ticket;
   }
-});
+
+  let ws;
+  let wsHBeat;
+  let reconnectBackoff = 500; // ms
+  const BACKOFF_MAX = 8000;
+
+  function setWsStatus(state, title) {
+    if (!els.wsStatus) return;
+    const label = statusLabels[state] || state;
+    els.wsStatus.textContent = label;
+    els.wsStatus.className = `badge ws-badge ${state}`;
+    if (title) {
+      els.wsStatus.title = title;
+    } else {
+      els.wsStatus.removeAttribute("title");
+    }
+  }
+
+  async function openSocket() {
+    try {
+      const ticket = await fetchTicket();
+      const wsUrl = new URL("/ws/chat/", baseUrl);
+      wsUrl.protocol = baseUrl.protocol === "https:" ? "wss:" : "ws:";
+      wsUrl.searchParams.set("t", ticket);
+
+      ws = new WebSocket(wsUrl.toString());
+      setWsStatus("connecting");
+
+      ws.onopen = () => {
+        setWsStatus("online");
+        hideError();
+        wsHBeat = window.setInterval(() => {
+          safeSend({ type: "client.ping", ts: nowISO() });
+        }, 20000);
+        reconnectBackoff = 500;
+      };
+
+      ws.onmessage = (evt) => {
+        try {
+          const ev = JSON.parse(evt.data);
+          handleEvent(ev);
+        } catch (err) {
+          console.error("Bad event payload", err, evt.data);
+        }
+      };
+
+      ws.onclose = () => {
+        setWsStatus("offline");
+        if (wsHBeat) {
+          clearInterval(wsHBeat);
+        }
+        const delay = reconnectBackoff + Math.floor(Math.random() * 250);
+        reconnectBackoff = Math.min(BACKOFF_MAX, reconnectBackoff * 2);
+        window.setTimeout(openSocket, delay);
+      };
+
+      ws.onerror = (err) => {
+        console.error("WebSocket error", err);
+        setWsStatus("error", "Erreur WebSocket");
+      };
+    } catch (err) {
+      console.error(err);
+      setWsStatus("error", String(err));
+      const delay = Math.min(BACKOFF_MAX, reconnectBackoff);
+      reconnectBackoff = Math.min(BACKOFF_MAX, reconnectBackoff * 2);
+      window.setTimeout(openSocket, delay);
+    }
+  }
+
+  function safeSend(obj) {
+    try {
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify(obj));
+      }
+    } catch (err) {
+      console.warn("Unable to send over WebSocket", err);
+    }
+  }
+
+  // ---- Typed event router -------------------------------------------------
+  function handleEvent(ev) {
+    const type = ev && ev.type ? ev.type : "";
+    const data = ev && ev.data ? ev.data : {};
+    switch (type) {
+      case "ai_model.response_chunk": {
+        const delta = typeof data.delta === "string" ? data.delta : data.text || "";
+        appendStream(delta);
+        break;
+      }
+      case "ai_model.response_complete": {
+        if (data && data.text && !streamBuf) {
+          appendStream(data.text);
+        }
+        endStream(data);
+        setBusy(false);
+        if (data && data.ok === false && data.error) {
+          line(
+            "system",
+            `<div class="chat-bubble chat-bubble-error">${escapeHTML(data.error)}</div>`,
+          );
+        }
+        break;
+      }
+      case "evolution_engine.training_complete": {
+        line(
+          "system",
+          `<div class="chat-bubble chat-bubble-ok">Évolution mise à jour ${escapeHTML(
+            data.version || "",
+          )}</div>`,
+        );
+        break;
+      }
+      case "evolution_engine.training_failed": {
+        line(
+          "system",
+          `<div class="chat-bubble chat-bubble-error">Échec de l'évolution : ${escapeHTML(
+            data.error || "inconnu",
+          )}</div>`,
+        );
+        break;
+      }
+      case "sleep_time_compute.phase_start": {
+        line(
+          "system",
+          '<div class="chat-bubble chat-bubble-hint">Optimisation en arrière-plan démarrée…</div>',
+        );
+        break;
+      }
+      case "sleep_time_compute.creative_phase": {
+        line(
+          "system",
+          `<div class="chat-bubble chat-bubble-hint">Exploration de ${escapeHTML(
+            Number(data.ideas || 1).toString(),
+          )} idées…</div>`,
+        );
+        break;
+      }
+      case "performance.alert": {
+        line(
+          "system",
+          `<div class="chat-bubble chat-bubble-warn">Perf : ${escapeHTML(formatPerf(data))}</div>`,
+        );
+        break;
+      }
+      case "ui.suggestions": {
+        applyQuickActionOrdering(Array.isArray(data.actions) ? data.actions : []);
+        break;
+      }
+      default:
+        if (type && type.startsWith("ws.")) {
+          return;
+        }
+        console.debug("Unhandled event", ev);
+    }
+  }
+
+  function formatPerf(d) {
+    const bits = [];
+    if (d && typeof d.cpu !== "undefined") {
+      const cpu = Number(d.cpu);
+      if (!Number.isNaN(cpu)) {
+        bits.push(`CPU ${cpu.toFixed(0)}%`);
+      }
+    }
+    if (d && typeof d.ttfb_ms !== "undefined") {
+      const ttfb = Number(d.ttfb_ms);
+      if (!Number.isNaN(ttfb)) {
+        bits.push(`TTFB ${ttfb} ms`);
+      }
+    }
+    return bits.join(" • ") || "mise à jour";
+  }
+
+  function applyQuickActionOrdering(suggestions) {
+    if (!els.quickActions) return;
+    if (!Array.isArray(suggestions) || suggestions.length === 0) return;
+    const buttons = Array.from(els.quickActions.querySelectorAll("button.qa"));
+    const lookup = new Map();
+    buttons.forEach((btn) => lookup.set(btn.dataset.action, btn));
+    const frag = document.createDocumentFragment();
+    suggestions.forEach((key) => {
+      if (lookup.has(key)) {
+        frag.appendChild(lookup.get(key));
+        lookup.delete(key);
+      }
+    });
+    lookup.forEach((btn) => frag.appendChild(btn));
+    els.quickActions.innerHTML = "";
+    els.quickActions.appendChild(frag);
+  }
+
+  // ---- Submit & quick actions --------------------------------------------
+  els.composer.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const text = (els.prompt.value || "").trim();
+    if (!text) {
+      return;
+    }
+    hideError();
+    const submittedAt = nowISO();
+    line(
+      "user",
+      `<div class=\"chat-bubble\">${escapeHTML(text)}<div class=\"chat-meta\">${escapeHTML(
+        formatTimestamp(submittedAt),
+      )}</div></div>`,
+    );
+    els.prompt.value = "";
+    setBusy(true);
+
+    try {
+      const jwt = await getJwt();
+      const resp = await fetch(apiUrl("/api/v1/conversation/chat"), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${jwt}`,
+        },
+        body: JSON.stringify({ message: text }),
+      });
+      if (!resp.ok) {
+        const payload = await resp.text();
+        throw new Error(`HTTP ${resp.status}: ${payload}`);
+      }
+      startStream();
+    } catch (err) {
+      setBusy(false);
+      showError(String(err));
+      line(
+        "system",
+        `<div class="chat-bubble chat-bubble-error">${escapeHTML(String(err))}</div>`,
+      );
+    }
+  });
+
+  if (els.quickActions) {
+    els.quickActions.addEventListener("click", (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLButtonElement)) {
+        return;
+      }
+      const action = target.dataset.action;
+      if (!action) {
+        return;
+      }
+      const presets = {
+        code: "Je souhaite écrire du code…",
+        summarize: "Résume la dernière conversation.",
+        explain: "Explique ta dernière réponse plus simplement.",
+      };
+      els.prompt.value = presets[action] || action;
+      els.composer.dispatchEvent(new Event("submit"));
+    });
+  }
+
+  // ---- Dark mode toggle ---------------------------------------------------
+  const darkModeKey = "dark-mode";
+  const toggleBtn = document.getElementById("toggle-dark-mode");
+
+  function applyDarkMode(enabled) {
+    document.body.classList.toggle("dark-mode", enabled);
+    if (toggleBtn) {
+      toggleBtn.textContent = enabled ? "Mode Clair" : "Mode Sombre";
+    }
+  }
+
+  try {
+    applyDarkMode(window.localStorage.getItem(darkModeKey) === "1");
+  } catch (err) {
+    console.warn("Unable to read dark mode preference", err);
+  }
+
+  if (toggleBtn) {
+    toggleBtn.addEventListener("click", () => {
+      const enabled = !document.body.classList.contains("dark-mode");
+      applyDarkMode(enabled);
+      try {
+        window.localStorage.setItem(darkModeKey, enabled ? "1" : "0");
+      } catch (err) {
+        console.warn("Unable to persist dark mode preference", err);
+      }
+    });
+  }
+
+  // ---- Boot ---------------------------------------------------------------
+  openSocket();
+})();


### PR DESCRIPTION
## Summary
- add a connection status badge, streaming transcript container, and quick-action shelf to the chat template
- restyle chat CSS to support the new transcript layout, status badges, and dark-mode friendly bubbles
- replace the chat JavaScript with an event-driven client that fetches WS tickets, reconnects automatically, streams AI chunks, and handles backend lifecycle events

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68db6422cc988333ba551897e035f1c9

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/monGARS/88)
<!-- GitContextEnd -->