### PR TITLE
Centralize API validation and publish OpenAPI docs

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,42 @@
+# monGARS OpenAPI Catalogue
+
+This directory contains generated artefacts and client guides for the public
+FastAPI surface exposed by `monGARS.api.web_api`. The specification is updated
+from the running application to ensure feature parity with the deployed
+behaviour.
+
+## Specification Files
+
+- [`openapi.json`](openapi.json) – canonical machine-readable description of
+  every route, request/response model, and authentication requirement.
+
+## Regenerating the Specification
+
+The schema depends on a configured `SECRET_KEY`. When regenerating, provide a
+throwaway value via the environment so the FastAPI application can boot:
+
+```bash
+SECRET_KEY="dev-secret" python - <<'PY'
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from monGARS.api.web_api import app
+
+spec = app.openapi()
+output_path = Path("docs/api/openapi.json")
+output_path.write_text(json.dumps(spec, indent=2))
+print(f"wrote {output_path}")
+PY
+```
+
+Commit the updated `openapi.json` alongside any API changes. Downstream client
+generators (see below) rely on the canonical file.
+
+## Example Client Libraries
+
+Sample integrations for popular stacks are documented under
+[`clients/`](clients). Each client example includes dependency instructions,
+authentication helpers, and typed request wrappers that mirror the generated
+schema.

--- a/docs/api/clients/python.md
+++ b/docs/api/clients/python.md
@@ -1,0 +1,78 @@
+# Python Client Example
+
+The following example uses [`httpx`](https://www.python-httpx.org/) and
+[`pydantic`](https://docs.pydantic.dev/) to provide a lightweight, fully typed
+client for the monGARS API. It mirrors the request/response schemas defined in
+`monGARS.api.schemas` and can be extended or generated automatically with tools
+like [`openapi-python-client`](https://github.com/openapi-generators/openapi-python-client).
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install httpx[http2] pydantic
+```
+
+## Usage
+
+```python
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+from pydantic import BaseModel
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str
+
+
+class ChatRequest(BaseModel):
+    message: str
+    session_id: str | None = None
+
+
+class ChatResponse(BaseModel):
+    response: str
+    confidence: float
+    processing_time: float
+
+
+async def main() -> None:
+    async with httpx.AsyncClient(base_url="https://mongars.example.com") as client:
+        token_resp = await client.post(
+            "/token",
+            data={"username": "u1", "password": "x"},
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        token = TokenResponse.model_validate_json(token_resp.text)
+
+        headers = {"Authorization": f"Bearer {token.access_token}"}
+        payload = ChatRequest(message="Summarise our latest incident report")
+        response = await client.post(
+            "/api/v1/conversation/chat",
+            json=payload.model_dump(mode="json"),
+            headers=headers,
+        )
+        chat = ChatResponse.model_validate_json(response.text)
+        print(chat.response)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+## Extending
+
+- Generate a fully featured SDK:
+
+  ```bash
+  openapi-python-client generate --path docs/api/openapi.json --config openapi-python-client.toml
+  ```
+
+- Use `monGARS.api.schemas` directly for shared validation logic inside custom
+data pipelines or CLI tooling.

--- a/docs/api/clients/typescript.md
+++ b/docs/api/clients/typescript.md
@@ -1,0 +1,56 @@
+# TypeScript Client Example
+
+This sample demonstrates how to generate a typed SDK with
+[`openapi-typescript-codegen`](https://www.npmjs.com/package/openapi-typescript-codegen)
+and consume it in a modern application (Node.js or React Native).
+
+## Prerequisites
+
+```bash
+npm install --save-dev openapi-typescript-codegen
+```
+
+## Generate the Client
+
+```bash
+npx openapi-typescript-codegen --input docs/api/openapi.json --output ./generated/mongars
+```
+
+The generator produces:
+
+- A `Client` wrapper with configurable base URL and interceptors.
+- Namespaced functions for each API group (e.g. `PeerService.registerPeer`).
+- Type definitions mirroring the Pydantic models in `monGARS.api.schemas`.
+
+## Example Usage
+
+```ts
+import { Client, ConversationService } from '../generated/mongars';
+
+const client = new Client({
+  BASE: 'https://mongars.example.com',
+  TOKEN: async () => `Bearer ${process.env.MONGARS_TOKEN ?? ''}`,
+});
+
+async function run() {
+  const chat = await ConversationService.postApiV1ConversationChat(
+    {
+      message: 'Draft a post-incident summary for ticket #42',
+    },
+    client,
+  );
+
+  console.log(chat.response, chat.confidence);
+}
+
+run().catch((error) => {
+  console.error('monGARS client error', error);
+});
+```
+
+## React Native Considerations
+
+- Use a fetch-compatible polyfill such as `cross-fetch` or `whatwg-fetch` if the
+target runtime does not provide `fetch` by default.
+- Wrap network calls with platform-aware permission guards when integrating with
+native diagnostics modules, as described in the repository guidelines.

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1,0 +1,801 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "monGARS API",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/api/v1/ui/suggestions": {
+      "post": {
+        "tags": [
+          "ui"
+        ],
+        "summary": "Suggestions",
+        "operationId": "suggestions_api_v1_ui_suggestions_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SuggestRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuggestResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/ws/ticket": {
+      "post": {
+        "tags": [
+          "ws-ticket"
+        ],
+        "summary": "Issue Ws Ticket",
+        "operationId": "issue_ws_ticket_api_v1_auth_ws_ticket_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WSTicketResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/token": {
+      "post": {
+        "summary": "Login",
+        "description": "Return a simple access token.",
+        "operationId": "login_token_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_login_token_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Login Token Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/user/register": {
+      "post": {
+        "summary": "Register User",
+        "operationId": "register_user_api_v1_user_register_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserRegistration"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Register User Api V1 User Register Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/healthz": {
+      "get": {
+        "summary": "Healthz",
+        "operationId": "healthz_healthz_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Healthz Healthz Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ready": {
+      "get": {
+        "summary": "Ready",
+        "operationId": "ready_ready_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Ready Ready Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/conversation/history": {
+      "get": {
+        "summary": "Conversation History",
+        "operationId": "conversation_history_api_v1_conversation_history_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "User Id"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 10,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MemoryItem"
+                  },
+                  "title": "Response Conversation History Api V1 Conversation History Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/conversation/chat": {
+      "post": {
+        "summary": "Chat",
+        "operationId": "chat_api_v1_conversation_chat_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChatRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/peer/message": {
+      "post": {
+        "summary": "Peer Message",
+        "description": "Receive an encrypted message from a peer.",
+        "operationId": "peer_message_api_v1_peer_message_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PeerMessage"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Peer Message Api V1 Peer Message Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/peer/register": {
+      "post": {
+        "summary": "Peer Register",
+        "description": "Register a peer URL for future broadcasts.",
+        "operationId": "peer_register_api_v1_peer_register_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PeerRegistration"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Peer Register Api V1 Peer Register Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/peer/unregister": {
+      "post": {
+        "summary": "Peer Unregister",
+        "description": "Remove a previously registered peer URL.",
+        "operationId": "peer_unregister_api_v1_peer_unregister_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PeerRegistration"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Peer Unregister Api V1 Peer Unregister Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/peer/list": {
+      "get": {
+        "summary": "Peer List",
+        "description": "Return the list of registered peer URLs.",
+        "operationId": "peer_list_api_v1_peer_list_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "title": "Response Peer List Api V1 Peer List Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Body_login_token_post": {
+        "properties": {
+          "grant_type": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^password$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grant Type"
+          },
+          "username": {
+            "type": "string",
+            "title": "Username"
+          },
+          "password": {
+            "type": "string",
+            "format": "password",
+            "title": "Password"
+          },
+          "scope": {
+            "type": "string",
+            "title": "Scope",
+            "default": ""
+          },
+          "client_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Id"
+          },
+          "client_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "format": "password",
+            "title": "Client Secret"
+          }
+        },
+        "type": "object",
+        "required": [
+          "username",
+          "password"
+        ],
+        "title": "Body_login_token_post"
+      },
+      "ChatRequest": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "maxLength": 1000,
+            "minLength": 1,
+            "title": "Message"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 100
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "message"
+        ],
+        "title": "ChatRequest",
+        "description": "Incoming chat message sent to the conversational endpoint."
+      },
+      "ChatResponse": {
+        "properties": {
+          "response": {
+            "type": "string",
+            "title": "Response"
+          },
+          "confidence": {
+            "type": "number",
+            "title": "Confidence"
+          },
+          "processing_time": {
+            "type": "number",
+            "title": "Processing Time"
+          }
+        },
+        "type": "object",
+        "required": [
+          "response",
+          "confidence",
+          "processing_time"
+        ],
+        "title": "ChatResponse",
+        "description": "Canonical response body returned by the chat endpoint."
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "MemoryItem": {
+        "properties": {
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "query": {
+            "type": "string",
+            "title": "Query"
+          },
+          "response": {
+            "type": "string",
+            "title": "Response"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp"
+          }
+        },
+        "type": "object",
+        "required": [
+          "user_id",
+          "query",
+          "response"
+        ],
+        "title": "MemoryItem"
+      },
+      "PeerMessage": {
+        "properties": {
+          "payload": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Payload"
+          }
+        },
+        "type": "object",
+        "required": [
+          "payload"
+        ],
+        "title": "PeerMessage",
+        "description": "Payload accepted by the peer message endpoint."
+      },
+      "PeerRegistration": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "maxLength": 2083,
+            "minLength": 1,
+            "format": "uri",
+            "title": "Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "title": "PeerRegistration",
+        "description": "Model describing a peer registration request."
+      },
+      "SuggestRequest": {
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "maxLength": 8000,
+            "minLength": 1,
+            "title": "Prompt"
+          },
+          "actions": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Actions"
+          }
+        },
+        "type": "object",
+        "required": [
+          "prompt"
+        ],
+        "title": "SuggestRequest",
+        "description": "Request body for the UI suggestion endpoint."
+      },
+      "SuggestResponse": {
+        "properties": {
+          "actions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Actions"
+          },
+          "scores": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Scores"
+          },
+          "model": {
+            "type": "string",
+            "title": "Model"
+          }
+        },
+        "type": "object",
+        "required": [
+          "actions",
+          "scores",
+          "model"
+        ],
+        "title": "SuggestResponse",
+        "description": "Response model returned by the UI suggestion endpoint."
+      },
+      "UserRegistration": {
+        "properties": {
+          "username": {
+            "type": "string",
+            "maxLength": 150,
+            "minLength": 1,
+            "title": "Username"
+          },
+          "password": {
+            "type": "string",
+            "minLength": 8,
+            "title": "Password"
+          }
+        },
+        "type": "object",
+        "required": [
+          "username",
+          "password"
+        ],
+        "title": "UserRegistration",
+        "description": "Input payload for user registration requests."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "WSTicketResponse": {
+        "properties": {
+          "ticket": {
+            "type": "string",
+            "title": "Ticket"
+          },
+          "ttl": {
+            "type": "integer",
+            "title": "Ttl"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ticket",
+          "ttl"
+        ],
+        "title": "WSTicketResponse"
+      }
+    },
+    "securitySchemes": {
+      "OAuth2PasswordBearer": {
+        "type": "oauth2",
+        "flows": {
+          "password": {
+            "scopes": {},
+            "tokenUrl": "token"
+          }
+        }
+      }
+    }
+  }
+}

--- a/monGARS/api/schemas.py
+++ b/monGARS/api/schemas.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, Field, HttpUrl, field_validator
+
+USERNAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+class UserRegistration(BaseModel):
+    """Input payload for user registration requests."""
+
+    username: str = Field(..., min_length=1, max_length=150)
+    password: str = Field(..., min_length=8)
+
+    @field_validator("username")
+    @classmethod
+    def validate_username(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("username cannot be blank")
+        if not USERNAME_PATTERN.match(cleaned):
+            raise ValueError(
+                "username may only contain letters, numbers, hyphens, or underscores"
+            )
+        return cleaned
+
+
+class ChatRequest(BaseModel):
+    """Incoming chat message sent to the conversational endpoint."""
+
+    message: str = Field(..., min_length=1, max_length=1000)
+    session_id: str | None = Field(default=None, max_length=100)
+
+    @field_validator("message")
+    @classmethod
+    def validate_message(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("message cannot be empty")
+        return cleaned
+
+    @field_validator("session_id")
+    @classmethod
+    def validate_session_id(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("session_id cannot be empty")
+        return cleaned
+
+
+class ChatResponse(BaseModel):
+    """Canonical response body returned by the chat endpoint."""
+
+    response: str
+    confidence: float
+    processing_time: float
+
+
+class PeerMessage(BaseModel):
+    """Payload accepted by the peer message endpoint."""
+
+    payload: str = Field(..., min_length=1)
+
+    @field_validator("payload")
+    @classmethod
+    def validate_payload(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("payload cannot be empty")
+        return cleaned
+
+
+class PeerRegistration(BaseModel):
+    """Model describing a peer registration request."""
+
+    url: HttpUrl
+
+    @field_validator("url")
+    @classmethod
+    def normalise_url(cls, value: HttpUrl) -> str:
+        return str(value).rstrip("/")
+
+
+class SuggestRequest(BaseModel):
+    """Request body for the UI suggestion endpoint."""
+
+    prompt: str = Field(..., min_length=1, max_length=8000)
+    actions: list[str] | None = None
+
+    @field_validator("prompt")
+    @classmethod
+    def validate_prompt(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("prompt cannot be empty")
+        return cleaned
+
+    @field_validator("actions")
+    @classmethod
+    def validate_actions(cls, value: list[str] | None) -> list[str] | None:
+        if value is None:
+            return None
+        seen: set[str] = set()
+        normalised: list[str] = []
+        for action in value:
+            cleaned = action.strip()
+            if not cleaned:
+                raise ValueError("actions cannot contain empty values")
+            if cleaned not in seen:
+                seen.add(cleaned)
+                normalised.append(cleaned)
+        if not normalised:
+            raise ValueError("actions must include at least one non-empty value")
+        return normalised
+
+
+class SuggestResponse(BaseModel):
+    """Response model returned by the UI suggestion endpoint."""
+
+    actions: list[str]
+    scores: dict[str, float]
+    model: str
+
+
+__all__ = [
+    "ChatRequest",
+    "ChatResponse",
+    "PeerMessage",
+    "PeerRegistration",
+    "SuggestRequest",
+    "SuggestResponse",
+    "UserRegistration",
+]

--- a/monGARS/api/ui.py
+++ b/monGARS/api/ui.py
@@ -2,35 +2,23 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
+from fastapi import APIRouter, Depends
 
 from ..core.aui import DEFAULT_ACTIONS, AUISuggester
 from .authentication import get_current_user
+from .schemas import SuggestRequest, SuggestResponse
 
 router = APIRouter(prefix="/api/v1/ui", tags=["ui"])
 logger = logging.getLogger(__name__)
 _suggester = AUISuggester()
 
 
-class SuggestRequest(BaseModel):
-    prompt: str = Field(..., min_length=1, max_length=8000)
-    actions: list[str] | None = None
-
-
-class SuggestResponse(BaseModel):
-    actions: list[str]
-    scores: dict[str, float]
-    model: str
-
-
 @router.post("/suggestions", response_model=SuggestResponse)
 async def suggestions(
-    body: SuggestRequest, current=Depends(get_current_user)
+    body: SuggestRequest,
+    current=Depends(get_current_user),
 ) -> SuggestResponse:  # noqa: ANN001
-    prompt = body.prompt.strip()
-    if not prompt:
-        raise HTTPException(status_code=422, detail="prompt is empty")
+    prompt = body.prompt
 
     if body.actions:
         desc_map = {

--- a/tests/test_api_schemas.py
+++ b/tests/test_api_schemas.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from monGARS.api.schemas import (
+    ChatRequest,
+    PeerMessage,
+    PeerRegistration,
+    SuggestRequest,
+    UserRegistration,
+)
+
+
+def test_user_registration_strips_and_validates_username() -> None:
+    payload = UserRegistration(username="  alice-01  ", password="supersecret")
+    assert payload.username == "alice-01"
+
+
+def test_user_registration_rejects_bad_username() -> None:
+    with pytest.raises(ValidationError):
+        UserRegistration(username="bad email@example.com", password="supersecret")
+
+
+def test_chat_request_rejects_blank_message() -> None:
+    with pytest.raises(ValidationError):
+        ChatRequest(message="   ", session_id=None)
+
+
+def test_peer_registration_normalises_url() -> None:
+    reg = PeerRegistration(url="https://example.com/api/")
+    assert reg.url == "https://example.com/api"
+
+
+def test_peer_message_requires_payload_content() -> None:
+    with pytest.raises(ValidationError):
+        PeerMessage(payload="   ")
+
+
+def test_suggest_request_deduplicates_actions() -> None:
+    request = SuggestRequest(prompt="generate", actions=[" code ", "code", "summarize"])
+    assert request.actions == ["code", "summarize"]
+
+
+def test_suggest_request_rejects_empty_actions() -> None:
+    with pytest.raises(ValidationError):
+        SuggestRequest(prompt="explain", actions=["   "])


### PR DESCRIPTION
## Summary
- add shared Pydantic request and response models for chat, peer communication, and UI suggestion endpoints
- refactor API routes to reuse the shared schemas and lazily initialize the conversational module
- document and publish the generated OpenAPI specification alongside example Python and TypeScript client guides

## Testing
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68dc06a02e488333aec4d9012264bb25

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/monGARS/91)
<!-- GitContextEnd -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Published an OpenAPI 3.1 specification describing all public endpoints and schemas.

- Documentation
  - Added API catalogue with regeneration and commit guidance.
  - Added Python client example demonstrating typed models and async usage.
  - Added TypeScript client guide for generating a typed SDK.

- Refactor
  - Centralized and standardized API request/response models for consistent validation and behavior.

- Tests
  - Added validation tests covering input normalization and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->