### PR TITLE
Harden JWT configuration validation and add environment template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# monGARS configuration example
+# Copy this file to .env and adjust values for your deployment.
+
+# Core FastAPI settings
+DEBUG=true
+SECRET_KEY=dev-secret-change-me
+# Use HS256 when signing tokens with SECRET_KEY. To enable RS256, set
+# JWT_ALGORITHM=RS256 and provide JWT_PRIVATE_KEY/JWT_PUBLIC_KEY entries in Vault.
+JWT_ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=60
+
+# Database connection string (asyncpg driver)
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost/mongars_db
+
+# Redis cache URL
+REDIS_URL=redis://localhost:6379/0
+
+# Optional OpenTelemetry collector endpoint
+OTEL_COLLECTOR_URL=http://localhost:4318
+OTEL_METRICS_ENABLED=false
+OTEL_TRACES_ENABLED=false
+
+# Vault integration (leave empty to skip)
+VAULT_URL=
+VAULT_TOKEN=


### PR DESCRIPTION
## Summary
- add runtime validation to ensure JWT algorithm choices align with available signing material
- enforce the check during settings initialization and document HS256 usage in a new `.env.example`
- cover the configuration guardrails with dedicated unit tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dc419010308333b31dccd050b6eb85