### PR TITLE
Harden debug host resolution for Django operator console

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ user/token.
 | `POSTGRES_PORT`, `REDIS_PORT`, `MLFLOW_PORT`, `VAULT_PORT`, `OLLAMA_PORT`, `RAY_HTTP_PORT`, `RAY_DASHBOARD_PORT` | Host bindings for stateful and optional services managed by Compose. |
 | `DB_PASSWORD` | Password applied to the Postgres user `mongars`; rotated automatically by the deploy script when left as `changeme`. |
 | `USE_RAY_SERVE` / `RAY_SERVE_URL` | Enable distributed inference and point at Ray Serve HTTP endpoints (defaults to `http://rayserve:8002/generate`). |
-| `DJANGO_SECRET_KEY`, `DJANGO_DEBUG`, `DJANGO_ALLOWED_HOSTS`, `FASTAPI_URL` | Settings used by the Django operator console when running inside Compose. |
+| `DJANGO_SECRET_KEY`, `DJANGO_DEBUG`, `DJANGO_ALLOWED_HOSTS`, `DJANGO_DEBUG_HOSTS`, `FASTAPI_URL` | Settings used by the Django operator console when running inside Compose. `DJANGO_DEBUG_HOSTS` appends comma-separated hostnames/IPs that should be trusted automatically when `DJANGO_DEBUG=true`. |
 | `OLLAMA_HOST` | URL for the Ollama runtime; defaults to the local container (`http://ollama:11434`). |
 | `LLM_MODELS_CONFIG_PATH` | Path to the JSON manifest listing model profiles and download preferences. |
 | `LLM_MODELS_PROFILE` | Name of the profile within `LLM_MODELS_CONFIG_PATH` used for inference defaults. |

--- a/tests/test_webapp_settings.py
+++ b/tests/test_webapp_settings.py
@@ -1,0 +1,78 @@
+"""Regression tests for Django settings helpers."""
+
+from __future__ import annotations
+
+import importlib
+import socket
+import sys
+from typing import Any
+
+
+def test_debug_includes_private_addresses(monkeypatch):
+    """Mobile devices should be able to target private debug IPs without 400s."""
+
+    monkeypatch.setenv("DJANGO_SECRET_KEY", "dummy")
+    monkeypatch.setenv("DJANGO_DEBUG", "true")
+    monkeypatch.delenv("DJANGO_ALLOWED_HOSTS", raising=False)
+    monkeypatch.delenv("DJANGO_DEBUG_HOSTS", raising=False)
+
+    monkeypatch.setattr("socket.gethostname", lambda: "mongars-dev")
+    monkeypatch.setattr("socket.getfqdn", lambda: "mongars-dev.local")
+    monkeypatch.setattr(
+        "socket.gethostbyname_ex",
+        lambda _hostname: ("mongars-dev", ["alias"], ["192.168.1.50", "203.0.113.9"]),
+    )
+
+    def fake_getaddrinfo(*_args: Any, **_kwargs: Any) -> list[tuple[Any, ...]]:
+        return [
+            (socket.AF_INET, None, None, "", ("10.0.5.77", 0)),
+            (socket.AF_INET, None, None, "", ("0.0.0.0", 0)),
+            (socket.AF_INET6, None, None, "", ("fd00::1", 0, 0, 0)),
+            (socket.AF_INET6, None, None, "", ("2001:4860::1", 0, 0, 0)),
+        ]
+
+    monkeypatch.setattr("socket.getaddrinfo", fake_getaddrinfo)
+
+    settings = _reload_settings()
+
+    allowed = set(settings.ALLOWED_HOSTS)
+    assert {
+        "mongars-dev",
+        "mongars-dev.local",
+        "192.168.1.50",
+        "10.0.5.77",
+        "fd00::1",
+    } <= allowed
+    assert "203.0.113.9" not in allowed
+    assert "0.0.0.0" not in allowed
+    assert "2001:4860::1" not in allowed
+
+
+def test_debug_env_hosts_are_preserved(monkeypatch):
+    """Explicit debug hosts should supplement discovered addresses."""
+
+    monkeypatch.setenv("DJANGO_SECRET_KEY", "dummy")
+    monkeypatch.setenv("DJANGO_DEBUG", "true")
+    monkeypatch.setenv("DJANGO_DEBUG_HOSTS", "dev.box,192.168.99.88")
+    monkeypatch.delenv("DJANGO_ALLOWED_HOSTS", raising=False)
+
+    monkeypatch.setattr("socket.gethostname", lambda: "broken", raising=False)
+
+    def erroring(
+        *_args: Any, **_kwargs: Any
+    ):  # pragma: no cover - verifying resilience
+        raise OSError("network lookup disabled in test")
+
+    monkeypatch.setattr("socket.getfqdn", erroring)
+    monkeypatch.setattr("socket.gethostbyname_ex", erroring)
+    monkeypatch.setattr("socket.getaddrinfo", erroring)
+
+    settings = _reload_settings()
+
+    assert "dev.box" in settings.ALLOWED_HOSTS
+    assert "192.168.99.88" in settings.ALLOWED_HOSTS
+
+
+def _reload_settings():
+    sys.modules.pop("webapp.webapp.settings", None)
+    return importlib.import_module("webapp.webapp.settings")

--- a/webapp/webapp/settings.py
+++ b/webapp/webapp/settings.py
@@ -104,10 +104,7 @@ def _is_private_ip(value: str) -> bool:
     except ValueError:
         return False
 
-    if address.version == 4:
-        return any(address in network for network in _PRIVATE_IPV4_NETWORKS)
-
-    return any(address in network for network in _PRIVATE_IPV6_NETWORKS)
+    return address.is_private
 
 
 T = TypeVar("T")

--- a/webapp/webapp/settings.py
+++ b/webapp/webapp/settings.py
@@ -1,9 +1,113 @@
 import os
+import socket
+from ipaddress import ip_address, ip_network
 from pathlib import Path
+from typing import Callable, Iterable, TypeVar
 
 from dotenv import load_dotenv
 
 load_dotenv()
+
+
+def _iter_debug_hosts() -> Iterable[str]:
+    """Yield hostnames and addresses safe to trust while debugging locally."""
+
+    explicit_hosts = _parse_debug_host_env()
+    for host in explicit_hosts:
+        yield host
+
+    hostname = _safe_socket_call(socket.gethostname)
+    if hostname:
+        yield hostname
+
+    fqdn = _safe_socket_call(socket.getfqdn)
+    if fqdn and fqdn != hostname:
+        yield fqdn
+
+    for address in _private_interface_addresses(hostname):
+        yield address
+
+
+def _parse_debug_host_env() -> list[str]:
+    """Return hosts declared via ``DJANGO_DEBUG_HOSTS`` in import order."""
+
+    raw_hosts = os.environ.get("DJANGO_DEBUG_HOSTS", "")
+    parsed: list[str] = []
+    for candidate in raw_hosts.split(","):
+        trimmed = candidate.strip()
+        if trimmed:
+            parsed.append(trimmed)
+    return parsed
+
+
+def _private_interface_addresses(hostname: str | None) -> Iterable[str]:
+    """Return private interface addresses discovered on the current machine."""
+
+    discovered: set[str] = set()
+
+    if hostname:
+        discovered.update(_resolve_private_ips(hostname))
+
+    for info in (
+        _safe_socket_call(socket.getaddrinfo, None, 0, proto=socket.IPPROTO_TCP) or []
+    ):
+        host = info[4][0]
+        if _is_private_ip(host):
+            discovered.add(host)
+
+    return sorted(discovered)
+
+
+def _resolve_private_ips(hostname: str) -> Iterable[str]:
+    """Resolve ``hostname`` to the private IPs bound locally."""
+
+    resolved: list[str] = []
+    host_info = _safe_socket_call(socket.gethostbyname_ex, hostname)
+    if host_info:
+        _, _, addresses = host_info
+        for address in addresses:
+            if _is_private_ip(address):
+                resolved.append(address)
+    return resolved
+
+
+_PRIVATE_IPV4_NETWORKS = (
+    ip_network("10.0.0.0/8"),
+    ip_network("172.16.0.0/12"),
+    ip_network("192.168.0.0/16"),
+    ip_network("169.254.0.0/16"),
+    ip_network("127.0.0.0/8"),
+    ip_network("100.64.0.0/10"),
+)
+_PRIVATE_IPV6_NETWORKS = (
+    ip_network("fc00::/7"),
+    ip_network("fe80::/10"),
+    ip_network("::1/128"),
+)
+
+
+def _is_private_ip(value: str) -> bool:
+    try:
+        address = ip_address(value)
+    except ValueError:
+        return False
+
+    if address.version == 4:
+        return any(address in network for network in _PRIVATE_IPV4_NETWORKS)
+
+    return any(address in network for network in _PRIVATE_IPV6_NETWORKS)
+
+
+T = TypeVar("T")
+
+
+def _safe_socket_call(func: Callable[..., T], *args, **kwargs) -> T | None:
+    try:
+        return func(*args, **kwargs)
+    except OSError:
+        return None
+
+
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
@@ -18,6 +122,11 @@ ALLOWED_HOSTS = [
     )
     if host.strip()
 ]
+
+if DEBUG:
+    for debug_host in _iter_debug_hosts():
+        if debug_host not in ALLOWED_HOSTS:
+            ALLOWED_HOSTS.append(debug_host)
 
 INSTALLED_APPS = [
     "django.contrib.admin",


### PR DESCRIPTION
### **User description**
## Summary
- replace the debug-time `ALLOWED_HOSTS` wildcard with dynamic host discovery that only admits loopback, private, and link-local interface addresses
- introduce the `DJANGO_DEBUG_HOSTS` environment override and document it for operators
- extend the Django settings regression tests to cover private-address discovery and the explicit host override flow

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ddebbc1b208333b893fd7defa23c44


___

### **PR Type**
Enhancement


___

### **Description**
- Replace wildcard debug hosts with dynamic discovery

- Add private/loopback address detection for Django debug

- Introduce `DJANGO_DEBUG_HOSTS` environment override

- Add comprehensive regression tests for host resolution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Environment Variables"] --> B["Debug Host Discovery"]
  B --> C["Socket Resolution"]
  C --> D["Private IP Filtering"]
  D --> E["ALLOWED_HOSTS"]
  F["DJANGO_DEBUG_HOSTS"] --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_webapp_settings.py</strong><dd><code>Add comprehensive debug host resolution tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_webapp_settings.py

<ul><li>Add test for private address discovery in debug mode<br> <li> Add test for explicit debug hosts environment override<br> <li> Mock socket functions to simulate network conditions<br> <li> Verify filtering of public IPs and invalid addresses</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/123/files#diff-b49b0c67415413af5daccd52c24e17673a66ab2b5467692ad2e31eb51747d1b1">+78/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settings.py</strong><dd><code>Implement dynamic debug host resolution system</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

webapp/webapp/settings.py

<ul><li>Add dynamic debug host discovery functions<br> <li> Implement private IP address filtering logic<br> <li> Add support for <code>DJANGO_DEBUG_HOSTS</code> environment variable<br> <li> Integrate debug host discovery into Django settings</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/123/files#diff-73af3f255ea8569ab7fdd058e4adcafce8c08b4de895375d691ae1a645bde3b1">+109/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document debug hosts environment variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Document new <code>DJANGO_DEBUG_HOSTS</code> environment variable<br> <li> Explain automatic host trust behavior in debug mode</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/123/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - When DJANGO_DEBUG is true, ALLOWED_HOSTS is automatically extended with the machine hostname, FQDN (if different), private interface IPs, and any comma-separated hosts from DJANGO_DEBUG_HOSTS.

- Documentation
  - README updated to document DJANGO_DEBUG_HOSTS and how it appends trusted hosts when DJANGO_DEBUG is enabled.

- Tests
  - Added tests validating ALLOWED_HOSTS population in DEBUG, ensuring explicit DJANGO_DEBUG_HOSTS entries are preserved and private addresses are discovered, with resilient handling of socket/address resolution errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->