### PR TITLE
Configure Django database from shared environment and add migration check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,21 @@
 version: "3.9"
 
+x-database-environment: &database-environment
+  DATABASE_URL: ${DATABASE_URL:-postgresql+asyncpg://mongars:${DB_PASSWORD:-changeme}@postgres:5432/mongars_db}
+  DJANGO_DATABASE_URL: ${DJANGO_DATABASE_URL:-}
+  DB_HOST: ${DB_HOST:-postgres}
+  DB_PORT: ${DB_PORT:-5432}
+  DB_USER: ${DB_USER:-mongars}
+  DB_PASSWORD: ${DB_PASSWORD:-changeme}
+  DB_NAME: ${DB_NAME:-mongars_db}
+
 x-app-environment: &app-environment
+  <<: *database-environment
   ENV: production
   HOST: 0.0.0.0
   PORT: ${API_PORT:-8000}
   USE_RAY_SERVE: ${USE_RAY_SERVE:-false}
   RAY_SERVE_URL: ${RAY_SERVE_URL:-http://rayserve:8002/generate}
-  DATABASE_URL: postgresql+asyncpg://mongars:${DB_PASSWORD:-changeme}@postgres:5432/mongars_db
   REDIS_URL: redis://redis:6379/0
   MLFLOW_TRACKING_URI: http://mlflow:5000
   OLLAMA_HOST: ${OLLAMA_HOST:-http://ollama:11434}
@@ -81,6 +90,7 @@ services:
     env_file:
       - .env
     environment:
+      <<: *database-environment
       DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-django-insecure-change-me}
       DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-localhost,127.0.0.1}
       DJANGO_DEBUG: ${DJANGO_DEBUG:-false}
@@ -107,6 +117,7 @@ services:
     env_file:
       - .env
     environment:
+      <<: *database-environment
       DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-django-insecure-change-me}
       DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-localhost,127.0.0.1}
       DJANGO_DEBUG: ${DJANGO_DEBUG:-false}

--- a/tests/test_webapp_migrations.py
+++ b/tests/test_webapp_migrations.py
@@ -1,0 +1,47 @@
+"""Regression tests that guard the Django migration workflow."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANAGE_PY = REPO_ROOT / "webapp" / "manage.py"
+
+
+def _run_manage_command(
+    args: list[str], env: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(MANAGE_PY), *args],
+        cwd=REPO_ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_django_migrations_apply_cleanly(tmp_path: Path) -> None:
+    """Ensure Django migrations run and report as fully applied."""
+
+    env = os.environ.copy()
+    env.setdefault("DJANGO_SECRET_KEY", "test-secret-key")
+    env.setdefault("DJANGO_ALLOWED_HOSTS", "localhost,127.0.0.1")
+    env.setdefault("DJANGO_DEBUG", "False")
+    env["DJANGO_USE_SQLITE"] = "1"
+    env["DJANGO_SQLITE_PATH"] = str(tmp_path / "test-webapp.sqlite3")
+
+    migrate_result = _run_manage_command(["migrate", "--noinput"], env)
+    assert (
+        migrate_result.returncode == 0
+    ), f"migrate failed: {migrate_result.stdout}\n{migrate_result.stderr}"
+
+    check_result = _run_manage_command(["migrate", "--check"], env)
+    assert (
+        check_result.returncode == 0
+    ), f"Pending migrations detected: {check_result.stdout}\n{check_result.stderr}"


### PR DESCRIPTION
## Summary
- parse shared DATABASE_URL, DJANGO_DATABASE_URL, and DB_* env vars in the Django settings so Postgres is used by default with an explicit SQLite fallback
- reuse the shared database environment for the webapp services in docker-compose so the Django stack uses the same connection info as the FastAPI app
- add a regression test that runs Django migrations and asserts `migrate --check` succeeds to guard against unapplied migrations

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68de19ba2e448333bf3f14b8d1268122

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/monGARS/130)
<!-- GitContextEnd -->