### PR TITLE
Fix async engine initialization with Postgres DSN

### DIFF
--- a/init_db.py
+++ b/init_db.py
@@ -86,7 +86,7 @@ class Interaction(Base):
 
 
 async_engine = create_async_engine(
-    settings.database_url,
+    str(settings.database_url),
     echo=settings.debug,
     pool_size=settings.db_pool_size,
     max_overflow=settings.db_max_overflow,

--- a/monGARS/config.py
+++ b/monGARS/config.py
@@ -248,7 +248,8 @@ class Settings(BaseSettings):
         except ValueError as exc:  # pragma: no cover - configuration error
             raise ValueError("Invalid REDIS_URL provided") from exc
 
-        return self.model_copy(update={"redis_url": override})
+        object.__setattr__(self, "redis_url", override)
+        return self
 
 
 def ensure_secret_key(


### PR DESCRIPTION
## Summary
- cast the Postgres DSN to a string before passing it to SQLAlchemy's async engine factory
- keep the Redis override validator returning the validated settings instance

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dc6cc117c0833389cfb026c76650cc

## Summary by Sourcery

Fix async engine initialization by casting the database URL to a string and correct the Redis URL override validator to mutate and return the settings instance

Bug Fixes:
- Cast Postgres DSN to string before creating the async SQLAlchemy engine
- Have Redis override validator update the settings instance in place and return it