### PR TITLE
Enhance Iris document extraction with trafilatura

### DIFF
--- a/monGARS/core/iris.py
+++ b/monGARS/core/iris.py
@@ -1,7 +1,14 @@
+"""Utilities for lightweight web retrieval used in the curiosity engine."""
+
+from __future__ import annotations
+
 import asyncio
+import json
 import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Optional
-from urllib.parse import quote_plus, urlparse
+from urllib.parse import parse_qs, quote_plus, unquote, urlparse
 
 import httpx
 import trafilatura
@@ -9,49 +16,322 @@ from bs4 import BeautifulSoup
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_HEADERS: Mapping[str, str] = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+
+@dataclass(slots=True)
+class IrisDocument:
+    """Structured representation of extracted web content."""
+
+    url: str
+    text: str | None
+    title: str | None = None
+    summary: str | None = None
+    language: str | None = None
+
 
 class Iris:
-    """Simple web scraper for retrieving page summaries."""
+    """Retrieve lightweight snippets from the public web with resiliency."""
 
-    _semaphore = asyncio.Semaphore(5)
+    def __init__(
+        self,
+        *,
+        max_concurrency: int = 5,
+        request_timeout: float = 10.0,
+        max_retries: int = 2,
+        backoff_factor: float = 0.5,
+        max_content_length: int = 1_500_000,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
+        if max_concurrency <= 0:
+            msg = "max_concurrency must be a positive integer"
+            raise ValueError(msg)
+        if max_retries < 0:
+            msg = "max_retries cannot be negative"
+            raise ValueError(msg)
+        if max_content_length <= 0:
+            msg = "max_content_length must be positive"
+            raise ValueError(msg)
+
+        self._semaphore = asyncio.Semaphore(max_concurrency)
+        self._timeout = httpx.Timeout(request_timeout)
+        self._max_retries = max_retries
+        self._backoff_factor = backoff_factor
+        self._max_content_length = max_content_length
+        merged_headers = dict(_DEFAULT_HEADERS)
+        if headers:
+            merged_headers.update(headers)
+        self._client_options = {
+            "headers": merged_headers,
+            "timeout": self._timeout,
+            "follow_redirects": True,
+            "limits": httpx.Limits(
+                max_connections=max_concurrency * 2,
+                max_keepalive_connections=max_concurrency,
+            ),
+        }
+
+    async def fetch_document(self, url: str) -> IrisDocument | None:
+        """Fetch structured content for ``url`` using trafilatura extraction."""
+
+        response = await self._get_response(url)
+        if response is None:
+            return None
+        document = self._extract_document(response)
+        return document
 
     async def fetch_text(self, url: str) -> Optional[str]:
-        """Fetch page text after validating the URL."""
-        parsed = urlparse(url)
-        if parsed.scheme not in {"http", "https"}:
-            logger.error("Invalid URL: %s", url)
-            return None
-        async with self._semaphore, httpx.AsyncClient() as client:
-            try:
-                response = await client.get(url, timeout=10)
-                response.raise_for_status()
-                text = trafilatura.extract(response.text)
-                return text.strip() if text else None
-            except (
-                httpx.RequestError,
-                httpx.HTTPStatusError,
-            ) as e:  # pragma: no cover - network issues
-                logger.error("Iris fetch error for %s: %s", url, e)
-                return None
+        """Fetch the main textual content for a given HTTP(S) URL."""
+
+        document = await self.fetch_document(url)
+        return document.text if document and document.text else None
 
     async def search(self, query: str) -> Optional[str]:
-        """Return snippet from the first DuckDuckGo result."""
+        """Return contextual snippet using the first DuckDuckGo result for *query*."""
+
         query = query.strip()
         if not query:
+            logger.debug("iris.search.empty_query")
             return None
+
         search_url = f"https://duckduckgo.com/html/?q={quote_plus(query)}"
-        async with self._semaphore, httpx.AsyncClient() as client:
+
+        async with self._semaphore:
+            response = await self._request_with_retries("GET", search_url)
+
+        if response is None or not self._is_textual_response(response):
+            return None
+
+        soup = BeautifulSoup(response.text, "html.parser")
+        primary_result = soup.select_one("div.result")
+        result_link = None
+        snippet_element = None
+        if primary_result:
+            result_link = primary_result.select_one("a.result__a")
+            snippet_element = primary_result.select_one("div.result__snippet")
+        if snippet_element is None:
+            snippet_element = soup.select_one("div.result__snippet")
+        if result_link is None:
+            result_link = soup.select_one("a.result__a")
+
+        snippet_text = (
+            snippet_element.get_text(" ", strip=True) if snippet_element else None
+        )
+
+        resolved_url = None
+        if result_link and result_link.has_attr("href"):
+            resolved_url = self._resolve_result_url(result_link["href"])
+
+        if resolved_url:
+            document = await self.fetch_document(resolved_url)
+            if document:
+                best_candidate = self._select_snippet(document, snippet_text)
+                if best_candidate:
+                    return best_candidate
+
+        return snippet_text or None
+
+    async def _request_with_retries(
+        self, method: str, url: str, **kwargs: object
+    ) -> httpx.Response | None:
+        """Execute an HTTP request with bounded retries."""
+
+        last_error: Exception | None = None
+        for attempt in range(self._max_retries + 1):
             try:
-                response = await client.get(search_url, timeout=10)
+                async with httpx.AsyncClient(**self._client_options) as client:
+                    response = await client.request(method, url, **kwargs)
                 response.raise_for_status()
-                soup = BeautifulSoup(response.text, "html.parser")
-                snippet = soup.select_one("div.result__snippet") or soup.select_one(
-                    "a.result__a"
-                )
-                return snippet.get_text(strip=True) if snippet else None
+                return response
+            except httpx.HTTPStatusError as exc:  # pragma: no cover - network timing
+                last_error = exc
+                status_code = exc.response.status_code if exc.response else None
+                should_retry = status_code is not None and 500 <= status_code < 600
+                if should_retry and attempt < self._max_retries:
+                    await asyncio.sleep(self._backoff_time(attempt))
+                    continue
+                break
             except (
+                httpx.TimeoutException,
+                httpx.TransportError,
                 httpx.RequestError,
-                httpx.HTTPStatusError,
-            ) as e:  # pragma: no cover - network issues
-                logger.error("Iris search error for %s: %s", query, e)
-                return None
+            ) as exc:  # pragma: no cover - network timing
+                last_error = exc
+                if attempt < self._max_retries:
+                    await asyncio.sleep(self._backoff_time(attempt))
+                    continue
+                break
+
+        if last_error is not None:
+            logger.error(
+                "iris.request.failed",
+                extra={
+                    "url": url,
+                    "error": str(last_error),
+                    "attempts": self._max_retries + 1,
+                },
+            )
+        return None
+
+    def _backoff_time(self, attempt: int) -> float:
+        return self._backoff_factor * (2**attempt)
+
+    async def _get_response(self, url: str) -> httpx.Response | None:
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"}:
+            logger.error(
+                "iris.fetch_text.invalid_scheme",
+                extra={"url": url, "scheme": parsed.scheme or ""},
+            )
+            return None
+
+        async with self._semaphore:
+            response = await self._request_with_retries("GET", url)
+
+        if response is None:
+            return None
+
+        if not self._is_textual_response(response):
+            logger.info(
+                "iris.fetch_text.non_textual_response",
+                extra={
+                    "url": url,
+                    "content_type": response.headers.get("Content-Type"),
+                },
+            )
+            return None
+
+        if self._content_too_large(response):
+            logger.info(
+                "iris.fetch_text.payload_too_large",
+                extra={
+                    "url": url,
+                    "content_length": response.headers.get("Content-Length"),
+                    "text_length": len(response.text),
+                },
+            )
+            return None
+
+        return response
+
+    def _is_textual_response(self, response: httpx.Response) -> bool:
+        content_type = response.headers.get("Content-Type", "").lower()
+        if not content_type:
+            return True
+        textual_indicators = ("text", "json", "xml", "javascript")
+        return any(token in content_type for token in textual_indicators)
+
+    def _content_too_large(self, response: httpx.Response) -> bool:
+        content_length = response.headers.get("Content-Length")
+        if content_length and content_length.isdigit():
+            if int(content_length) > self._max_content_length:
+                return True
+        return len(response.text) > self._max_content_length
+
+    def _extract_document(self, response: httpx.Response) -> IrisDocument | None:
+        extracted_json: str | None = None
+        try:
+            extracted_json = trafilatura.extract(
+                response.text,
+                include_comments=False,
+                include_tables=False,
+                favor_precision=True,
+                output_format="json",
+                url=str(response.request.url),
+            )
+        except Exception as exc:  # pragma: no cover - library edge case
+            logger.debug(
+                "iris.fetch_text.trafilatura_failed",
+                extra={"error": str(exc)},
+            )
+
+        document_data: Mapping[str, object] | None = None
+        if extracted_json:
+            try:
+                document_data = json.loads(extracted_json)
+            except json.JSONDecodeError as exc:  # pragma: no cover - unexpected format
+                logger.debug(
+                    "iris.fetch_text.invalid_trafilatura_payload",
+                    extra={"error": str(exc)},
+                )
+
+        fallback_text = None
+        if document_data:
+            text = document_data.get("text")
+            summary = document_data.get("summary")
+            title = document_data.get("title")
+            language = document_data.get("language")
+            cleaned_text = (
+                self._normalise_whitespace(text) if isinstance(text, str) else None
+            )
+            cleaned_summary = (
+                self._normalise_whitespace(summary)
+                if isinstance(summary, str)
+                else None
+            )
+            if cleaned_text or cleaned_summary or isinstance(title, str):
+                return IrisDocument(
+                    url=str(response.request.url),
+                    text=cleaned_text,
+                    summary=cleaned_summary,
+                    title=title if isinstance(title, str) else None,
+                    language=language if isinstance(language, str) else None,
+                )
+            fallback_text = self._fallback_text(response)
+        else:
+            fallback_text = self._fallback_text(response)
+
+        if fallback_text:
+            return IrisDocument(
+                url=str(response.request.url),
+                text=fallback_text,
+                summary=None,
+                title=None,
+                language=None,
+            )
+
+        return None
+
+    def _fallback_text(self, response: httpx.Response) -> str | None:
+        soup = BeautifulSoup(response.text, "html.parser")
+        extracted = soup.get_text(" ", strip=True)
+        if not extracted:
+            return None
+        return self._normalise_whitespace(extracted)
+
+    def _normalise_whitespace(self, value: str | None) -> str | None:
+        if not value:
+            return None
+        return " ".join(value.split())
+
+    def _resolve_result_url(self, href: str) -> str | None:
+        if not href:
+            return None
+        parsed = urlparse(href)
+        if not parsed.scheme:
+            href = f"https://duckduckgo.com{href}" if href.startswith("/") else href
+            parsed = urlparse(href)
+        if parsed.netloc.endswith("duckduckgo.com") and parsed.path.startswith("/l/"):
+            query_params = parse_qs(parsed.query)
+            uddg_values = query_params.get("uddg")
+            if uddg_values:
+                return unquote(uddg_values[0])
+        if parsed.scheme in {"http", "https"}:
+            return href
+        return None
+
+    def _select_snippet(
+        self, document: IrisDocument, fallback: str | None
+    ) -> str | None:
+        if document.summary:
+            return document.summary
+        if document.text:
+            return document.text[:500]
+        return fallback

--- a/tests/test_iris.py
+++ b/tests/test_iris.py
@@ -1,9 +1,61 @@
+import json
 import sys
 import types
 
 import httpx
 import pytest
 import trafilatura
+
+
+def make_response(
+    url: str,
+    text: str,
+    *,
+    status_code: int = 200,
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    request = httpx.Request("GET", url)
+    response_headers = {"Content-Type": "text/html"}
+    if headers:
+        response_headers.update(headers)
+    return httpx.Response(
+        status_code,
+        request=request,
+        content=text.encode("utf-8"),
+        headers=response_headers,
+    )
+
+
+class ClientFactory:
+    def __init__(
+        self,
+        *,
+        responses: list[httpx.Response] | None = None,
+        error_factory=None,
+    ) -> None:
+        self._responses = list(responses or [])
+        self._error_factory = error_factory
+
+    def __call__(self, *args, **kwargs):  # pragma: no cover - helper behaviour
+        factory = self
+
+        class _DummyAsyncClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def request(self, method, url, **request_kwargs):
+                if factory._error_factory is not None:
+                    raise factory._error_factory(method, url)
+                if not factory._responses:
+                    raise AssertionError("No response queued for request")
+                if len(factory._responses) == 1:
+                    return factory._responses[0]
+                return factory._responses.pop(0)
+
+        return _DummyAsyncClient()
 
 
 @pytest.fixture(autouse=True)
@@ -27,7 +79,16 @@ def patch_dependencies(monkeypatch):
         sys.modules,
         "monGARS.config",
         types.SimpleNamespace(
-            get_settings=lambda: types.SimpleNamespace(DOC_RETRIEVAL_URL="")
+            get_settings=lambda: types.SimpleNamespace(
+                DOC_RETRIEVAL_URL="",
+                curiosity_similarity_threshold=0.5,
+                curiosity_minimum_similar_history=0,
+                curiosity_graph_gap_cutoff=1,
+                curiosity_kg_cache_ttl=300,
+                curiosity_kg_cache_max_entries=512,
+                curiosity_research_cache_ttl=900,
+                curiosity_research_cache_max_entries=256,
+            )
         ),
     )
     monkeypatch.setitem(
@@ -35,29 +96,23 @@ def patch_dependencies(monkeypatch):
         "monGARS.core.neurones",
         types.SimpleNamespace(EmbeddingSystem=lambda *a, **k: None),
     )
-    monkeypatch.setitem(
-        sys.modules,
-        "bs4",
-        types.SimpleNamespace(BeautifulSoup=lambda *a, **k: None),
-    )
     yield
 
 
 @pytest.mark.asyncio
 async def test_fetch_text_success(monkeypatch):
-    async def fake_get(self, url, timeout=10):
-        class Resp:
-            text = "<html><body>hello world</body></html>"
-
-            def raise_for_status(self):
-                pass
-
-        return Resp()
-
     from monGARS.core.iris import Iris
 
-    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
-    monkeypatch.setattr(trafilatura, "extract", lambda html: "hello world")
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        ClientFactory(responses=[make_response("http://example.com", "<p>hello</p>")]),
+    )
+    monkeypatch.setattr(
+        trafilatura,
+        "extract",
+        lambda html, **_: json.dumps({"text": "hello world"}),
+    )
     iris = Iris()
     result = await iris.fetch_text("http://example.com")
     assert result == "hello world"
@@ -65,25 +120,28 @@ async def test_fetch_text_success(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_fetch_text_http_error(monkeypatch):
-    async def fake_get(self, url, timeout=10):
-        raise httpx.HTTPStatusError("bad", request=None, response=None)
-
     from monGARS.core.iris import Iris
 
-    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
-    iris = Iris()
+    response = make_response("http://bad.com", "", status_code=500)
+    monkeypatch.setattr(httpx, "AsyncClient", ClientFactory(responses=[response]))
+    iris = Iris(max_retries=0)
     assert await iris.fetch_text("http://bad.com") is None
 
 
 @pytest.mark.asyncio
 async def test_fetch_text_timeout(monkeypatch):
-    async def fake_get(self, url, timeout=10):
-        raise httpx.TimeoutException("slow")
-
     from monGARS.core.iris import Iris
 
-    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
-    iris = Iris()
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        ClientFactory(
+            error_factory=lambda method, url: httpx.TimeoutException(
+                "slow", request=httpx.Request(method, url)
+            )
+        ),
+    )
+    iris = Iris(max_retries=0)
     assert await iris.fetch_text("http://slow.com") is None
 
 
@@ -94,6 +152,146 @@ async def test_fetch_text_invalid_url():
     iris = Iris()
     result = await iris.fetch_text("ftp://example.com")
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_text_rejects_binary_payload(monkeypatch):
+    from monGARS.core.iris import Iris
+
+    response = make_response(
+        "http://example.com/image",
+        text="binary",
+        headers={"Content-Type": "image/png"},
+    )
+    monkeypatch.setattr(httpx, "AsyncClient", ClientFactory(responses=[response]))
+    iris = Iris()
+    result = await iris.fetch_text("http://example.com/image")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_text_honours_max_content_length(monkeypatch):
+    from monGARS.core.iris import Iris
+
+    response = make_response("http://example.com/long", "<p>too long</p>")
+    monkeypatch.setattr(httpx, "AsyncClient", ClientFactory(responses=[response]))
+    monkeypatch.setattr(
+        trafilatura,
+        "extract",
+        lambda html, **_: json.dumps({"text": "too long"}),
+    )
+    iris = Iris(max_content_length=5)
+    assert await iris.fetch_text("http://example.com/long") is None
+
+
+@pytest.mark.asyncio
+async def test_search_returns_snippet(monkeypatch):
+    from monGARS.core.iris import Iris
+
+    html = """
+    <html>
+      <body>
+        <div class="results">
+          <div class="result">
+            <a class="result__a">Example</a>
+            <div class="result__snippet">Example snippet</div>
+          </div>
+        </div>
+      </body>
+    </html>
+    """
+    encoded = "https://duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2F"
+    html = html.replace(
+        '<a class="result__a">Example</a>',
+        f'<a class="result__a" href="{encoded}">Example</a>',
+    )
+    search_response = make_response("https://duckduckgo.com/html/?q=test", html)
+    document_response = make_response("https://example.com/", "<p>Doc</p>")
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        ClientFactory(responses=[search_response, document_response]),
+    )
+    monkeypatch.setattr(
+        trafilatura,
+        "extract",
+        lambda html, **_: json.dumps({"summary": "Doc summary", "text": "Doc text"}),
+    )
+    iris = Iris()
+    result = await iris.search("test")
+    assert result == "Doc summary"
+
+
+@pytest.mark.asyncio
+async def test_search_falls_back_to_snippet(monkeypatch):
+    from monGARS.core.iris import Iris
+
+    html = """
+    <html>
+      <body>
+        <div class="result">
+          <a class="result__a" href="https://example.com">Example</a>
+          <div class="result__snippet">Example snippet</div>
+        </div>
+      </body>
+    </html>
+    """
+    response = make_response("https://duckduckgo.com/html/?q=test", html)
+
+    async def fake_fetch_document(url):
+        return None
+
+    monkeypatch.setattr(httpx, "AsyncClient", ClientFactory(responses=[response]))
+    iris = Iris()
+    monkeypatch.setattr(iris, "fetch_document", fake_fetch_document)
+    result = await iris.search("test")
+    assert result == "Example snippet"
+
+
+@pytest.mark.asyncio
+async def test_fetch_document_returns_structured_payload(monkeypatch):
+    from monGARS.core.iris import Iris
+
+    response = make_response("http://example.com", "<p>hello</p>")
+    monkeypatch.setattr(httpx, "AsyncClient", ClientFactory(responses=[response]))
+    monkeypatch.setattr(
+        trafilatura,
+        "extract",
+        lambda html, **_: json.dumps(
+            {
+                "text": "hello world",
+                "summary": "short summary",
+                "title": "Hello",
+                "language": "en",
+            }
+        ),
+    )
+    iris = Iris()
+    document = await iris.fetch_document("http://example.com")
+    assert document is not None
+    assert document.text == "hello world"
+    assert document.summary == "short summary"
+    assert document.title == "Hello"
+    assert document.language == "en"
+
+
+@pytest.mark.asyncio
+async def test_fetch_document_fallbacks_to_html_text(monkeypatch):
+    from monGARS.core.iris import Iris
+
+    response = make_response(
+        "http://example.com", "<p>hello <strong>world</strong></p>"
+    )
+    monkeypatch.setattr(httpx, "AsyncClient", ClientFactory(responses=[response]))
+
+    def raise_extract(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(trafilatura, "extract", raise_extract)
+    iris = Iris()
+    document = await iris.fetch_document("http://example.com")
+    assert document is not None
+    assert document.text == "hello world"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add an `IrisDocument` abstraction with `fetch_document` to surface trafilatura-powered extraction, metadata, and resilient fallbacks
- deepen DuckDuckGo search handling by resolving outbound links, fetching article content, and preferring extracted summaries over raw snippets
- extend the Iris tests with structured payload coverage, snippet fallbacks, and updated curiosity-engine fixtures

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd70623e988333919f5a2f47d42a13