### PR TITLE
Implement DB-backed authentication and improve JWT key management

### DIFF
--- a/monGARS/api/authentication.py
+++ b/monGARS/api/authentication.py
@@ -1,12 +1,60 @@
+"""Authentication helpers and dependencies for the FastAPI layer."""
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 
 from monGARS.config import get_settings
+from monGARS.core.persistence import PersistenceRepository
 from monGARS.core.security import SecurityManager
+from monGARS.init_db import UserAccount
 
 settings = get_settings()
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 router = APIRouter(prefix="/api/v1/auth", tags=["auth"])
+logger = logging.getLogger(__name__)
+
+
+async def authenticate_user(
+    repo: PersistenceRepository,
+    username: str,
+    password: str,
+    sec_manager: SecurityManager,
+    defaults: Mapping[str, Mapping[str, Any]],
+) -> UserAccount:
+    """Authenticate ``username`` using persisted accounts or default fallbacks."""
+
+    user = await repo.get_user_by_username(username)
+    if user and sec_manager.verify_password(password, user.password_hash):
+        return user
+
+    default_user = defaults.get(username)
+    if default_user and sec_manager.verify_password(
+        password, default_user["password_hash"]
+    ):
+        try:
+            return await repo.create_user(
+                username,
+                default_user["password_hash"],
+                is_admin=default_user["is_admin"],
+            )
+        except ValueError as exc:
+            logger.debug(
+                "auth.default_user_race",
+                extra={"username": username},
+                exc_info=exc,
+            )
+            user = await repo.get_user_by_username(username)
+            if user:
+                return user
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid credentials",
+    )
 
 
 def get_current_user(token: str = Depends(oauth2_scheme)) -> dict:
@@ -16,8 +64,8 @@ def get_current_user(token: str = Depends(oauth2_scheme)) -> dict:
     try:
         payload = sec.verify_token(token)
         return payload
-    except Exception as e:
-        raise HTTPException(status_code=401, detail=f"Invalid token: {e}") from e
+    except Exception as exc:  # pragma: no cover - FastAPI handles response
+        raise HTTPException(status_code=401, detail=f"Invalid token: {exc}") from exc
 
 
 def get_current_admin_user(current_user: dict = Depends(get_current_user)) -> dict:

--- a/monGARS/api/dependencies.py
+++ b/monGARS/api/dependencies.py
@@ -5,6 +5,7 @@ from weakref import WeakKeyDictionary
 from monGARS.core.dynamic_response import AdaptiveResponseGenerator
 from monGARS.core.hippocampus import Hippocampus
 from monGARS.core.peer import PeerCommunicator
+from monGARS.core.persistence import PersistenceRepository
 from monGARS.core.personality import PersonalityEngine
 
 hippocampus = Hippocampus()
@@ -13,6 +14,7 @@ _personality_engine: PersonalityEngine | None = None
 _adaptive_generators: WeakKeyDictionary[
     PersonalityEngine, AdaptiveResponseGenerator
 ] = WeakKeyDictionary()
+_persistence_repository = PersistenceRepository()
 
 
 def _resolve_personality_engine() -> PersonalityEngine:
@@ -30,6 +32,11 @@ def get_hippocampus() -> Hippocampus:
 def get_peer_communicator() -> PeerCommunicator:
     """Return the shared PeerCommunicator instance."""
     return peer_communicator
+
+
+def get_persistence_repository() -> PersistenceRepository:
+    """Return the shared PersistenceRepository instance."""
+    return _persistence_repository
 
 
 def get_personality_engine() -> PersonalityEngine:

--- a/monGARS/config.py
+++ b/monGARS/config.py
@@ -78,6 +78,18 @@ class Settings(BaseSettings):
         description="Application secret used for JWT signing; override in production.",
     )
     JWT_ALGORITHM: str = Field(default="HS256")
+    JWT_PRIVATE_KEY: str | None = Field(
+        default=None,
+        description=(
+            "PEM-encoded RSA private key used for JWT signing when JWT_ALGORITHM is set to RS256."
+        ),
+    )
+    JWT_PUBLIC_KEY: str | None = Field(
+        default=None,
+        description=(
+            "PEM-encoded RSA public key used for JWT verification when JWT_ALGORITHM is set to RS256."
+        ),
+    )
     ACCESS_TOKEN_EXPIRE_MINUTES: int = Field(default=60)
 
     database_url: PostgresDsn = Field(

--- a/monGARS/core/persistence.py
+++ b/monGARS/core/persistence.py
@@ -5,7 +5,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from sqlalchemy import desc, select
-from sqlalchemy.exc import DBAPIError, InterfaceError, OperationalError
+from sqlalchemy.exc import DBAPIError, IntegrityError, InterfaceError, OperationalError
 from tenacity import (
     AsyncRetrying,
     retry_if_exception_type,
@@ -13,7 +13,12 @@ from tenacity import (
     wait_exponential,
 )
 
-from ..init_db import ConversationHistory, Interaction, async_session_factory
+from ..init_db import (
+    ConversationHistory,
+    Interaction,
+    UserAccount,
+    async_session_factory,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -26,14 +31,20 @@ class PersistenceRepository:
         self._session_factory = session_factory
 
     async def _execute_with_retry(
-        self, operation: SessionCallable, *, operation_name: str
+        self,
+        operation: SessionCallable,
+        *,
+        operation_name: str,
+        retry_exceptions: tuple[type[Exception], ...] = (
+            OperationalError,
+            InterfaceError,
+            DBAPIError,
+        ),
     ) -> Any:
         retrying = AsyncRetrying(
             stop=stop_after_attempt(3),
             wait=wait_exponential(multiplier=0.5, min=0.5, max=5),
-            retry=retry_if_exception_type(
-                (OperationalError, InterfaceError, DBAPIError)
-            ),
+            retry=retry_if_exception_type(retry_exceptions),
             reraise=True,
         )
         try:
@@ -110,3 +121,36 @@ class PersistenceRepository:
             return result.scalars().all()
 
         return await self._execute_with_retry(operation, operation_name="get_history")
+
+    async def get_user_by_username(self, username: str) -> UserAccount | None:
+        async def operation(session):
+            result = await session.execute(
+                select(UserAccount).where(UserAccount.username == username)
+            )
+            return result.scalar_one_or_none()
+
+        return await self._execute_with_retry(
+            operation, operation_name="get_user_by_username"
+        )
+
+    async def create_user(
+        self, username: str, password_hash: str, *, is_admin: bool = False
+    ) -> UserAccount:
+        async def operation(session):
+            async with session.begin():
+                user = UserAccount(
+                    username=username,
+                    password_hash=password_hash,
+                    is_admin=is_admin,
+                )
+                session.add(user)
+            return user
+
+        try:
+            return await self._execute_with_retry(
+                operation,
+                operation_name="create_user",
+                retry_exceptions=(OperationalError, InterfaceError),
+            )
+        except IntegrityError as exc:
+            raise ValueError("Username already exists") from exc

--- a/monGARS/init_db.py
+++ b/monGARS/init_db.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import asynccontextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import AsyncIterator
+from weakref import WeakKeyDictionary
 
 from sqlalchemy import JSON, Boolean, DateTime, Float, Integer, String, create_engine
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -23,6 +24,10 @@ class Base(DeclarativeBase):
     """Base class for all lightweight ORM models."""
 
 
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
 class ConversationHistory(Base):
     __tablename__ = "conversation_history"
 
@@ -30,9 +35,7 @@ class ConversationHistory(Base):
     user_id: Mapped[str] = mapped_column(String, index=True)
     query: Mapped[str] = mapped_column(String)
     response: Mapped[str] = mapped_column(String)
-    timestamp: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, index=True
-    )
+    timestamp: Mapped[datetime] = mapped_column(DateTime, default=_utcnow, index=True)
     vector: Mapped[list[float] | None] = mapped_column(JSON, default=list)
 
 
@@ -51,11 +54,9 @@ class Interaction(Base):
     meta_data: Mapped[str | None] = mapped_column(String, nullable=True)
     confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
     processing_time: Mapped[float | None] = mapped_column(Float, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, index=True
-    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow, index=True)
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+        DateTime, default=_utcnow, onupdate=_utcnow
     )
 
 
@@ -77,7 +78,7 @@ class UserPersonality(Base):
     context_preferences: Mapped[dict] = mapped_column(JSON, default=dict)
     adaptation_rate: Mapped[float] = mapped_column(Float, default=0.1)
     confidence: Mapped[float] = mapped_column(Float, default=0.5)
-    last_updated: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    last_updated: Mapped[datetime] = mapped_column(DateTime, default=_utcnow)
 
 
 class UserAccount(Base):
@@ -85,11 +86,11 @@ class UserAccount(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     username: Mapped[str] = mapped_column(String(150), unique=True, index=True)
-    password_hash: Mapped[str] = mapped_column(String, nullable=False)
+    password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow)
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+        DateTime, default=_utcnow, onupdate=_utcnow
     )
 
 
@@ -111,8 +112,19 @@ else:
     _async_engine = None
     _async_session_maker = None
 
-_init_lock: asyncio.Lock | None = None
+_init_locks: "WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock]" = (
+    WeakKeyDictionary()
+)
 _initialized = False
+
+
+def _get_loop_lock() -> asyncio.Lock:
+    loop = asyncio.get_running_loop()
+    lock = _init_locks.get(loop)
+    if lock is None:
+        lock = asyncio.Lock()
+        _init_locks[loop] = lock
+    return lock
 
 
 class _AsyncSessionProxy:
@@ -171,13 +183,11 @@ class _AsyncSessionProxy:
 async def _ensure_schema() -> None:
     """Create the lightweight schema once per process."""
 
-    global _initialized, _init_lock
+    global _initialized
     if _initialized:
         return
-    current_loop = asyncio.get_running_loop()
-    if _init_lock is None or getattr(_init_lock, "_loop", None) is not current_loop:
-        _init_lock = asyncio.Lock()
-    async with _init_lock:
+    lock = _get_loop_lock()
+    async with lock:
         if _initialized:
             return
         if HAS_AIOSQLITE:
@@ -212,11 +222,9 @@ async def async_session_factory() -> AsyncIterator[AsyncSession]:
 async def reset_database() -> None:
     """Utility for tests that need a clean in-memory database."""
 
-    global _init_lock, _initialized
-    current_loop = asyncio.get_running_loop()
-    if _init_lock is None or getattr(_init_lock, "_loop", None) is not current_loop:
-        _init_lock = asyncio.Lock()
-    async with _init_lock:
+    global _initialized
+    lock = _get_loop_lock()
+    async with lock:
         if HAS_AIOSQLITE:
             assert _async_engine is not None
             async with _async_engine.begin() as conn:

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -1,195 +1,200 @@
-import asyncio
-import os
-
-os.environ.setdefault("SECRET_KEY", "test")
-os.environ.setdefault("JWT_ALGORITHM", "HS256")
+"""End-to-end tests for user registration and authentication flows."""
 
 import pytest
-from fastapi.testclient import TestClient
+import pytest_asyncio
+from fastapi import status
+from httpx import ASGITransport, AsyncClient
 
 from monGARS.api.dependencies import get_peer_communicator, get_persistence_repository
 from monGARS.api.web_api import app, sec_manager
 from monGARS.init_db import reset_database
 
 
-@pytest.fixture
-def client():
-    try:
-        previous_loop = asyncio.get_event_loop()
-    except RuntimeError:
-        previous_loop = None
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
+@pytest_asyncio.fixture
+async def client() -> AsyncClient:
+    await reset_database()
     repo = get_persistence_repository()
+    await repo.create_user(
+        "admin", sec_manager.get_password_hash("secret"), is_admin=True
+    )
+    await repo.create_user(
+        "user", sec_manager.get_password_hash("passphrase"), is_admin=False
+    )
 
-    async def setup() -> None:
-        await reset_database()
-        await repo.create_user(
-            "admin", sec_manager.get_password_hash("secret"), is_admin=True
-        )
-        await repo.create_user(
-            "user", sec_manager.get_password_hash("passphrase"), is_admin=False
-        )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as async_client:
+        yield async_client
 
-    loop.run_until_complete(setup())
-    client = TestClient(app)
-
-    try:
-        yield client
-    finally:
-        client.close()
-
-        async def teardown() -> None:
-            await reset_database()
-
-        loop.run_until_complete(teardown())
-        loop.close()
-        if previous_loop is not None and not previous_loop.is_closed():
-            asyncio.set_event_loop(previous_loop)
-        else:
-            asyncio.set_event_loop(None)
+    await reset_database()
 
 
-def get_token(client, username, password):
-    response = client.post("/token", data={"username": username, "password": password})
+async def get_token(client: AsyncClient, username: str, password: str) -> str:
+    response = await client.post(
+        "/token", data={"username": username, "password": password}
+    )
+    assert response.status_code == 200, response.json()
     data = response.json()
-    if "access_token" in data:
-        return data["access_token"]
-    print(f"Failed to get access_token for {username}: {data}")
-    return None
+    assert "access_token" in data
+    return data["access_token"]
 
 
-def test_register_and_login(client):
-    resp = client.post(
-        "/api/v1/user/register", json={"username": "newuser", "password": "newpassword"}
+@pytest.mark.asyncio
+async def test_register_and_login(client: AsyncClient) -> None:
+    resp = await client.post(
+        "/api/v1/user/register",
+        json={"username": "newuser", "password": "newpassword"},
     )
     assert resp.status_code == 200
     assert resp.json()["status"] == "registered"
 
-    token = get_token(client, "newuser", "newpassword")
-    assert token
+    token = await get_token(client, "newuser", "newpassword")
+    payload = sec_manager.verify_token(token)
+    assert payload["sub"] == "newuser"
+    assert payload["admin"] is False
 
 
-def test_register_existing_username(client):
-    resp1 = client.post(
-        "/api/v1/user/register", json={"username": "dup", "password": "password123"}
+@pytest.mark.asyncio
+async def test_register_existing_username_returns_conflict(
+    client: AsyncClient,
+) -> None:
+    resp_first = await client.post(
+        "/api/v1/user/register",
+        json={"username": "dup", "password": "password123"},
     )
-    assert resp1.status_code == 200
-    assert resp1.json()["status"] == "registered"
-    resp2 = client.post(
-        "/api/v1/user/register", json={"username": "dup", "password": "password123"}
+    assert resp_first.status_code == 200
+    resp_second = await client.post(
+        "/api/v1/user/register",
+        json={"username": "dup", "password": "password123"},
     )
-    assert resp2.status_code in (400, 409)
+    assert resp_second.status_code == status.HTTP_409_CONFLICT
+    assert resp_second.json()["detail"] == "Username already exists"
 
 
-def test_register_invalid_username(client):
-    resp = client.post(
+@pytest.mark.asyncio
+async def test_register_invalid_username(client: AsyncClient) -> None:
+    resp = await client.post(
         "/api/v1/user/register", json={"username": "", "password": "password123"}
     )
-    assert resp.status_code == 422
-    resp = client.post(
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    resp = await client.post(
         "/api/v1/user/register",
         json={"username": "invalid user!", "password": "password123"},
     )
-    assert resp.status_code == 422
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
-def test_register_short_password(client):
-    resp = client.post(
-        "/api/v1/user/register", json={"username": "shortpwuser", "password": "pw"}
+@pytest.mark.asyncio
+async def test_register_short_password(client: AsyncClient) -> None:
+    resp = await client.post(
+        "/api/v1/user/register",
+        json={"username": "shortpwuser", "password": "pw"},
     )
-    assert resp.status_code == 422
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
-def test_login_incorrect_credentials(client):
-    client.post(
+@pytest.mark.asyncio
+async def test_login_incorrect_credentials(client: AsyncClient) -> None:
+    await client.post(
         "/api/v1/user/register",
         json={"username": "loginuser", "password": "correctpassword"},
     )
-    resp = client.post(
+    resp = await client.post(
         "/token", data={"username": "loginuser", "password": "wrongpassword"}
     )
-    assert resp.status_code == 401
-    resp = client.post("/token", data={"username": "nosuchuser", "password": "any"})
-    assert resp.status_code == 401
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+    resp = await client.post(
+        "/token", data={"username": "nosuchuser", "password": "any"}
+    )
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
 
 
-def test_peer_endpoints_require_admin(client, monkeypatch):
+@pytest.mark.asyncio
+async def test_admin_claim_reflects_admin_status(client: AsyncClient) -> None:
+    admin_token = await get_token(client, "admin", "secret")
+    admin_payload = sec_manager.verify_token(admin_token)
+    assert admin_payload["admin"] is True
+
+    user_token = await get_token(client, "user", "passphrase")
+    user_payload = sec_manager.verify_token(user_token)
+    assert user_payload["admin"] is False
+
+
+@pytest.mark.asyncio
+async def test_peer_endpoints_require_admin(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
     peer_comm = get_peer_communicator()
     peer_comm.peers = set()
 
-    user_token = get_token(client, "user", "passphrase")
-    admin_token = get_token(client, "admin", "secret")
+    user_token = await get_token(client, "user", "passphrase")
+    admin_token = await get_token(client, "admin", "secret")
     invalid_token = "invalid.token.value"
 
-    # /peer/register
-    resp = client.post("/api/v1/peer/register", json={"url": "http://x"})
-    assert resp.status_code == 401
+    resp = await client.post("/api/v1/peer/register", json={"url": "http://x"})
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
 
-    resp = client.post(
+    resp = await client.post(
         "/api/v1/peer/register",
         json={"url": "http://x"},
         headers={"Authorization": f"Bearer {invalid_token}"},
     )
-    assert resp.status_code in (401, 403)
+    assert resp.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
 
-    resp = client.post(
+    resp = await client.post(
         "/api/v1/peer/register",
         json={"url": "http://x"},
         headers={"Authorization": f"Bearer {user_token}"},
     )
-    assert resp.status_code == 403
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
 
-    resp = client.post(
+    resp = await client.post(
         "/api/v1/peer/register",
         json={"url": "http://x"},
         headers={"Authorization": f"Bearer {admin_token}"},
     )
-    assert resp.status_code == 200
+    assert resp.status_code == status.HTTP_200_OK
 
-    # /peer/unregister
-    resp = client.post("/api/v1/peer/unregister", json={"url": "http://x"})
-    assert resp.status_code == 401
+    resp = await client.post("/api/v1/peer/unregister", json={"url": "http://x"})
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
 
-    resp = client.post(
+    resp = await client.post(
         "/api/v1/peer/unregister",
         json={"url": "http://x"},
         headers={"Authorization": f"Bearer {invalid_token}"},
     )
-    assert resp.status_code in (401, 403)
+    assert resp.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
 
-    resp = client.post(
+    resp = await client.post(
         "/api/v1/peer/unregister",
         json={"url": "http://x"},
         headers={"Authorization": f"Bearer {user_token}"},
     )
-    assert resp.status_code == 403
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
 
-    resp = client.post(
+    resp = await client.post(
         "/api/v1/peer/unregister",
         json={"url": "http://x"},
         headers={"Authorization": f"Bearer {admin_token}"},
     )
-    assert resp.status_code in (200, 404)
+    assert resp.status_code in (status.HTTP_200_OK, status.HTTP_404_NOT_FOUND)
 
-    # /peer/list
-    resp = client.get("/api/v1/peer/list")
-    assert resp.status_code == 401
+    resp = await client.get("/api/v1/peer/list")
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
 
-    resp = client.get(
+    resp = await client.get(
         "/api/v1/peer/list",
         headers={"Authorization": f"Bearer {invalid_token}"},
     )
-    assert resp.status_code in (401, 403)
+    assert resp.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
 
-    resp = client.get(
+    resp = await client.get(
         "/api/v1/peer/list",
         headers={"Authorization": f"Bearer {user_token}"},
     )
-    assert resp.status_code == 403
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
 
-    resp = client.get(
+    resp = await client.get(
         "/api/v1/peer/list",
         headers={"Authorization": f"Bearer {admin_token}"},
     )
-    assert resp.status_code == 200
+    assert resp.status_code == status.HTTP_200_OK


### PR DESCRIPTION
## Summary
- route user registration and login through the PersistenceRepository with database-backed `UserAccount` records and default user bootstrap
- add repository helpers and tests to create seeded accounts while updating API dependencies to share a persistence instance
- extend `SecurityManager` and settings with RSA key support for JWTs while hardening async session locking

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dbe33d883c83339cd97f90c1290da9

## Summary by Sourcery

Implement database-backed user authentication by migrating login and registration endpoints to use a persistent UserAccount model and repository, introduce RSA key management for JWT tokens, and harden persistence retry and initialization logic

New Features:
- Provide database-backed authentication with a UserAccount model and repository methods for user retrieval and creation
- Add RSA-based JWT signing and verification support with private/public key configuration and enforced key presence

Enhancements:
- Refine persistence retry logic to accept customizable exception types
- Enhance database initialization and reset routines to manage asyncio locks per event loop

Tests:
- Replace in-memory user fixtures with database setup and teardown using the persistence repository

Chores:
- Register a shared PersistenceRepository in FastAPI dependencies for injection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Database-backed user accounts with persistent registration and login.
  - Fallback for predefined legacy/admin users during authentication.
  - RSA (RS*) JWT support with configurable private/public keys.
  - New persistent user entity with creation timestamps (UTC-aware).

- Bug Fixes / Reliability
  - Improved database initialization locking to prevent concurrent setup.
  - Atomic user creation with conflict handling to avoid race conditions.

- Tests
  - Tests migrated to async, using the persistence-backed setup and DB reset utilities.

- Chores
  - Shared persistence repository injected into API auth flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->