### PR TITLE
Resolve merge conflicts for LLM provisioning readiness

### DIFF
--- a/monGARS/core/model_manager.py
+++ b/monGARS/core/model_manager.py
@@ -356,9 +356,9 @@ class LLMModelManager:
         self, role: str, payload: Any
     ) -> ModelDefinition | None:
         if isinstance(payload, str):
-            return _DEFAULT_MODELS.get(
-                role.lower(), _DEFAULT_MODELS["general"]
-            ).with_name(payload)
+            role_key = role.lower()
+            base_definition = _DEFAULT_MODELS.get(role_key, _DEFAULT_MODELS["general"])
+            return replace(base_definition, role=role_key, name=str(payload))
         if not isinstance(payload, Mapping):
             return None
         name_value = payload.get("name") or payload.get("model") or payload.get("id")
@@ -374,6 +374,13 @@ class LLMModelManager:
         auto_download = payload.get("auto_download")
         if auto_download is None:
             auto_download_flag = True
+        elif isinstance(auto_download, str):
+            auto_download_flag = auto_download.strip().lower() in {
+                "true",
+                "1",
+                "yes",
+                "on",
+            }
         else:
             auto_download_flag = bool(auto_download)
         description = payload.get("description")

--- a/tests/test_llm_model_manager.py
+++ b/tests/test_llm_model_manager.py
@@ -31,7 +31,7 @@ def test_model_manager_loads_profile_from_config(tmp_path):
                     "coding": {
                         "name": "ollama/custom-coder",
                         "provider": "ollama",
-                        "auto_download": False,
+                        "auto_download": "false",
                     },
                 }
             }
@@ -53,6 +53,26 @@ def test_model_manager_loads_profile_from_config(tmp_path):
     coding = manager.get_model_definition("coding")
     assert coding.name == "ollama/custom-coder"
     assert coding.auto_download is False
+
+
+def test_model_definition_string_entries_preserve_role(tmp_path):
+    config_data = {
+        "profiles": {
+            "default": {
+                "models": {
+                    "summarisation": "ollama/summarise",
+                }
+            }
+        }
+    }
+    config_path = _write_config(tmp_path / "models.json", config_data)
+    settings = _build_settings(llm_models_config_path=config_path)
+
+    manager = LLMModelManager(settings)
+
+    definition = manager.get_model_definition("summarisation")
+    assert definition.role == "summarisation"
+    assert definition.name == "ollama/summarise"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### **User description**
## Summary
- tighten the LLM integration readiness check to only mark models ready when provisioning reports contain successful statuses
- update the model manager tests to construct settings from the cached configuration helper while preserving coverage for string-based auto-download flags

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd3dcbbea483338c2dfa0f241f8454


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Tighten LLM readiness check to require all models successful

- Fix model definition parsing for string-based configurations

- Add string auto-download flag parsing support

- Preserve role information in model definitions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Model Manager"] --> B["Parse String Config"]
  B --> C["Preserve Role Info"]
  A --> D["Ensure Models"]
  D --> E["Check All Success"]
  E --> F["Set Ready Status"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>llm_integration.py</strong><dd><code>Tighten model readiness validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

monGARS/core/llm_integration.py

<ul><li>Add <code>all_success</code> tracking for model provisioning<br> <li> Only mark models ready when all statuses are successful<br> <li> Include "skipped" as valid success action</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/108/files#diff-61b8bef18961794dbc8434d91ef826d7f4c69d60d6bb7c40689ae37a4aa7649d">+26/-21</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>model_manager.py</strong><dd><code>Fix model definition parsing for strings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

monGARS/core/model_manager.py

<ul><li>Fix string model definition parsing with <code>replace()</code><br> <li> Add string-based auto_download flag parsing<br> <li> Preserve role information in model definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/108/files#diff-48405832997c5265bd2f3b559115779de00fa00f2755008f1ca6c742725fad02">+10/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_llm_model_manager.py</strong><dd><code>Add string configuration parsing tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_llm_model_manager.py

<ul><li>Change auto_download test value to string "false"<br> <li> Add test for string model entries preserving role</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/108/files#diff-6bd05242110a69a7dda2572fdc9b1f7ddf19d7ff408c017af65fa77ed8592250">+21/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

