### PR TITLE
Resolve PR #103 conflicts and stabilize scheduler metrics logging

### DIFF
--- a/monGARS/core/distributed_scheduler.py
+++ b/monGARS/core/distributed_scheduler.py
@@ -244,6 +244,7 @@ class DistributedScheduler:
             for index in range(self.concurrency)
         ]
         try:
+            await self._emit_metrics_log(force=True)
             while self._running:
                 await asyncio.sleep(0.1)
                 await self._update_metrics()


### PR DESCRIPTION
### **User description**
## Summary
- reconcile the PR #103 branch with current work by keeping the validated LLM model caching logic
- ensure the LLM model manager tests use `get_settings()` after the merge
- emit an initial metrics log entry when the distributed scheduler starts so fast runs still satisfy telemetry expectations

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd43efb9a48333ab7b7eb73303c4a9


___

### **PR Type**
Bug fix


___

### **Description**
- Add initial metrics log emission on scheduler startup

- Ensure telemetry expectations are met for fast runs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Scheduler Start"] --> B["Configure Metrics"] --> C["Emit Initial Metrics"] --> D["Main Loop"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>distributed_scheduler.py</strong><dd><code>Add initial metrics emission on startup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

monGARS/core/distributed_scheduler.py

<ul><li>Add forced metrics log emission immediately after scheduler startup<br> <li> Ensures initial telemetry data is captured before main loop begins</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/109/files#diff-dc21c83493be247a35ed791ed9a82512cbf5231318e3405072e0bc35181a759f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

