### PR TITLE
Deepen chat interface analytics and export tooling

### DIFF
--- a/webapp/chat/templates/chat/index.html
+++ b/webapp/chat/templates/chat/index.html
@@ -1,102 +1,331 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="fr-CA">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>monGARS - Interface de Chat</title>
     {% load static %}
     <!-- Bootstrap 5 CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="{% static 'css/chat.css' %}">
-</head>
-<body class="bg-light">
-  <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container-fluid">
-      <a class="navbar-brand" href="#">monGARS Chat</a>
-      <button class="btn btn-outline-light ms-auto" id="toggle-dark-mode">Mode Sombre</button>
-    </div>
-  </nav>
-  <div class="container mt-4">
-    <div class="row">
-      <div class="col-lg-8 offset-lg-2">
-        <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
-          <h4 class="mb-0">Historique du Chat</h4>
-          <span id="ws-status" class="badge ws-badge offline" aria-live="polite">Hors ligne</span>
-        </div>
-        {% if flash_message %}
-        <div class="alert alert-success" role="status">{{ flash_message }}</div>
-        {% endif %}
-        <section id="connection" class="alert alert-info visually-hidden" role="status" aria-live="polite"></section>
-        <main id="chat" class="card shadow-sm">
-          <div class="card-body p-0">
-            <div id="transcript" class="chat-transcript" aria-live="polite" aria-busy="false">
-              {% if history_error %}
-              <div class="chat-row chat-system">
-                <div class="chat-bubble chat-bubble-error">{{ history_error }}</div>
-              </div>
-              {% endif %}
-              {% for item in history %}
-                {% if item.query %}
-                <div class="chat-row chat-user">
-                  <div class="chat-bubble">
-                    {{ item.query }}
-                    <div class="chat-meta">{{ item.timestamp|default_if_none:"" }}</div>
-                  </div>
-                </div>
-                {% endif %}
-                {% if item.response %}
-                <div class="chat-row chat-assistant">
-                  <div class="chat-bubble">
-                    {{ item.response }}
-                    <div class="chat-meta">{{ item.timestamp|default_if_none:"" }}</div>
-                  </div>
-                </div>
-                {% endif %}
-              {% empty %}
-              {% if not history_error %}
-              <div class="chat-row chat-system">
-                <div class="chat-bubble chat-bubble-hint">Aucun échange pour le moment.</div>
-              </div>
-              {% endif %}
-              {% endfor %}
-            </div>
-            <div id="error-alert" class="alert alert-danger m-3 d-none alert-dismissible fade show" role="alert">
-              <span id="error-message"></span>
-              <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
-            </div>
-            <aside id="actions" class="chat-actions px-3 pb-3">
-              <div class="chat-actions-row" id="quick-actions" role="list">
-                <button role="listitem" class="qa btn btn-outline-secondary" data-action="summarize">Résumer</button>
-                <button role="listitem" class="qa btn btn-outline-secondary" data-action="code">Code</button>
-                <button role="listitem" class="qa btn btn-outline-secondary" data-action="explain">Expliquer</button>
-              </div>
-            </aside>
-            <form id="composer" class="p-3 border-top" autocomplete="off" method="post">
-              {% csrf_token %}
-              {% if form_error %}
-              <div class="alert alert-warning" role="alert">{{ form_error }}</div>
-              {% endif %}
-              <div class="input-group">
-                <input id="prompt" name="prompt" class="form-control" placeholder="Entrez votre message…" value="{{ prompt_value }}" autocomplete="off" />
-                <button id="send" type="submit" class="btn btn-primary">Envoyer</button>
-              </div>
-            </form>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="{% static 'css/chat.css' %}" />
+  </head>
+  <body class="bg-light">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="#">monGARS Chat</a>
+        <button
+          type="button"
+          class="btn btn-outline-light ms-auto"
+          id="toggle-dark-mode"
+          aria-pressed="false"
+        >
+          Mode Sombre
+        </button>
+      </div>
+    </nav>
+    <div class="container mt-4">
+      <div class="row">
+        <div class="col-lg-10 col-xl-8 offset-lg-1">
+          {% if flash_message %}
+          <div class="alert alert-success" role="status">
+            {{ flash_message }}
           </div>
-        </main>
+          {% endif %}
+          <section
+            id="connection"
+            class="alert alert-info visually-hidden"
+            role="status"
+            aria-live="polite"
+          ></section>
+          <main id="chat" class="card shadow-sm">
+            <header class="card-header border-0 bg-transparent pb-0">
+              <div
+                class="d-flex flex-column flex-md-row justify-content-between gap-2"
+              >
+                <div>
+                  <h1 class="h5 mb-1">Historique du Chat</h1>
+                  <p class="text-muted small mb-0">
+                    Suivez les échanges et l'état de la connexion en temps réel.
+                  </p>
+                </div>
+                <span
+                  id="ws-status"
+                  class="badge ws-badge offline align-self-start align-self-md-center"
+                  aria-live="polite"
+                  >Hors ligne</span
+                >
+              </div>
+              <p
+                id="connection-meta"
+                class="small text-muted mb-0 mt-2"
+                aria-live="polite"
+              >
+                En attente de connexion…
+              </p>
+              <section
+                id="connection-diagnostics"
+                class="connection-diagnostics mt-3"
+                aria-live="polite"
+                aria-label="Diagnostics de connexion"
+              >
+                <dl class="connection-diagnostics-list">
+                  <div class="connection-diagnostics-item">
+                    <dt>Connecté depuis</dt>
+                    <dd id="diag-connected">—</dd>
+                  </div>
+                  <div class="connection-diagnostics-item">
+                    <dt>Dernier message</dt>
+                    <dd id="diag-last-message">—</dd>
+                  </div>
+                  <div class="connection-diagnostics-item">
+                    <dt>Latence</dt>
+                    <dd id="diag-latency">—</dd>
+                  </div>
+                  <div class="connection-diagnostics-item">
+                    <dt>Réseau</dt>
+                    <dd id="diag-network">Vérification…</dd>
+                  </div>
+                </dl>
+              </section>
+            </header>
+            <div class="card-body p-0">
+              <div class="chat-wrapper">
+                <div
+                  id="transcript"
+                  class="chat-transcript"
+                  aria-live="polite"
+                  aria-busy="false"
+                >
+                  {% if history_error %}
+                  <div class="chat-row chat-system">
+                    <div class="chat-bubble chat-bubble-error">
+                      {{ history_error }}
+                    </div>
+                  </div>
+                  {% endif %} {% for item in history %} {% if item.query %}
+                  <div class="chat-row chat-user">
+                    <div class="chat-bubble">
+                      {{ item.query }}
+                      <div class="chat-meta">
+                        {{ item.timestamp|default_if_none:"" }}
+                      </div>
+                    </div>
+                  </div>
+                  {% endif %} {% if item.response %}
+                  <div class="chat-row chat-assistant">
+                    <div class="chat-bubble">
+                      {{ item.response }}
+                      <div class="chat-meta">
+                        {{ item.timestamp|default_if_none:"" }}
+                      </div>
+                    </div>
+                  </div>
+                  {% endif %} {% empty %} {% if not history_error %}
+                  <div class="chat-row chat-system">
+                    <div class="chat-bubble chat-bubble-hint">
+                      Aucun échange pour le moment.
+                    </div>
+                  </div>
+                  {% endif %} {% endfor %}
+                </div>
+                <p
+                  id="filter-empty"
+                  class="text-muted small text-center py-3 d-none"
+                  role="status"
+                  aria-live="polite"
+                >
+                  Aucun message ne correspond à votre filtre.
+                </p>
+                <button
+                  type="button"
+                  id="scroll-bottom"
+                  class="btn btn-outline-secondary btn-sm scroll-bottom d-none"
+                  aria-hidden="true"
+                >
+                  Dernier message
+                </button>
+              </div>
+              <div
+                id="error-alert"
+                class="alert alert-danger m-3 d-none alert-dismissible fade show"
+                role="alert"
+              >
+                <span id="error-message"></span>
+                <button
+                  type="button"
+                  class="btn-close"
+                  data-bs-dismiss="alert"
+                  aria-label="Fermer"
+                ></button>
+              </div>
+              <aside id="actions" class="chat-actions px-3 pb-3">
+                <div class="chat-actions-toolbar mb-3">
+                  <div class="input-group input-group-sm chat-filter">
+                    <span class="input-group-text" id="chat-search-label"
+                      >Filtrer</span
+                    >
+                    <input
+                      type="search"
+                      id="chat-search"
+                      class="form-control"
+                      placeholder="Rechercher dans la conversation"
+                      aria-describedby="chat-search-label chat-search-hint"
+                    />
+                    <button
+                      type="button"
+                      class="btn btn-outline-secondary"
+                      id="chat-search-clear"
+                    >
+                      Effacer
+                    </button>
+                  </div>
+                  <p
+                    id="chat-search-hint"
+                    class="form-text small text-muted mb-0 mt-2"
+                  >
+                    Utilisez le filtre pour limiter l'historique. Appuyez sur
+                    Échap pour effacer.
+                  </p>
+                  <div class="btn-toolbar mt-3" role="toolbar">
+                    <div class="btn-group btn-group-sm me-2" role="group">
+                      <button
+                        type="button"
+                        class="btn btn-outline-primary"
+                        id="export-json"
+                      >
+                        Export JSON
+                      </button>
+                      <button
+                        type="button"
+                        class="btn btn-outline-primary"
+                        id="export-markdown"
+                      >
+                        Export Markdown
+                      </button>
+                    </div>
+                    <button
+                      type="button"
+                      class="btn btn-outline-secondary btn-sm"
+                      id="export-copy"
+                    >
+                      Copier la conversation
+                    </button>
+                  </div>
+                  <p
+                    class="form-text small text-muted mb-0 mt-2"
+                    id="export-hint"
+                  >
+                    Les exports incluent l'ensemble des messages, même ceux qui
+                    ne sont plus visibles.
+                  </p>
+                </div>
+                <div
+                  class="chat-actions-row"
+                  id="quick-actions"
+                  role="list"
+                  aria-label="Suggestions rapides"
+                >
+                  <button
+                    type="button"
+                    role="listitem"
+                    class="qa btn btn-outline-secondary"
+                    data-action="summarize"
+                  >
+                    Résumer
+                  </button>
+                  <button
+                    type="button"
+                    role="listitem"
+                    class="qa btn btn-outline-secondary"
+                    data-action="code"
+                  >
+                    Code
+                  </button>
+                  <button
+                    type="button"
+                    role="listitem"
+                    class="qa btn btn-outline-secondary"
+                    data-action="explain"
+                  >
+                    Expliquer
+                  </button>
+                </div>
+              </aside>
+              <form
+                id="composer"
+                class="p-3 border-top"
+                autocomplete="off"
+                method="post"
+                novalidate
+              >
+                {% csrf_token %} {% if form_error %}
+                <div class="alert alert-warning" role="alert">
+                  {{ form_error }}
+                </div>
+                {% endif %}
+                <div class="input-group">
+                  <textarea
+                    id="prompt"
+                    name="prompt"
+                    class="form-control"
+                    placeholder="Entrez votre message…"
+                    autocomplete="off"
+                    rows="1"
+                    maxlength="1000"
+                    aria-describedby="composer-hint"
+                  >
+{{ prompt_value|default_if_none:"" }}</textarea
+                  >
+                  <button
+                    id="send"
+                    type="submit"
+                    class="btn btn-primary"
+                    data-idle-label="Envoyer"
+                  >
+                    Envoyer
+                  </button>
+                </div>
+                <div
+                  class="composer-meta form-text d-flex justify-content-between flex-wrap gap-2 mt-2"
+                  id="composer-hint"
+                >
+                  <span id="composer-status" class="composer-status text-muted"
+                    >Appuyez sur Ctrl+Entrée pour envoyer rapidement.</span
+                  >
+                  <span
+                    id="prompt-count"
+                    class="composer-count text-muted"
+                    data-max="1000"
+                    >0 / 1000</span
+                  >
+                </div>
+              </form>
+            </div>
+          </main>
+        </div>
       </div>
     </div>
-  </div>
-  <!-- Bootstrap 5 JS -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  {{ history_json|json_script:"chat-history" }}
-  <script>
-    window.chatConfig = {
-      fastapiUrl: "{{ fastapi_url }}",
-      userId: "{{ user_id }}",
-      token: "{{ token }}",
-    };
-  </script>
-  <script src="{% static 'js/chat.js' %}"></script>
-</body>
+    <!-- Bootstrap 5 JS -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    {{ history_json|json_script:"chat-history" }}
+    <script>
+      window.chatConfig = {
+        fastapiUrl: "{{ fastapi_url }}",
+        userId: "{{ user_id }}",
+        token: "{{ token }}",
+      };
+    </script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"
+      crossorigin="anonymous"
+    ></script>
+    <script src="{% static 'js/chat.js' %}"></script>
+  </body>
 </html>
-

--- a/webapp/static/css/chat.css
+++ b/webapp/static/css/chat.css
@@ -1,6 +1,26 @@
+body {
+  transition:
+    background-color 0.3s ease,
+    color 0.3s ease;
+}
+
 body.dark-mode {
   background-color: #121212;
   color: #e0e0e0;
+}
+
+body.dark-mode .card {
+  background-color: #1b1b1b;
+  border-color: #2a2a2a;
+}
+
+body.dark-mode .card-header {
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.chat-wrapper {
+  position: relative;
 }
 
 .chat-transcript {
@@ -13,9 +33,81 @@ body.dark-mode {
   transition: background-color 0.3s ease;
 }
 
+.chat-transcript.filtered {
+  border-color: #b6d4fe;
+  box-shadow: inset 0 0 0 1px rgba(13, 110, 253, 0.15);
+}
+
+.chat-transcript.filtered .chat-row.chat-hidden {
+  display: none !important;
+}
+
+.chat-transcript.filtered .chat-bubble {
+  opacity: 0.95;
+}
+
+.chat-transcript.filtered .chat-row.chat-filter-match .chat-bubble {
+  outline: 2px solid rgba(13, 110, 253, 0.35);
+  box-shadow: 0 0 0 3px rgba(13, 110, 253, 0.08);
+}
+
 body.dark-mode .chat-transcript {
   background-color: #1e1e1e;
   border-color: #333333;
+}
+
+#connection-meta {
+  transition: color 0.2s ease;
+}
+
+body.dark-mode #connection-meta {
+  color: #b8b8b8;
+}
+
+.connection-diagnostics {
+  border-radius: 0.75rem;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  background: rgba(248, 249, 250, 0.6);
+  padding: 0.75rem 1rem;
+  transition:
+    background-color 0.3s ease,
+    border-color 0.3s ease;
+}
+
+.connection-diagnostics-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.5rem 1.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.connection-diagnostics-item {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.connection-diagnostics-item dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #6c757d;
+  margin: 0;
+}
+
+.connection-diagnostics-item dd {
+  font-weight: 600;
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+body.dark-mode .connection-diagnostics {
+  background: rgba(26, 26, 26, 0.7);
+  border-color: rgba(255, 255, 255, 0.06);
+}
+
+body.dark-mode .connection-diagnostics-item dt {
+  color: #9d9d9d;
 }
 
 .chat-row {
@@ -37,12 +129,21 @@ body.dark-mode .chat-transcript {
 }
 
 .chat-bubble {
+  position: relative;
   max-width: 70ch;
   padding: 0.85rem 1rem;
   border-radius: 1rem;
   background-color: #f5f5f5;
-  line-height: 1.4;
+  line-height: 1.5;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  transition:
+    background-color 0.3s ease,
+    box-shadow 0.3s ease,
+    transform 0.3s ease;
+}
+
+.chat-bubble.has-tools {
+  padding-right: 2.75rem;
 }
 
 .chat-row.chat-user .chat-bubble {
@@ -65,6 +166,15 @@ body.dark-mode .chat-row.chat-user .chat-bubble {
 
 body.dark-mode .chat-row.chat-system .chat-bubble {
   background-color: #262626;
+}
+
+.chat-row-highlight .chat-bubble {
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
+  transform: translateY(-2px);
+}
+
+body.dark-mode .chat-row-highlight .chat-bubble {
+  box-shadow: 0 12px 35px rgba(0, 0, 0, 0.45);
 }
 
 .chat-bubble-ok {
@@ -122,12 +232,166 @@ body.dark-mode .chat-meta {
   color: #8a1c1c;
 }
 
+.scroll-bottom {
+  position: absolute;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  box-shadow: 0 6px 16px rgba(33, 37, 41, 0.2);
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(8px);
+}
+
+.scroll-bottom.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+body.dark-mode .scroll-bottom {
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
+}
+
 .chat-actions {
   background-color: #f8f9fa;
 }
 
 body.dark-mode .chat-actions {
   background-color: #1a1a1a;
+}
+
+.chat-actions-toolbar {
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  border-radius: 0.75rem;
+  padding: 1rem;
+}
+
+.chat-actions-toolbar .btn-toolbar {
+  flex-wrap: wrap;
+}
+
+.chat-actions-toolbar .btn-toolbar .btn-group {
+  margin-bottom: 0.5rem;
+}
+
+.chat-actions-toolbar .btn-toolbar > .btn {
+  margin-bottom: 0.5rem;
+}
+
+.chat-filter .form-control {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.chat-filter .input-group-text {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.chat-actions-toolbar p.form-text {
+  font-size: 0.7rem;
+}
+
+body.dark-mode .chat-actions-toolbar {
+  background: rgba(0, 0, 0, 0.35);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.composer-meta {
+  font-size: 0.75rem;
+  color: #6c757d;
+}
+
+.composer-status {
+  transition: color 0.2s ease;
+}
+
+.composer-count {
+  font-variant-numeric: tabular-nums;
+}
+
+body.dark-mode .composer-meta {
+  color: #b0b0b0;
+}
+
+body.dark-mode .composer-count {
+  color: #d1d1d1;
+}
+
+#prompt {
+  resize: none;
+  min-height: 2.75rem;
+  max-height: 12rem;
+  transition:
+    height 0.2s ease,
+    background-color 0.3s ease,
+    color 0.3s ease,
+    border-color 0.3s ease;
+  line-height: 1.5;
+}
+
+#prompt::placeholder {
+  color: #6c757d;
+}
+
+body.dark-mode #prompt {
+  background-color: #262626;
+  color: #f1f1f1;
+  border-color: #3a3a3a;
+}
+
+body.dark-mode #prompt::placeholder {
+  color: #9d9d9d;
+}
+
+.chat-bubble .copy-btn {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.55rem;
+  padding: 0.125rem 0.35rem;
+  font-size: 0.75rem;
+  color: #6c757d;
+  text-decoration: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.chat-bubble:hover .copy-btn,
+.chat-bubble:focus-within .copy-btn {
+  opacity: 1;
+}
+
+.chat-bubble .copy-btn:focus {
+  opacity: 1;
+  outline: none;
+  box-shadow: none;
+}
+
+body.dark-mode .chat-bubble .copy-btn {
+  color: #c7c7c7;
+}
+
+.chat-bubble .copy-btn .visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.chat-bubble .copy-btn:active {
+  opacity: 1;
 }
 
 .chat-actions-row {
@@ -149,6 +413,53 @@ body.dark-mode .chat-actions {
   transform: translateY(-1px);
 }
 
+.chat-transcript .filter-highlight {
+  background: linear-gradient(90deg, rgba(13, 110, 253, 0.16), transparent);
+  border-radius: 0.35rem;
+  padding: 0 0.1rem;
+}
+
+#filter-empty {
+  transition: opacity 0.2s ease;
+}
+
+.chat-bubble pre,
+.chat-bubble code {
+  font-family:
+    "JetBrains Mono", "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+}
+
+.chat-bubble pre {
+  margin-top: 0.75rem;
+  margin-bottom: 0.5rem;
+  padding: 0.75rem;
+  background-color: #0b17272b;
+  border-radius: 0.75rem;
+  overflow-x: auto;
+  font-size: 0.85rem;
+}
+
+.chat-bubble pre code {
+  display: block;
+  white-space: pre;
+}
+
+.chat-bubble code {
+  background-color: rgba(33, 37, 41, 0.08);
+  border-radius: 0.35rem;
+  padding: 0.1rem 0.25rem;
+  font-size: 0.85em;
+}
+
+body.dark-mode .chat-bubble pre {
+  background-color: rgba(12, 84, 96, 0.28);
+}
+
+body.dark-mode .chat-bubble code {
+  background-color: rgba(173, 216, 230, 0.1);
+}
+
 .chat-cursor {
   display: inline-block;
   margin-left: 0.25rem;
@@ -159,5 +470,18 @@ body.dark-mode .chat-actions {
 @keyframes blink {
   to {
     visibility: hidden;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body,
+  .chat-transcript,
+  .chat-bubble,
+  .scroll-bottom,
+  #prompt {
+    transition: none;
+  }
+  .chat-transcript {
+    scroll-behavior: auto;
   }
 }


### PR DESCRIPTION
## Summary
- add a diagnostics header, transcript filter, and export controls to the chat template for richer operator tooling
- extend the chat stylesheet to support diagnostics cards, filtered transcript states, and readable markdown/code blocks across themes
- enhance chat.js with timeline tracking, markdown sanitisation, export helpers, transcript filtering, and live diagnostics/network handling

## Testing
- pytest -q
- npx prettier --write webapp/chat/templates/chat/index.html webapp/static/css/chat.css webapp/static/js/chat.js

------
https://chatgpt.com/codex/tasks/task_e_68dd9e7ffdf88333b1d2d85e5546357f