### PR TITLE
Add automated Docker deployment stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,16 +4,28 @@
 # Core FastAPI settings
 DEBUG=true
 SECRET_KEY=dev-secret-change-me
+# Ports exposed by docker-compose services
+API_PORT=8000
+WEBAPP_PORT=8001
+POSTGRES_PORT=5432
+REDIS_PORT=6379
+MLFLOW_PORT=5000
+VAULT_PORT=8200
+OLLAMA_PORT=11434
+RAY_HTTP_PORT=8000
+RAY_DASHBOARD_PORT=8265
 # Use HS256 when signing tokens with SECRET_KEY. To enable RS256, set
 # JWT_ALGORITHM=RS256 and provide JWT_PRIVATE_KEY/JWT_PUBLIC_KEY entries in Vault.
 JWT_ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=60
 
 # Database connection string (asyncpg driver)
-DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost/mongars_db
+# Replace `postgres` with `localhost` if you run Postgres outside of Docker.
+DATABASE_URL=postgresql+asyncpg://mongars:changeme@postgres/mongars_db
+DB_PASSWORD=changeme
 
 # Redis cache URL
-REDIS_URL=redis://localhost:6379/0
+REDIS_URL=redis://redis:6379/0
 
 # Optional OpenTelemetry collector endpoint
 OTEL_COLLECTOR_URL=http://localhost:4318
@@ -21,5 +33,21 @@ OTEL_METRICS_ENABLED=false
 OTEL_TRACES_ENABLED=false
 
 # Vault integration (leave empty to skip)
-VAULT_URL=
-VAULT_TOKEN=
+VAULT_URL=http://vault:8200
+VAULT_TOKEN=dev-root-token
+
+# Django operator console defaults
+DJANGO_SECRET_KEY=django-insecure-change-me
+DJANGO_DEBUG=false
+DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
+FASTAPI_URL=http://api:8000
+
+# Distributed inference toggles
+USE_RAY_SERVE=false
+RAY_SERVE_URL=http://rayserve:8000/generate
+
+# Ollama connectivity
+OLLAMA_HOST=http://ollama:11434
+
+# WebSocket origin whitelist for the API layer
+WS_ALLOWED_ORIGINS=["http://localhost:8000","http://localhost:8001"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN python -m venv /opt/venv \
 COPY . /app
 
 # --- Final Stage ---
-FROM nvcr.io/nvidia/pytorch:23.10-py3-runtime
+FROM nvcr.io/nvidia/pytorch:23.10-py3-runtime AS runtime
 RUN groupadd --system --gid 10001 mongars \
     && useradd --system --uid 10001 --gid mongars --create-home --home-dir /home/mongars mongars
 WORKDIR /app
@@ -20,4 +20,4 @@ ENV PATH="/opt/venv/bin:${PATH}"
 USER mongars
 
 EXPOSE 8000
-CMD ["uvicorn", "monGARS.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "monGARS.api.web_api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -111,11 +111,23 @@ uvicorn monGARS.api.web_api:app --host 0.0.0.0 --port 8000 --reload
 
 ### Docker Compose Stack
 ```bash
-./setup.sh               # installs Python deps and pre-flight tooling
-cp .env.example .env
-docker-compose up        # FastAPI, Postgres, Redis, MLflow, Vault, Ollama
+scripts/deploy_docker.sh up --pull         # build images, generate secrets, start core services
+scripts/deploy_docker.sh up --with-all     # include Ollama and Ray Serve profiles
+scripts/deploy_docker.sh logs api          # follow API logs
+scripts/deploy_docker.sh destroy           # stop stack and drop volumes
 ```
-Use `docker-compose down -v` to reset stateful services when required.
+
+The helper script automatically creates `.env` from `.env.example`, rotates
+development secrets, and keeps your Compose project name consistent. Optional
+profiles:
+
+- `--with-ollama` downloads and runs the Ollama runtime for local LLMs.
+- `--with-ray` provisions a Ray Serve control plane; toggle `USE_RAY_SERVE=true`
+  and update `RAY_SERVE_URL` in `.env` to route traffic through it.
+
+Use `scripts/deploy_docker.sh ps` to inspect container health and
+`scripts/deploy_docker.sh destroy` when you need a clean slate (volumes and
+orphan containers are removed).
 
 ### Django Operator Console
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,90 +1,254 @@
-version: '3.8'
+version: "3.9"
+
+x-app-environment: &app-environment
+  ENV: production
+  HOST: 0.0.0.0
+  PORT: ${API_PORT:-8000}
+  USE_RAY_SERVE: ${USE_RAY_SERVE:-false}
+  RAY_SERVE_URL: ${RAY_SERVE_URL:-http://rayserve:8000/generate}
+  DATABASE_URL: postgresql+asyncpg://mongars:${DB_PASSWORD:-changeme}@postgres:5432/mongars_db
+  REDIS_URL: redis://redis:6379/0
+  MLFLOW_TRACKING_URI: http://mlflow:5000
+  OLLAMA_HOST: ${OLLAMA_HOST:-http://ollama:11434}
+  VAULT_URL: http://vault:8200
+  VAULT_TOKEN: ${VAULT_TOKEN:-dev-root-token}
+  WS_ALLOWED_ORIGINS: ${WS_ALLOWED_ORIGINS:-["http://localhost:8000","http://localhost:8001"]}
 
 services:
-  app:
-    build: .
-    ports:
-      - "${PORT:-8000}:8000"
+  migrations:
+    image: ${MONGARS_IMAGE:-mongars-app:latest}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: runtime
+    command: ["python", "init_db.py"]
+    restart: "no"
+    env_file:
+      - .env
     environment:
-      - ENV=production
-      - PORT=8000
-      - USE_RAY_SERVE=False
-    volumes:
-      - .:/app
+      <<: *app-environment
     depends_on:
       postgres:
         condition: service_healthy
+    networks:
+      - mongars
+
+  api:
+    image: ${MONGARS_IMAGE:-mongars-app:latest}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: runtime
+    depends_on:
+      migrations:
+        condition: service_completed_successfully
       redis:
         condition: service_healthy
+      postgres:
+        condition: service_healthy
+      vault:
+        condition: service_healthy
+      mlflow:
+        condition: service_healthy
+    ports:
+      - "${API_PORT:-8000}:8000"
+    env_file:
+      - .env
+    environment:
+      <<: *app-environment
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - >-
+          python -c "import http.client,sys; conn=http.client.HTTPConnection('127.0.0.1',8000,timeout=5);
+          conn.request('GET','/healthz');
+          sys.exit(0 if conn.getresponse().status == 200 else 1)"
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - mongars
+
+  webapp:
+    image: ${MONGARS_IMAGE:-mongars-app:latest}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: runtime
+    command: >-
+      bash -lc "python webapp/manage.py migrate --noinput &&
+      python webapp/manage.py runserver 0.0.0.0:8001"
+    depends_on:
+      api:
+        condition: service_started
+    ports:
+      - "${WEBAPP_PORT:-8001}:8001"
+    env_file:
+      - .env
+    environment:
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-django-insecure-change-me}
+      DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-localhost,127.0.0.1}
+      DJANGO_DEBUG: ${DJANGO_DEBUG:-false}
+      FASTAPI_URL: http://api:8000
+      PYTHONUNBUFFERED: "1"
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - >-
+          python -c "import http.client,sys; conn=http.client.HTTPConnection('127.0.0.1',8001,timeout=5);
+          conn.request('GET','/chat/login/');
+          sys.exit(0 if conn.getresponse().status == 200 else 1)"
+      interval: 45s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - mongars
 
   postgres:
-    image: ankane/pgvector
+    image: ankane/pgvector:latest
+    container_name: mongars-postgres
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
+    environment:
+      POSTGRES_USER: mongars
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-changeme}
+      POSTGRES_DB: mongars_db
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U mongars"]
+      test: ["CMD-SHELL", "pg_isready -U mongars -d mongars_db"]
       interval: 5s
       timeout: 5s
       retries: 5
-    environment:
-      POSTGRES_USER: mongars
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
-      POSTGRES_DB: mongars_db
     volumes:
       - pgdata:/var/lib/postgresql/data
+    restart: unless-stopped
+    networks:
+      - mongars
 
   redis:
     image: redis/redis-stack-server:latest
+    container_name: mongars-redis
     ports:
-      - "6379:6379"
+      - "${REDIS_PORT:-6379}:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
-      interval: 1s
+      interval: 5s
       timeout: 3s
-      retries: 5
+      retries: 10
     volumes:
       - redisdata:/data
+    restart: unless-stopped
+    networks:
+      - mongars
 
   mlflow:
-    image: mlflow/mlflow
+    image: ghcr.io/mlflow/mlflow:v2.16.2
+    container_name: mongars-mlflow
+    command:
+      - mlflow
+      - server
+      - --host
+      - 0.0.0.0
+      - --port
+      - "5000"
+      - --backend-store-uri
+      - sqlite:////mlflow/mlflow.db
+      - --default-artifact-root
+      - /mlruns
     ports:
-      - "5000:5000"
-    environment:
-      MLFLOW_TRACKING_URI: ${MLFLOW_TRACKING_URI}
+      - "${MLFLOW_PORT:-5000}:5000"
     volumes:
-      - ./mlruns:/mlruns
+      - mlflowdata:/mlflow
+      - mlruns:/mlruns
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - >-
+          python -c "import http.client,sys; conn=http.client.HTTPConnection('127.0.0.1',5000,timeout=5);
+          conn.request('GET','/api/2.0/mlflow/experiments/list');
+          sys.exit(0 if conn.getresponse().status == 200 else 1)"
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - mongars
 
   ollama:
-    image: ollama/ollama
+    image: ollama/ollama:latest
+    container_name: mongars-ollama
+    profiles:
+      - inference
     ports:
-      - "11434:11434"
+      - "${OLLAMA_PORT:-11434}:11434"
+    environment:
+      OLLAMA_KEEP_ALIVE: 24h
     volumes:
-      - ollama:/root/.ollama
+      - ollamadata:/root/.ollama
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - "curl -fsS http://127.0.0.1:11434/api/tags >/dev/null"
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - mongars
 
   vault:
-    image: vault:1.9.2
+    image: hashicorp/vault:1.15
+    container_name: mongars-vault
     environment:
-      VAULT_DEV_ROOT_TOKEN_ID: ${VAULT_TOKEN}
+      VAULT_DEV_ROOT_TOKEN_ID: ${VAULT_TOKEN:-dev-root-token}
       VAULT_DEV_LISTEN_ADDRESS: "0.0.0.0:8200"
+    cap_add:
+      - IPC_LOCK
     ports:
-      - "8200:8200"
+      - "${VAULT_PORT:-8200}:8200"
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - "vault status -address=http://127.0.0.1:8200 >/dev/null"
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - mongars
 
   rayserve:
-    image: rayproject/ray:latest
+    image: rayproject/ray:2.48.0-py311
+    container_name: mongars-rayserve
+    profiles:
+      - ray
     environment:
       - PYTHONUNBUFFERED=1
-    command: >
-      bash -c "pip install ray[serve] && ray start --head --include-dashboard false --port=8265 && python -m ray.serve.start"
+    command: >-
+      bash -lc "pip install --no-cache-dir 'ray[serve]==2.48.0' &&
+      serve start --http-host 0.0.0.0 --http-port 8000 --dashboard-host 0.0.0.0 --ray-remote-address=''"
     ports:
-      - "8265:8265"
-    deploy:
-      replicas: 1
-      resources:
-        limits:
-          cpu: "2"
-          memory: "4Gi"
+      - "${RAY_HTTP_PORT:-8000}:8000"
+      - "${RAY_DASHBOARD_PORT:-8265}:8265"
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - "curl -fsS http://127.0.0.1:8265 >/dev/null"
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - mongars
+
+networks:
+  mongars:
+    driver: bridge
 
 volumes:
   pgdata:
   redisdata:
-  ollama:
+  mlflowdata:
+  mlruns:
+  ollamadata:

--- a/monGARS_structure.txt
+++ b/monGARS_structure.txt
@@ -11,6 +11,8 @@ monGARS/
 ├── pyproject.toml
 ├── requirements.txt
 ├── setup.py
+├── scripts/
+│   └── deploy_docker.sh
 ├── tasks.py
 ├── tests/
 │   ├── __init__.py

--- a/scripts/deploy_docker.sh
+++ b/scripts/deploy_docker.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+COMPOSE_FILE="${PROJECT_ROOT}/docker-compose.yml"
+ENV_FILE="${PROJECT_ROOT}/.env"
+PROJECT_NAME=${COMPOSE_PROJECT_NAME:-mongars}
+
+log() {
+  printf '\033[1;34m[monGARS]\033[0m %s\n' "$1"
+}
+
+warn() {
+  printf '\033[1;33m[monGARS]\033[0m %s\n' "$1"
+}
+
+err() {
+  printf '\033[1;31m[monGARS]\033[0m %s\n' "$1" >&2
+}
+
+ensure_tool() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    err "Required tool '$1' is not installed or not on PATH."
+    exit 1
+  fi
+}
+
+resolve_compose_command() {
+  if docker compose version >/dev/null 2>&1; then
+    COMPOSE_BIN=(docker compose)
+    return
+  fi
+  if command -v docker-compose >/dev/null 2>&1; then
+    COMPOSE_BIN=(docker-compose)
+    return
+  fi
+  err "Docker Compose plugin or docker-compose binary is required."
+  exit 1
+}
+
+compose() {
+  "${COMPOSE_BIN[@]}" -f "$COMPOSE_FILE" --project-name "$PROJECT_NAME" "$@"
+}
+
+ensure_env_file() {
+  local template="${PROJECT_ROOT}/.env.example"
+  if [[ ! -f "$template" ]]; then
+    err "Missing template file: $template"
+    exit 1
+  fi
+  if [[ ! -f "$ENV_FILE" ]]; then
+    cp "$template" "$ENV_FILE"
+    log "Created .env from .env.example"
+  fi
+  python3 <<'PY' "$ENV_FILE"
+import secrets
+import sys
+from pathlib import Path
+
+env_path = Path(sys.argv[1])
+content = env_path.read_text().splitlines()
+entries: dict[str, str] = {}
+for line in content:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in line:
+        continue
+    key, _, value = line.partition("=")
+    entries[key] = value
+
+def requires_refresh(value: str | None) -> bool:
+    if value is None:
+        return True
+    candidate = value.strip()
+    if not candidate:
+        return True
+    return candidate in {
+        "changeme",
+        "dev-secret-change-me",
+        "django-insecure-change-me",
+    }
+
+updates: dict[str, str] = {}
+if requires_refresh(entries.get("SECRET_KEY")):
+    updates["SECRET_KEY"] = secrets.token_urlsafe(64)
+if requires_refresh(entries.get("DJANGO_SECRET_KEY")):
+    updates["DJANGO_SECRET_KEY"] = secrets.token_urlsafe(64)
+if requires_refresh(entries.get("DB_PASSWORD")):
+    updates["DB_PASSWORD"] = secrets.token_urlsafe(24)
+if requires_refresh(entries.get("VAULT_TOKEN")):
+    updates["VAULT_TOKEN"] = secrets.token_hex(16)
+
+if not updates:
+    sys.exit(0)
+
+updated_lines = []
+for line in content:
+    if "=" not in line or line.lstrip().startswith("#"):
+        updated_lines.append(line)
+        continue
+    key, _, _ = line.partition("=")
+    if key in updates:
+        updated_lines.append(f"{key}={updates[key]}")
+        updates.pop(key)
+    else:
+        updated_lines.append(line)
+
+for key, value in updates.items():
+    updated_lines.append(f"{key}={value}")
+
+env_path.write_text("\n".join(updated_lines) + "\n")
+print("Refreshed sensitive defaults in", env_path)
+PY
+}
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/deploy_docker.sh <command> [options] [-- additional docker compose args]
+
+Commands:
+  up            Build (unless --no-build) and start the stack in the background.
+  down          Stop services while preserving volumes.
+  destroy       Stop services and remove volumes and orphaned containers.
+  restart       Restart running services.
+  logs          Tail service logs (default: all).
+  ps|status     Show service status.
+
+Options (for `up` unless noted):
+  --with-ollama    Include the Ollama profile (downloads ~12GB image).
+  --with-ray       Include the Ray Serve profile.
+  --with-all       Enable all optional profiles.
+  --pull           Run `docker compose pull` before starting.
+  --no-build       Skip image rebuild during `up`.
+  -h, --help       Show this help message.
+
+Examples:
+  scripts/deploy_docker.sh up --with-ollama
+  scripts/deploy_docker.sh logs api
+  scripts/deploy_docker.sh destroy
+USAGE
+}
+
+main() {
+  ensure_tool docker
+  resolve_compose_command
+
+  if [[ $# -eq 0 ]]; then
+    usage
+    exit 1
+  fi
+
+  local command="$1"
+  shift || true
+
+  local profiles=()
+  local pull_before=0
+  local build_images=1
+  local passthrough=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --with-ollama)
+        profiles+=(inference)
+        ;;
+      --with-ray)
+        profiles+=(ray)
+        ;;
+      --with-all)
+        profiles+=(inference ray)
+        ;;
+      --profile)
+        shift
+        profiles+=("$1")
+        ;;
+      --pull)
+        pull_before=1
+        ;;
+      --no-build)
+        build_images=0
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      --)
+        shift
+        passthrough+=("$@")
+        break
+        ;;
+      *)
+        passthrough+=("$1")
+        ;;
+    esac
+    shift || true
+  done
+
+  local profile_args=()
+  if [[ ${#profiles[@]} -gt 0 ]]; then
+    declare -A seen
+    for profile in "${profiles[@]}"; do
+      if [[ -n "${profile}" && -z "${seen[$profile]+_}" ]]; then
+        profile_args+=(--profile "$profile")
+        seen[$profile]=1
+      fi
+    done
+  fi
+
+  case "$command" in
+    up)
+      ensure_env_file
+      if (( pull_before )); then
+        log "Pulling container images"
+        compose "${profile_args[@]}" pull
+      fi
+      local up_args=(-d)
+      if (( build_images )); then
+        up_args+=(--build)
+      fi
+      log "Starting docker-compose stack"
+      compose "${profile_args[@]}" up "${up_args[@]}" "${passthrough[@]}"
+      log "Services status:"
+      compose "${profile_args[@]}" ps
+      ;;
+    down)
+      log "Stopping services"
+      compose down "${passthrough[@]}"
+      ;;
+    destroy)
+      log "Removing services, volumes, and orphans"
+      compose down -v --remove-orphans "${passthrough[@]}"
+      ;;
+    restart)
+      log "Restarting services"
+      compose restart "${passthrough[@]}"
+      ;;
+    logs)
+      log "Streaming logs"
+      compose logs -f "${passthrough[@]}"
+      ;;
+    ps|status)
+      compose ps "${passthrough[@]}"
+      ;;
+    *)
+      err "Unknown command: $command"
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- replace the docker-compose definition with a full stack that wires the API, Django console, Postgres, Redis, MLflow, Vault, and optional Ollama/Ray services with health checks and migrations
- add a deployment helper script plus refreshed `.env.example` defaults and structure docs so secrets and ports are ready for Compose
- document the new workflow in the README so operators can launch, inspect, and tear down the stack with one command

## Testing
- black .
- isort .
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68dc75cac9788333af3b3a0eeffcf15f