### PR TITLE
Add UTC import shim for Python 3.10 compatibility

### DIFF
--- a/monGARS/api/web_api.py
+++ b/monGARS/api/web_api.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime
+from datetime import datetime
+
+try:
+    from datetime import UTC  # Python 3.11+
+except ImportError:  # Python 3.10 fallback
+    from datetime import timezone
+
+    UTC = timezone.utc
 from typing import Annotated, Any
 
 from fastapi import Depends, FastAPI, HTTPException, status

--- a/monGARS/core/bouche.py
+++ b/monGARS/core/bouche.py
@@ -4,7 +4,14 @@ import logging
 import re
 import uuid
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime
+
+try:
+    from datetime import UTC  # Python 3.11+
+except ImportError:  # Python 3.10 fallback
+    from datetime import timezone
+
+    UTC = timezone.utc
 from typing import Iterable
 
 logger = logging.getLogger(__name__)

--- a/monGARS/core/self_training.py
+++ b/monGARS/core/self_training.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from datetime import UTC, datetime
+from datetime import datetime
+
+try:
+    from datetime import UTC  # Python 3.11+
+except ImportError:  # Python 3.10 fallback
+    from datetime import timezone
+
+    UTC = timezone.utc
 from pathlib import Path
 from typing import Any, Dict, Iterable, Sequence
 from uuid import uuid4


### PR DESCRIPTION
## Summary
- add Python 3.10-compatible UTC fallback for bouche, self-training, and API modules

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dddfbcc3108333b50e98fb846a1d4b