### PR TITLE
Add Alembic migrations and dataset curation safeguards

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,6 +1,6 @@
 [alembic]
 script_location = alembic
-sqlalchemy.url = sqlite:///./test.db
+sqlalchemy.url = postgresql+asyncpg://postgres:postgres@localhost/mongars_db
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,95 @@
+"""Alembic environment for monGARS."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from logging.config import fileConfig
+from pathlib import Path
+
+from sqlalchemy import pool
+from sqlalchemy.engine import Connection, make_url
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+from alembic import context
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from init_db import Base  # noqa: E402
+from monGARS.config import get_settings  # noqa: E402
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+settings = get_settings()
+config.set_main_option("sqlalchemy.url", str(settings.database_url))
+
+target_metadata = Base.metadata
+
+
+def _as_sync_url(async_url: str) -> str:
+    url = make_url(async_url)
+    drivername = url.drivername
+    if "+" in drivername:
+        dialect, _, driver = drivername.partition("+")
+        if "asyncpg" in driver:
+            drivername = dialect
+        else:
+            drivername = dialect
+    elif "asyncpg" in drivername:
+        drivername = "postgresql"
+    return str(url.set(drivername=drivername))
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+
+    url = _as_sync_url(str(settings.database_url))
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        compare_type=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+
+    configuration = config.get_section(config.config_ini_section) or {}
+    configuration["sqlalchemy.url"] = str(settings.database_url)
+
+    connectable = async_engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    async def do_run_migrations(connection: Connection) -> None:
+        context.configure(
+            connection=connection, target_metadata=target_metadata, compare_type=True
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+    async def run_async_migrations() -> None:
+        async with connectable.connect() as connection:
+            await connection.run_sync(do_run_migrations)
+        await connectable.dispose()
+
+    asyncio.run(run_async_migrations())
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,17 @@
+"""${message}"""
+
+revision = ${repr(revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/20250108_01_initial_schema.py
+++ b/alembic/versions/20250108_01_initial_schema.py
@@ -1,0 +1,150 @@
+"""Create core persistence tables"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from pgvector.sqlalchemy import Vector
+
+from alembic import op
+
+revision = "20250108_01"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+
+    op.create_table(
+        "conversation_history",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("user_id", sa.String(), nullable=True),
+        sa.Column("query", sa.String(), nullable=True),
+        sa.Column("response", sa.String(), nullable=True),
+        sa.Column(
+            "timestamp",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("vector", Vector(3072), nullable=True),
+    )
+    op.create_index(
+        "idx_user_timestamp",
+        "conversation_history",
+        ["user_id", "timestamp"],
+    )
+
+    op.create_table(
+        "conversation_sessions",
+        sa.Column("user_id", sa.String(), primary_key=True, nullable=False),
+        sa.Column("session_data", sa.JSON(), nullable=True),
+        sa.Column(
+            "last_active",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+    op.create_table(
+        "user_preferences",
+        sa.Column("user_id", sa.String(), primary_key=True, nullable=False),
+        sa.Column("interaction_style", sa.JSON(), nullable=True),
+        sa.Column("preferred_topics", sa.JSON(), nullable=True),
+    )
+
+    op.create_table(
+        "user_personality",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column("traits", sa.JSON(), nullable=True),
+        sa.Column("interaction_style", sa.JSON(), nullable=True),
+        sa.Column("context_preferences", sa.JSON(), nullable=True),
+        sa.Column(
+            "adaptation_rate", sa.Float(), server_default=sa.text("0.1"), nullable=False
+        ),
+        sa.Column(
+            "confidence", sa.Float(), server_default=sa.text("0.5"), nullable=False
+        ),
+        sa.Column(
+            "last_updated",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("user_id"),
+    )
+    op.create_index(
+        op.f("ix_user_personality_user_id"),
+        "user_personality",
+        ["user_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "emotion_trends",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("user_id", sa.String(), nullable=True),
+        sa.Column("emotion", sa.String(), nullable=True),
+        sa.Column(
+            "timestamp",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+    op.create_table(
+        "interactions",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column("session_id", sa.String(), nullable=True),
+        sa.Column("input_data", sa.JSON(), nullable=True),
+        sa.Column("output_data", sa.JSON(), nullable=True),
+        sa.Column("message", sa.String(), nullable=True),
+        sa.Column("response", sa.String(), nullable=True),
+        sa.Column("personality", sa.JSON(), nullable=True),
+        sa.Column("context", sa.JSON(), nullable=True),
+        sa.Column("meta_data", sa.String(), nullable=True),
+        sa.Column("confidence", sa.Float(), nullable=True),
+        sa.Column("processing_time", sa.Float(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "idx_user_session_created",
+        "interactions",
+        ["user_id", "session_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_user_session_created", table_name="interactions")
+    op.drop_table("interactions")
+
+    op.drop_table("emotion_trends")
+
+    op.drop_index(op.f("ix_user_personality_user_id"), table_name="user_personality")
+    op.drop_table("user_personality")
+
+    op.drop_table("user_preferences")
+
+    op.drop_table("conversation_sessions")
+
+    op.drop_index("idx_user_timestamp", table_name="conversation_history")
+    op.drop_table("conversation_history")
+
+    op.execute("DROP EXTENSION IF EXISTS vector")

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for managing local model artifacts and datasets."""

--- a/models/datasets/__init__.py
+++ b/models/datasets/__init__.py
@@ -1,0 +1,6 @@
+"""Dataset curation helpers."""
+
+from .catalog import DatasetCatalog, DatasetVersion
+from .sanitizer import sanitize_record, scrub_text
+
+__all__ = ["DatasetCatalog", "DatasetVersion", "sanitize_record", "scrub_text"]

--- a/models/datasets/catalog.py
+++ b/models/datasets/catalog.py
@@ -1,0 +1,124 @@
+"""Version catalog management for curated fine-tuning datasets."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class DatasetVersion:
+    """Metadata describing a curated dataset export."""
+
+    version: int
+    run_id: str
+    created_at: datetime
+    dataset_dir: Path
+    dataset_file: Path
+    record_count: int
+    extra: Mapping[str, Any] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "version": self.version,
+            "run_id": self.run_id,
+            "created_at": self.created_at.replace(tzinfo=UTC).isoformat(),
+            "dataset_dir": str(self.dataset_dir),
+            "dataset_file": str(self.dataset_file),
+            "record_count": self.record_count,
+        }
+        if self.extra:
+            payload["extra"] = dict(self.extra)
+        return payload
+
+
+class DatasetCatalog:
+    """Maintain a JSON index of available curated datasets."""
+
+    def __init__(self, root: Path, *, catalog_name: str = "catalog.json") -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.catalog_path = self.root / catalog_name
+        self._cache: dict[str, Any] | None = None
+
+    def register(
+        self,
+        *,
+        run_id: str,
+        dataset_dir: Path,
+        dataset_file: Path,
+        record_count: int,
+        extra: Mapping[str, Any] | None = None,
+    ) -> DatasetVersion:
+        catalog = self._load()
+        next_version = int(catalog.get("latest_version", 0)) + 1
+        version = DatasetVersion(
+            version=next_version,
+            run_id=run_id,
+            created_at=datetime.now(UTC),
+            dataset_dir=dataset_dir,
+            dataset_file=dataset_file,
+            record_count=record_count,
+            extra=extra,
+        )
+        catalog.setdefault("versions", []).append(version.as_dict())
+        catalog["latest_version"] = version.version
+        catalog.setdefault("index", {})[run_id] = version.version
+        self._write_catalog(catalog)
+        log.info(
+            "dataset_version_registered",
+            extra={
+                "run_id": run_id,
+                "version": version.version,
+                "records": record_count,
+            },
+        )
+        return version
+
+    def latest(self) -> DatasetVersion | None:
+        catalog = self._load()
+        versions = catalog.get("versions") or []
+        if not versions:
+            return None
+        payload = versions[-1]
+        return DatasetVersion(
+            version=int(payload["version"]),
+            run_id=str(payload["run_id"]),
+            created_at=datetime.fromisoformat(str(payload["created_at"])),
+            dataset_dir=Path(payload["dataset_dir"]),
+            dataset_file=Path(payload["dataset_file"]),
+            record_count=int(payload["record_count"]),
+            extra=payload.get("extra"),
+        )
+
+    def _load(self) -> dict[str, Any]:
+        if self._cache is not None:
+            return dict(self._cache)
+        if not self.catalog_path.exists():
+            self._cache = {"versions": [], "latest_version": 0, "index": {}}
+            return dict(self._cache)
+        try:
+            data = json.loads(self.catalog_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            log.warning("Failed to parse dataset catalog: %s", exc)
+            data = {"versions": [], "latest_version": 0, "index": {}}
+        self._cache = data
+        return dict(data)
+
+    def _write_catalog(self, catalog: Mapping[str, Any]) -> None:
+        tmp_path = self.catalog_path.with_suffix(".tmp")
+        tmp_path.write_text(
+            json.dumps(catalog, indent=2, sort_keys=True), encoding="utf-8"
+        )
+        tmp_path.replace(self.catalog_path)
+        self._cache = dict(catalog)
+
+
+__all__ = ["DatasetCatalog", "DatasetVersion"]

--- a/models/datasets/sanitizer.py
+++ b/models/datasets/sanitizer.py
@@ -1,0 +1,73 @@
+"""Utilities for removing personally identifiable information from datasets."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+_EMAIL_PATTERN = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
+_PHONE_PATTERN = re.compile(
+    r"(?:(?:\+?\d{1,3}[\s.-]?)?(?:\(\d{2,4}\)|\d{2,4})[\s.-]?\d{3,4}[\s.-]?\d{3,4})"
+)
+_CREDIT_CARD_PATTERN = re.compile(r"\b(?:\d[ -]*?){13,19}\b")
+_IP_PATTERN = re.compile(r"\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d?\d)(?:\.(?!$)|$)){4}\b")
+_UUID_PATTERN = re.compile(
+    r"\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b",
+    re.IGNORECASE,
+)
+
+
+_REPLACEMENTS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (_EMAIL_PATTERN, "[REDACTED_EMAIL]"),
+    (_PHONE_PATTERN, "[REDACTED_PHONE]"),
+    (_CREDIT_CARD_PATTERN, "[REDACTED_PAYMENT]"),
+    (_IP_PATTERN, "[REDACTED_IP]"),
+    (_UUID_PATTERN, "[REDACTED_UUID]"),
+)
+
+
+def scrub_text(text: str) -> str:
+    """Return ``text`` with known PII patterns redacted."""
+
+    cleaned = text
+    total_replacements = 0
+    for pattern, replacement in _REPLACEMENTS:
+        cleaned, replacements = pattern.subn(replacement, cleaned)
+        total_replacements += replacements
+    if total_replacements:
+        log.debug(
+            "pii_redacted",
+            extra={"replacements": total_replacements, "original_length": len(text)},
+        )
+    return cleaned
+
+
+def sanitize_record(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Recursively sanitize mappings so that nested strings are PII-free."""
+
+    sanitized: dict[str, Any] = {}
+    for key, value in record.items():
+        sanitized[key] = _sanitize_value(value)
+    return sanitized
+
+
+def _sanitize_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return scrub_text(value)
+    if isinstance(value, Mapping):
+        return sanitize_record(value)
+    if isinstance(value, Iterable) and not isinstance(value, (bytes, bytearray)):
+        sanitized_items = []
+        for item in value:
+            if isinstance(item, (str, Mapping)):
+                sanitized_items.append(_sanitize_value(item))
+            else:
+                sanitized_items.append(item)
+        if isinstance(value, tuple):
+            return tuple(sanitized_items)
+        return sanitized_items
+    return value


### PR DESCRIPTION
## Summary
- configure Alembic with an async environment and create the initial PostgreSQL migration covering the core tables
- add dataset catalog/version management with PII scrubbing utilities and integrate them into the self-training pipeline
- extend the self-training test suite to validate sanitized datasets and version metadata

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dc0f39f7888333bf4fe4f95f6ac751