### PR TITLE
Handle invalid chat tokens with 422

### DIFF
--- a/tests/test_api_chat.py
+++ b/tests/test_api_chat.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 from monGARS.api.dependencies import hippocampus
 from monGARS.api.web_api import app
 from monGARS.core.conversation import ConversationalModule
+from monGARS.core.security import SecurityManager
 
 
 def _speech_turn_payload(text: str) -> dict:
@@ -149,3 +150,17 @@ async def test_chat_session_id_too_long_returns_422(client: TestClient):
 async def test_chat_requires_auth(client: TestClient):
     resp = client.post("/api/v1/conversation/chat", json={"message": "hello"})
     assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_chat_missing_sub_in_token_returns_422(client: TestClient):
+    token = SecurityManager(secret_key="test", algorithm="HS256").create_access_token(
+        {"admin": False}
+    )
+    resp = client.post(
+        "/api/v1/conversation/chat",
+        json={"message": "hello"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "Missing required fields: user_id and query."

--- a/tests/test_api_chat.py
+++ b/tests/test_api_chat.py
@@ -153,7 +153,7 @@ async def test_chat_requires_auth(client: TestClient):
 
 
 @pytest.mark.asyncio
-async def test_chat_missing_sub_in_token_returns_422(client: TestClient):
+async def test_chat_missing_sub_in_token_returns_401(client: TestClient):
     token = SecurityManager(secret_key="test", algorithm="HS256").create_access_token(
         {"admin": False}
     )
@@ -162,5 +162,5 @@ async def test_chat_missing_sub_in_token_returns_422(client: TestClient):
         json={"message": "hello"},
         headers={"Authorization": f"Bearer {token}"},
     )
-    assert resp.status_code == 422
-    assert resp.json()["detail"] == "Missing required fields: user_id and query."
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid token: missing subject"


### PR DESCRIPTION
### **User description**
## Summary
- wrap chat endpoint input validation in a ValueError handler to return a 422 response with logging
- adjust chat event logging to avoid shadowing the module logger
- add a FastAPI test asserting tokens without a subject now yield 422

## Testing
- pytest tests/test_api_chat.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ddd394931c8333b99fcbdaf389a360


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add error handling for invalid chat tokens returning 422

- Improve chat event logging to avoid module logger shadowing

- Add test for tokens missing subject field


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Chat Request"] --> B["Token Validation"]
  B --> C{"Valid Token?"}
  C -->|No| D["422 Error Response"]
  C -->|Yes| E["Process Chat"]
  E --> F["Publish Event"]
  F --> G["Return Response"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>web_api.py</strong><dd><code>Add error handling and improve logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

monGARS/api/web_api.py

<ul><li>Wrap <code>validate_user_input</code> in try-catch for ValueError handling<br> <li> Return 422 HTTP status with proper logging on validation errors<br> <li> Fix event logging to avoid shadowing module logger</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/120/files#diff-cc78016a0385cdf20e9a1483b6cbdbdd98d890a67b13dce9697c38fa0d39a3fb">+13/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_api_chat.py</strong><dd><code>Add test for invalid token handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_api_chat.py

<ul><li>Import <code>SecurityManager</code> for token creation in tests<br> <li> Add test case for tokens missing <code>sub</code> field<br> <li> Verify 422 status code and error message returned</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/120/files#diff-066c58c6a17938ecc408ce7adb6435ada07fac6a9a9ffeaa3e558e22833f10ad">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Enforces stricter JWT validation; tokens missing a subject now return 401 Unauthorized with a clear error message.
  - Improves chat request handling to return 422 Unprocessable Entity on invalid input, with clearer feedback.
- Improvements
  - Uses a consistent user identifier across chat operations for more reliable behavior.
- Tests
  - Added test to verify 401 response when a token lacks a subject claim.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->