### PR TITLE
Add documentation for RAG context enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ can be extended to register additional Ollama models or alternate providers.
 | Code audit notes | [docs/code_audit_summary.md](docs/code_audit_summary.md) |
 | Ray Serve deployment | [docs/ray_serve_deployment.md](docs/ray_serve_deployment.md) |
 | Repository vs. memory mapping | [docs/repo_memory_alignment.md](docs/repo_memory_alignment.md) |
+| RAG context enrichment | [docs/rag_context_enrichment.md](docs/rag_context_enrichment.md) |
 | API specification & clients | [docs/api/](docs/api/README.md) |
 | Conversation workflow deep dive | [docs/conversation_workflow.md](docs/conversation_workflow.md) |
 | Model configuration & provisioning | [docs/model_management.md](docs/model_management.md) |

--- a/docs/rag_context_enrichment.md
+++ b/docs/rag_context_enrichment.md
@@ -1,0 +1,50 @@
+# RAG Context Enrichment
+
+## Overview
+
+RAG Context Enrichment enhances AI-assisted reviews by retrieving contextually relevant code patterns from indexed repositories. The feature augments pull request (PR) analysis with references to similar implementations, enabling reviewers to make faster, more informed decisions.
+
+## Prerequisites
+
+- Available exclusively to Qodo Enterprise single-tenant or on-premises deployments.
+- Requires a prepared database and fully indexed codebase. Contact support if indexing has not been completed.
+
+## Configuration
+
+Add the following section to your configuration file to enable repository enrichment:
+
+```
+[rag_arguments]
+enable_rag=true
+```
+
+### RAG Arguments
+
+| Option          | Description |
+| --------------- | ----------- |
+| `enable_rag`    | Enable or disable repository enrichment. Defaults to `false`. |
+| `rag_repo_list` | Repositories used for semantic search. Use `['all']` to search the entire codebase or specify a list such as `['my-org/my-repo']`. Defaults to the repository where the PR originated. |
+
+## Applications
+
+RAG context is surfaced in the following tools:
+
+- `/ask`
+- `/compliance`
+- `/implement`
+- `/review`
+
+Within `/review`, the Focus area highlights findings derived from RAG data, and a dedicated References section lists every relevant source discovered during analysis.
+
+## Limitations
+
+- Natural-language search drives retrieval quality; results may vary between queries.
+- To minimize noise, scope searches to the PR repository whenever possible.
+- Requires a secure, private, and indexed codebase.
+- Only available on Qodo Merge Enterprise single-tenant or on-premises deployments.
+
+## Recommended Practices
+
+- Keep repository indexing up to date to maintain high-quality results.
+- Review and curate the `rag_repo_list` to balance context coverage against retrieval noise.
+- Document any new configuration in deployment runbooks so operators can monitor and maintain the feature.


### PR DESCRIPTION
## Summary
- document the RAG Context Enrichment capability, including configuration, prerequisites, and usage guidance
- link the new guide from the README documentation map for easy discovery

## Testing
- ⚠️ `pytest -q` *(interrupted after ~30s due to long runtime; no failures observed before cancellation)*

------
https://chatgpt.com/codex/tasks/task_e_68ddbb6298848333b7fdb59d008b8c34