### PR TITLE
Add automated guardrail for incomplete logic markers

### DIFF
--- a/docs/incomplete_logic_audit.md
+++ b/docs/incomplete_logic_audit.md
@@ -1,6 +1,6 @@
 # Incomplete Logic Audit
 
-_Date: 2025-03-18_
+## Date: 2025-09-30
 
 This follow-up audit re-runs and expands the repository-wide scan for patterns
 that typically signal unfinished implementations. The review covered the core


### PR DESCRIPTION
## Summary
- add a pytest guardrail that scans Python sources for TODO/FIXME/XXX markers and unapproved NotImplementedError usage
- document the new safeguard in the incomplete logic audit write-up

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dc54336db4833394d47e8d030c85d3

## Summary by Sourcery

Add an automated pytest guardrail to fail CI on any TODO, FIXME, XXX markers or unapproved NotImplementedError usage in Python sources and include a detailed incomplete logic audit document in the docs.

New Features:
- Introduce a pytest test that scans all Python files for TODO/FIXME/XXX markers and unauthorized NotImplementedError occurrences.
- Allowlist specific NotImplementedError lines in designated test doubles to avoid false positives.

Documentation:
- Add an incomplete logic audit write-up detailing the scan methodology, findings, and guardrail integration in docs/incomplete_logic_audit.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an audit report outlining an “incomplete logic” review (scope, methodology, findings, and recommendations). No runtime behavior changes.

* **Tests**
  * Introduced a guardrail test that scans the codebase for TODO/FIXME/XXX and NotImplementedError occurrences outside an allowlist, failing if violations are found. Improves code completeness and quality assurance without impacting users. The test gracefully handles encoding and parsing edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->