### PR TITLE
Fix Ray Serve Dockerfile permissions for apt-get

### DIFF
--- a/Dockerfile.rayserve
+++ b/Dockerfile.rayserve
@@ -1,5 +1,9 @@
 FROM rayproject/ray:2.48.0-py311
 
+# Elevate to root to install system level dependencies, then drop back to the
+# default non-root user for runtime execution.
+USER root
+
 # System dependencies for pulling model weights and executing multimedia-aware
 # pipelines from Ray Serve deployments.
 RUN apt-get update \
@@ -24,6 +28,9 @@ RUN pip install --no-cache-dir \
         "peft>=0.13.2" \
         "sentencepiece>=0.2.0" \
         "transformers>=4.44.2"
+
+# Return to the default ray user for runtime safety.
+USER ray
 
 ENV PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
## Summary
- switch to the root user during build so apt-based dependency installs succeed
- revert to the default ray user after installing system and python dependencies to keep runtime non-root

## Testing
- not run (dockerfile-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ddd1883b3883338af4aa02877ce943

## Summary by Sourcery

Fix Ray Serve Dockerfile to run apt-get as root and maintain non-root runtime user

Bug Fixes:
- Allow apt-based system dependencies to install by switching to root user during Docker build

Build:
- Revert back to the default ray user after installing system and Python dependencies in the Dockerfile