### PR TITLE
Improve chat progressive enhancement and event handling

### DIFF
--- a/tests/test_webapp_chat_services.py
+++ b/tests/test_webapp_chat_services.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import pytest
+
+from webapp.chat import services
+
+
+class DummyResponse:
+    def __init__(self, status_code: int, payload: object) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):  # noqa: D401 - mimic httpx API
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+class DummyAsyncClient:
+    def __init__(self, response: DummyResponse, recorder: dict[str, object]):
+        self._response = response
+        self._recorder = recorder
+
+    async def __aenter__(self) -> "DummyAsyncClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    async def post(self, url: str, *, json=None, headers=None):
+        self._recorder["url"] = url
+        self._recorder["json"] = json
+        self._recorder["headers"] = headers
+        return self._response
+
+    async def get(self, url: str, *, params=None, headers=None):
+        self._recorder["url"] = url
+        self._recorder["params"] = params
+        self._recorder["headers"] = headers
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_post_chat_message_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder: dict[str, object] = {}
+    response = DummyResponse(
+        200, {"response": "pong", "confidence": 0.9, "processing_time": 1.2}
+    )
+
+    async_client_factory = lambda *args, **kwargs: DummyAsyncClient(response, recorder)
+    monkeypatch.setattr(services, "FASTAPI_URL", "http://api")
+    monkeypatch.setattr(services.httpx, "AsyncClient", async_client_factory)
+
+    result = await services.post_chat_message("alice", "token-123", "hello")
+
+    assert recorder["url"] == "http://api/api/v1/conversation/chat"
+    assert recorder["json"] == {"message": "hello"}
+    assert recorder["headers"] == {"Authorization": "Bearer token-123"}
+    assert result["response"] == "pong"
+    assert pytest.approx(result["confidence"], rel=1e-3) == 0.9
+    assert pytest.approx(result["processing_time"], rel=1e-3) == 1.2
+
+
+@pytest.mark.asyncio
+async def test_post_chat_message_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder: dict[str, object] = {}
+    response = DummyResponse(503, {"detail": "maintenance"})
+
+    async_client_factory = lambda *args, **kwargs: DummyAsyncClient(response, recorder)
+    monkeypatch.setattr(services, "FASTAPI_URL", "http://api")
+    monkeypatch.setattr(services.httpx, "AsyncClient", async_client_factory)
+
+    result = await services.post_chat_message("alice", "token-123", "hello")
+
+    assert "maintenance" in result["error"]
+    assert recorder["url"] == "http://api/api/v1/conversation/chat"

--- a/webapp/chat/services.py
+++ b/webapp/chat/services.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import logging
 import os
+from typing import Any, TypedDict
 
 import httpx
 
@@ -7,7 +10,23 @@ logger = logging.getLogger(__name__)
 FASTAPI_URL = os.getenv("FASTAPI_URL", "http://localhost:8000")
 
 
-async def fetch_history(user_id: str, token: str) -> dict:
+class ChatResult(TypedDict, total=False):
+    """Result returned by :func:`post_chat_message`."""
+
+    response: str
+    confidence: float
+    processing_time: float
+    error: str
+
+
+async def fetch_history(user_id: str, token: str) -> Any:
+    """Return recent conversation history for ``user_id``.
+
+    The FastAPI endpoint responds with a JSON list sorted from newest to oldest.
+    When the request fails, a mapping containing an ``error`` key is returned so
+    callers can surface a user-friendly message.
+    """
+
     headers = {"Authorization": f"Bearer {token}"}
     try:
         async with httpx.AsyncClient() as client:
@@ -16,12 +35,60 @@ async def fetch_history(user_id: str, token: str) -> dict:
                 params={"user_id": user_id},
                 headers=headers,
             )
-        if resp.status_code == 200:
+    except httpx.HTTPError as exc:  # pragma: no cover - network failure
+        logger.error("fetch_history failed", exc_info=exc)
+        return {"error": f"Impossible de se connecter: {exc}"}
+
+    if resp.status_code == 200:
+        try:
             return resp.json()
-        return {"error": f"Erreur: {resp.status_code}"}
-    except Exception as e:  # pragma: no cover - network failure
-        logger.error("fetch_history failed: %s", e)
-        return {"error": f"Impossible de se connecter: {e}"}
+        except ValueError as exc:
+            logger.error("fetch_history invalid JSON", exc_info=exc)
+            return {"error": "Réponse d'historique invalide"}
+    detail = _extract_error(resp)
+    return {"error": detail or f"Erreur: {resp.status_code}"}
+
+
+async def post_chat_message(user_id: str, token: str, message: str) -> ChatResult:
+    """Send ``message`` to the FastAPI chat endpoint and return the response."""
+
+    headers = {"Authorization": f"Bearer {token}"}
+    payload = {"message": message}
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{FASTAPI_URL}/api/v1/conversation/chat",
+                json=payload,
+                headers=headers,
+            )
+    except httpx.HTTPError as exc:  # pragma: no cover - network failure
+        logger.error("post_chat_message failed", exc_info=exc)
+        return {"error": f"Impossible d'envoyer le message: {exc}"}
+
+    if resp.status_code != 200:
+        detail = _extract_error(resp)
+        return {"error": detail or f"Erreur: {resp.status_code}"}
+
+    try:
+        body: dict[str, Any] = resp.json()
+    except ValueError as exc:
+        logger.error("post_chat_message invalid JSON", exc_info=exc)
+        return {"error": "Réponse inattendue du service de chat"}
+
+    result: ChatResult = {
+        "response": str(body.get("response", "")),
+    }
+    if "confidence" in body:
+        try:
+            result["confidence"] = float(body["confidence"])
+        except (TypeError, ValueError):
+            logger.debug("Confidence value not convertible", exc_info=True)
+    if "processing_time" in body:
+        try:
+            result["processing_time"] = float(body["processing_time"])
+        except (TypeError, ValueError):
+            logger.debug("Processing time value not convertible", exc_info=True)
+    return result
 
 
 async def authenticate_user(username: str, password: str) -> str | None:
@@ -31,8 +98,28 @@ async def authenticate_user(username: str, password: str) -> str | None:
                 f"{FASTAPI_URL}/token",
                 data={"username": username, "password": password},
             )
-        if resp.status_code == 200:
+    except httpx.HTTPError as exc:  # pragma: no cover - network failure
+        logger.error("authenticate_user failed", exc_info=exc)
+        return None
+
+    if resp.status_code == 200:
+        try:
             return resp.json().get("access_token")
-    except Exception as e:  # pragma: no cover - network failure
-        logger.error("authenticate_user failed: %s", e)
+        except ValueError as exc:
+            logger.error("authenticate_user invalid JSON", exc_info=exc)
+            return None
+    return None
+
+
+def _extract_error(resp: httpx.Response) -> str | None:
+    """Return a human-friendly error message from an HTTP response."""
+
+    try:
+        payload = resp.json()
+    except ValueError:
+        return None
+    if isinstance(payload, dict):
+        detail = payload.get("detail") or payload.get("error")
+        if isinstance(detail, str):
+            return detail
     return None

--- a/webapp/chat/templates/chat/index.html
+++ b/webapp/chat/templates/chat/index.html
@@ -23,10 +23,43 @@
           <h4 class="mb-0">Historique du Chat</h4>
           <span id="ws-status" class="badge ws-badge offline" aria-live="polite">Hors ligne</span>
         </div>
-        <section id="connection" class="visually-hidden" aria-live="polite"></section>
+        {% if flash_message %}
+        <div class="alert alert-success" role="status">{{ flash_message }}</div>
+        {% endif %}
+        <section id="connection" class="alert alert-info visually-hidden" role="status" aria-live="polite"></section>
         <main id="chat" class="card shadow-sm">
           <div class="card-body p-0">
-            <div id="transcript" class="chat-transcript" aria-live="polite" aria-busy="false"></div>
+            <div id="transcript" class="chat-transcript" aria-live="polite" aria-busy="false">
+              {% if history_error %}
+              <div class="chat-row chat-system">
+                <div class="chat-bubble chat-bubble-error">{{ history_error }}</div>
+              </div>
+              {% endif %}
+              {% for item in history %}
+                {% if item.query %}
+                <div class="chat-row chat-user">
+                  <div class="chat-bubble">
+                    {{ item.query }}
+                    <div class="chat-meta">{{ item.timestamp|default_if_none:"" }}</div>
+                  </div>
+                </div>
+                {% endif %}
+                {% if item.response %}
+                <div class="chat-row chat-assistant">
+                  <div class="chat-bubble">
+                    {{ item.response }}
+                    <div class="chat-meta">{{ item.timestamp|default_if_none:"" }}</div>
+                  </div>
+                </div>
+                {% endif %}
+              {% empty %}
+              {% if not history_error %}
+              <div class="chat-row chat-system">
+                <div class="chat-bubble chat-bubble-hint">Aucun échange pour le moment.</div>
+              </div>
+              {% endif %}
+              {% endfor %}
+            </div>
             <div id="error-alert" class="alert alert-danger m-3 d-none alert-dismissible fade show" role="alert">
               <span id="error-message"></span>
               <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
@@ -38,9 +71,13 @@
                 <button role="listitem" class="qa btn btn-outline-secondary" data-action="explain">Expliquer</button>
               </div>
             </aside>
-            <form id="composer" class="p-3 border-top" autocomplete="off">
+            <form id="composer" class="p-3 border-top" autocomplete="off" method="post">
+              {% csrf_token %}
+              {% if form_error %}
+              <div class="alert alert-warning" role="alert">{{ form_error }}</div>
+              {% endif %}
               <div class="input-group">
-                <input id="prompt" name="prompt" class="form-control" placeholder="Entrez votre message…" autocomplete="off" />
+                <input id="prompt" name="prompt" class="form-control" placeholder="Entrez votre message…" value="{{ prompt_value }}" autocomplete="off" />
                 <button id="send" type="submit" class="btn btn-primary">Envoyer</button>
               </div>
             </form>
@@ -51,7 +88,7 @@
   </div>
   <!-- Bootstrap 5 JS -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  {{ data|json_script:"chat-history" }}
+  {{ history_json|json_script:"chat-history" }}
   <script>
     window.chatConfig = {
       fastapiUrl: "{{ fastapi_url }}",

--- a/webapp/chat/views.py
+++ b/webapp/chat/views.py
@@ -1,25 +1,81 @@
 import logging
 import os
 import re
+from typing import Any
 
 from django.shortcuts import redirect, render
 
 from .decorators import require_token
-from .services import authenticate_user, fetch_history
+from .services import authenticate_user, fetch_history, post_chat_message
 
 logger = logging.getLogger(__name__)
 
 
 @require_token
 async def index(request):
-    """Show conversation history for the logged-in user."""
-    data = await fetch_history(request.user_id, request.token)
+    """Render the chat interface for the authenticated operator.
+
+    Context:
+        history (list[dict[str, Any]]): Chronological conversation history
+            (oldest first). Empty when history retrieval fails.
+        history_json (list[dict[str, Any]]): Raw history payload passed to the
+            progressive-enhancement bootstrap script.
+        history_error (str | None): Error message displayed when the history API
+            is unavailable.
+        flash_message (str | None): Ephemeral acknowledgement shown after a
+            successful POST when JavaScript is disabled.
+        form_error (str | None): Validation or transport error displayed above
+            the composer.
+        prompt_value (str): Current value shown in the composer input when a
+            submission fails validation.
+        fastapi_url (str): Base URL for the FastAPI service used by the
+            JavaScript layer.
+        user_id (str): Identifier for the authenticated operator.
+        token (str): JWT used by the client-side enhancements.
+    """
+
+    flash_message = request.session.pop("chat_flash", None)
+    form_error = None
+    prompt_value = ""
+
+    if request.method == "POST":
+        prompt_value = request.POST.get("prompt", "").strip()
+        if not prompt_value:
+            form_error = "Le message ne peut pas être vide."
+        else:
+            result = await post_chat_message(
+                request.user_id, request.token, prompt_value
+            )
+            error = result.get("error") if isinstance(result, dict) else None
+            if error:
+                form_error = error
+            else:
+                request.session["chat_flash"] = "Message envoyé avec succès."
+                return redirect("index")
+
+    history_raw: Any = await fetch_history(request.user_id, request.token)
+    history_error: str | None = None
+    history: list[dict[str, Any]] = []
+    history_json: list[dict[str, Any]] = []
+    if isinstance(history_raw, dict) and history_raw.get("error"):
+        history_error = str(history_raw.get("error"))
+    elif isinstance(history_raw, list):
+        history_json = history_raw
+        history = list(reversed(history_raw))
+    else:
+        history_error = "Historique indisponible pour le moment."
+
     fastapi_url = os.environ.get("FASTAPI_URL", "http://localhost:8000")
     return render(
         request,
         "chat/index.html",
         {
-            "data": data,
+            "history": history,
+            "history_json": history_json,
+            "history_error": history_error,
+            "flash_message": flash_message,
+            "form_error": form_error,
+            "prompt_value": prompt_value,
             "fastapi_url": fastapi_url,
             "user_id": request.user_id,
             "token": request.token,


### PR DESCRIPTION
## Summary
- add robust chat service helpers and async view handling to support server-side submissions with clear feedback
- render chat history and composer fallbacks in the Django template so the interface works without JavaScript
- enhance the WebSocket client to handle connection and history snapshot events while avoiding duplicate history rendering
- cover the new chat proxy logic with asynchronous unit tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dc2cf31a788333b5f0a38a05f785a1