### PR TITLE
Add UI suggestions API and hook chat quick actions

### DIFF
--- a/monGARS/api/ui.py
+++ b/monGARS/api/ui.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from ..core.aui import DEFAULT_ACTIONS, AUISuggester
+from .dependencies import get_current_user
+
+router = APIRouter(prefix="/api/v1/ui", tags=["ui"])
+logger = logging.getLogger(__name__)
+_suggester = AUISuggester()
+
+
+class SuggestRequest(BaseModel):
+    prompt: str = Field(..., min_length=1, max_length=8000)
+    actions: list[str] | None = None
+
+
+class SuggestResponse(BaseModel):
+    actions: list[str]
+    scores: dict[str, float]
+    model: str
+
+
+@router.post("/suggestions", response_model=SuggestResponse)
+async def suggestions(
+    body: SuggestRequest, current=Depends(get_current_user)
+) -> SuggestResponse:  # noqa: ANN001
+    prompt = body.prompt.strip()
+    if not prompt:
+        raise HTTPException(status_code=422, detail="prompt is empty")
+
+    if body.actions:
+        desc_map = {
+            "code": "Write, refactor or generate code and tests.",
+            "summarize": "Summarize long texts or chats.",
+            "explain": "Explain a concept simply with examples.",
+        }
+        actions = [(key, desc_map.get(key, key)) for key in body.actions]
+    else:
+        actions = DEFAULT_ACTIONS
+
+    ordered, scores = _suggester.order(prompt, actions)
+    model_name = _suggester.model_name
+    logger.debug(
+        "aui_suggestions_generated",
+        extra={
+            "user_id": getattr(current, "id", None),
+            "actions": ordered,
+            "model": model_name,
+        },
+    )
+    return SuggestResponse(actions=ordered, scores=scores, model=model_name)

--- a/monGARS/api/ui.py
+++ b/monGARS/api/ui.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
 from ..core.aui import DEFAULT_ACTIONS, AUISuggester
-from .dependencies import get_current_user
+from .authentication import get_current_user
 
 router = APIRouter(prefix="/api/v1/ui", tags=["ui"])
 logger = logging.getLogger(__name__)
@@ -42,7 +42,7 @@ async def suggestions(
     else:
         actions = DEFAULT_ACTIONS
 
-    ordered, scores = _suggester.order(prompt, actions)
+    ordered, scores = await _suggester.order(prompt, actions)
     model_name = _suggester.model_name
     logger.debug(
         "aui_suggestions_generated",

--- a/monGARS/api/web_api.py
+++ b/monGARS/api/web_api.py
@@ -29,10 +29,12 @@ from monGARS.core.ui_events import event_bus, make_event
 app = FastAPI(title="monGARS API")
 
 from . import authentication as auth_routes
+from . import ui as ui_routes
 from . import ws_manager
 
 app.include_router(ws_manager.router)
 app.include_router(auth_routes.router)
+app.include_router(ui_routes.router)
 app.include_router(ws_ticket_router)
 _ws_manager = ws_manager.ws_manager
 sec_manager = SecurityManager()

--- a/monGARS/core/aui.py
+++ b/monGARS/core/aui.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import logging
+import math
+from collections.abc import Iterable, Sequence
+
+# Prefer the existing embedding system if present
+try:  # pragma: no cover - import guard
+    from .neurones import EmbeddingSystem  # type: ignore[attr-defined]
+
+    _HAS_NEURONES = True
+except Exception:  # pragma: no cover - optional dependency
+    _HAS_NEURONES = False
+
+logger = logging.getLogger(__name__)
+
+# Default actions (keys MUST match the front-end data-action)
+DEFAULT_ACTIONS: list[tuple[str, str]] = [
+    ("code", "Write, refactor or generate source code and tests."),
+    ("summarize", "Summarize long passages, chats, or documents succinctly."),
+    ("explain", "Explain a concept in simpler terms with examples."),
+]
+
+
+def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a)) or 1.0
+    nb = math.sqrt(sum(x * x for x in b)) or 1.0
+    return dot / (na * nb)
+
+
+def _keyword_score(action_key: str, prompt: str, action_desc: str) -> float:
+    p = prompt.lower()
+    d = action_desc.lower()
+    hints: dict[str, tuple[str, ...]] = {
+        "code": (
+            "code",
+            "function",
+            "bug",
+            "refactor",
+            "compile",
+            "typescript",
+            "python",
+            "class",
+        ),
+        "summarize": ("tl;dr", "summary", "summarize", "condense", "short version"),
+        "explain": ("explain", "why", "how", "teach", "beginner", "simple"),
+    }
+    score = 0.0
+    for word in hints.get(action_key, ()):
+        if word in p:
+            score += 1.0
+        if word in d:
+            score += 0.25
+    return score
+
+
+class AUISuggester:
+    """Produces ordered suggestions for action-oriented UI shortcuts."""
+
+    def __init__(self) -> None:
+        self._embed: EmbeddingSystem | None = None
+        if _HAS_NEURONES:
+            try:
+                self._embed = EmbeddingSystem()
+            except Exception as exc:  # pragma: no cover - instantiation failure
+                logger.warning("aui_embed_init_failed", extra={"error": repr(exc)})
+                self._embed = None
+
+    @property
+    def model_name(self) -> str:
+        return "neurones" if self._embed else "keyword"
+
+    def suggest(
+        self,
+        prompt: str,
+        actions: Iterable[tuple[str, str]] = DEFAULT_ACTIONS,
+    ) -> dict[str, float]:
+        """
+        Return a mapping of action key to relevance score for the provided prompt.
+
+        Falls back to the keyword heuristic when embeddings are unavailable.
+        """
+
+        items = list(actions)
+        if not items:
+            return {}
+
+        if self._embed:
+            try:
+                prompt_vector = self._embed.encode([prompt])[0]
+                action_vectors = self._embed.encode(
+                    [description for _, description in items]
+                )
+                return {
+                    key: _cosine(prompt_vector, vector)
+                    for (key, _), vector in zip(items, action_vectors, strict=False)
+                }
+            except Exception as exc:  # pragma: no cover - runtime fallback
+                logger.warning(
+                    "aui_embedding_inference_failed", extra={"error": repr(exc)}
+                )
+
+        return {
+            key: _keyword_score(key, prompt, description) for key, description in items
+        }
+
+    def order(
+        self,
+        prompt: str,
+        actions: Iterable[tuple[str, str]] = DEFAULT_ACTIONS,
+    ) -> tuple[list[str], dict[str, float]]:
+        scores = self.suggest(prompt, actions)
+        ordered = sorted(scores.items(), key=lambda kv: kv[1], reverse=True)
+        return [key for key, _ in ordered], scores

--- a/tests/test_ui_suggestions.py
+++ b/tests/test_ui_suggestions.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
+import pytest
+
 from monGARS.core.aui import AUISuggester
 
 
-def test_order_keyword_reflects_intent() -> None:
+@pytest.mark.asyncio
+async def test_order_keyword_reflects_intent() -> None:
     suggester = AUISuggester()
-    order, _ = suggester.order("please refactor this python function")
+    order, _ = await suggester.order("please refactor this python function")
     assert order[0] == "code"
 
-    order2, _ = suggester.order("tl;dr the following conversation")
+    order2, _ = await suggester.order("tl;dr the following conversation")
     assert order2[0] == "summarize"
 
-    order3, _ = suggester.order("explain transformers like I'm five")
+    order3, _ = await suggester.order("explain transformers like I'm five")
     assert order3[0] == "explain"

--- a/tests/test_ui_suggestions.py
+++ b/tests/test_ui_suggestions.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from monGARS.core.aui import AUISuggester
+
+
+def test_order_keyword_reflects_intent() -> None:
+    suggester = AUISuggester()
+    order, _ = suggester.order("please refactor this python function")
+    assert order[0] == "code"
+
+    order2, _ = suggester.order("tl;dr the following conversation")
+    assert order2[0] == "summarize"
+
+    order3, _ = suggester.order("explain transformers like I'm five")
+    assert order3[0] == "explain"


### PR DESCRIPTION
## Summary
- add a reusable AUISuggester helper that prefers embeddings with keyword fallback
- expose a JWT-protected `/api/v1/ui/suggestions` FastAPI endpoint for adaptive quick actions
- debounce chat composer input to fetch suggestions live and cover fallback behaviour with tests

## Testing
- pytest tests/test_ui_suggestions.py


------
https://chatgpt.com/codex/tasks/task_e_68db6815186c8333bb259eefb37ba9aa

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/monGARS/89)
<!-- GitContextEnd -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added UI Suggestions API to recommend quick actions based on the prompt.
  * Integrated routes into the app and enabled debounced fetching of suggestions on input.
  * Quick-action buttons now reorder dynamically; defaults initialize after sending a message.
  * Handles failures gracefully with non-blocking logging.

* Tests
  * Added tests validating that suggested quick actions match expected intent (e.g., code, summarize, explain).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->