### PR TITLE
feat: improve scheduler telemetry and load-aware routing

### DIFF
--- a/docs/implementation_status.md
+++ b/docs/implementation_status.md
@@ -46,7 +46,8 @@ and reality.
   and background jobs.
 - Safe optimisation wrappers prevent destructive upgrades by executing changes in
   a sandbox.
-- Next step: smarter load-aware scheduling and cross-node telemetry sharing.
+- Smarter load-aware scheduling now prioritises lower-risk peers using shared telemetry, and
+  nodes broadcast scheduler metrics for collaborative optimisation.
 
 ## Phase 5 – Web Interface & API Refinement (Target Q1 2026)
 - FastAPI routes for `/token`, `/api/v1/conversation/chat`, `/api/v1/conversation/history`,

--- a/monGARS/api/schemas.py
+++ b/monGARS/api/schemas.py
@@ -194,6 +194,30 @@ class PeerLoadSnapshot(BaseModel):
         return value
 
 
+class PeerTelemetryPayload(PeerLoadSnapshot):
+    """Detailed telemetry snapshot propagated between schedulers."""
+
+    worker_uptime_seconds: float = Field(default=0.0, ge=0.0)
+    tasks_processed: int = Field(default=0, ge=0)
+    tasks_failed: int = Field(default=0, ge=0)
+    task_failure_rate: float = Field(default=0.0, ge=0.0)
+    observed_at: datetime | None = None
+    source: str | None = Field(default=None, max_length=2048)
+
+    @field_validator("task_failure_rate")
+    @classmethod
+    def validate_failure_rate(cls, value: float) -> float:
+        if value < 0:
+            raise ValueError("task_failure_rate cannot be negative")
+        return value
+
+
+class PeerTelemetryEnvelope(BaseModel):
+    """Aggregated telemetry view returned by the peer telemetry endpoint."""
+
+    telemetry: list[PeerTelemetryPayload] = Field(default_factory=list)
+
+
 class SuggestRequest(BaseModel):
     """Request body for the UI suggestion endpoint."""
 

--- a/openapi.lock.json
+++ b/openapi.lock.json
@@ -407,6 +407,110 @@
         "title": "PeerRegistration",
         "type": "object"
       },
+      "PeerTelemetryEnvelope": {
+        "description": "Aggregated telemetry view returned by the peer telemetry endpoint.",
+        "properties": {
+          "telemetry": {
+            "items": {
+              "$ref": "#/components/schemas/PeerTelemetryPayload"
+            },
+            "title": "Telemetry",
+            "type": "array"
+          }
+        },
+        "title": "PeerTelemetryEnvelope",
+        "type": "object"
+      },
+      "PeerTelemetryPayload": {
+        "description": "Detailed telemetry snapshot propagated between schedulers.",
+        "properties": {
+          "active_workers": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Active Workers",
+            "type": "integer"
+          },
+          "concurrency": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Concurrency",
+            "type": "integer"
+          },
+          "load_factor": {
+            "default": 0.0,
+            "minimum": 0.0,
+            "title": "Load Factor",
+            "type": "number"
+          },
+          "observed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Observed At"
+          },
+          "queue_depth": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Queue Depth",
+            "type": "integer"
+          },
+          "scheduler_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scheduler Id"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "maxLength": 2048,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          },
+          "task_failure_rate": {
+            "default": 0.0,
+            "minimum": 0.0,
+            "title": "Task Failure Rate",
+            "type": "number"
+          },
+          "tasks_failed": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Tasks Failed",
+            "type": "integer"
+          },
+          "tasks_processed": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Tasks Processed",
+            "type": "integer"
+          },
+          "worker_uptime_seconds": {
+            "default": 0.0,
+            "minimum": 0.0,
+            "title": "Worker Uptime Seconds",
+            "type": "number"
+          }
+        },
+        "title": "PeerTelemetryPayload",
+        "type": "object"
+      },
       "RagContextRequest": {
         "description": "Request payload for the RAG context enrichment endpoint.",
         "properties": {
@@ -1084,6 +1188,76 @@
           }
         ],
         "summary": "Peer Register"
+      }
+    },
+    "/api/v1/peer/telemetry": {
+      "get": {
+        "description": "Return cached telemetry for local and remote schedulers.",
+        "operationId": "peer_telemetry_snapshot_api_v1_peer_telemetry_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PeerTelemetryEnvelope"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Peer Telemetry Snapshot"
+      },
+      "post": {
+        "description": "Accept telemetry published by peer schedulers.",
+        "operationId": "peer_telemetry_ingest_api_v1_peer_telemetry_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PeerTelemetryPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Peer Telemetry Ingest Api V1 Peer Telemetry Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Peer Telemetry Ingest"
       }
     },
     "/api/v1/peer/unregister": {

--- a/tests/test_distributed_scheduler.py
+++ b/tests/test_distributed_scheduler.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import patch
 
@@ -185,6 +186,11 @@ async def test_scheduler_routes_to_least_loaded(monkeypatch):
             "http://peer2/api/v1/peer/message",
         ]
     )
+
+    async def noop_broadcast(payload):
+        communicator.update_local_telemetry(payload)
+
+    monkeypatch.setattr(communicator, "broadcast_telemetry", noop_broadcast)
     routed: list[tuple[tuple[str, ...], dict[str, Any]]] = []
 
     async def fake_send_to(peers, message):
@@ -228,6 +234,11 @@ async def test_scheduler_falls_back_to_broadcast_when_no_better_peer(monkeypatch
     communicator = PeerCommunicator(["http://peer/api/v1/peer/message"])
     calls: list[tuple[tuple[str, ...], dict[str, Any]]] = []
 
+    async def noop_broadcast(payload):
+        communicator.update_local_telemetry(payload)
+
+    monkeypatch.setattr(communicator, "broadcast_telemetry", noop_broadcast)
+
     async def fake_send(message):
         calls.append((("broadcast",), message))
         return [True]
@@ -257,4 +268,63 @@ async def test_scheduler_falls_back_to_broadcast_when_no_better_peer(monkeypatch
     assert calls
     route, message = calls[0]
     assert route == ("broadcast",)
+    assert message["result"] == "payload"
+
+
+@pytest.mark.asyncio
+async def test_scheduler_prefers_cached_peer_load(monkeypatch):
+    communicator = PeerCommunicator(["http://peer/api/v1/peer/message"])
+    communicator.ingest_remote_telemetry(
+        "http://peer/api/v1/peer/message",
+        {
+            "scheduler_id": "remote",
+            "queue_depth": 0,
+            "active_workers": 0,
+            "concurrency": 1,
+            "load_factor": 0.1,
+            "worker_uptime_seconds": 1.0,
+            "tasks_processed": 5,
+            "tasks_failed": 0,
+            "task_failure_rate": 0.0,
+            "observed_at": datetime.now(timezone.utc).isoformat(),
+            "source": "http://peer/api/v1/peer/message",
+        },
+    )
+
+    routed: list[tuple[tuple[str, ...], dict[str, Any]]] = []
+
+    async def fake_send_to(peers, message):
+        routed.append((tuple(peers), message))
+        return [True] * len(tuple(peers))
+
+    async def fake_send(message):
+        routed.append((("broadcast",), message))
+        return [True]
+
+    async def fail_fetch():
+        raise AssertionError("fetch should not be called")
+
+    async def noop_broadcast(payload):
+        communicator.update_local_telemetry(payload)
+
+    monkeypatch.setattr(communicator, "send_to", fake_send_to)
+    monkeypatch.setattr(communicator, "send", fake_send)
+    monkeypatch.setattr(communicator, "fetch_peer_loads", fail_fetch)
+    monkeypatch.setattr(communicator, "broadcast_telemetry", noop_broadcast)
+
+    scheduler = DistributedScheduler(communicator, concurrency=1, metrics_interval=0.1)
+
+    async def task():
+        await asyncio.sleep(0.01)
+        return "payload"
+
+    await scheduler.add_task(task)
+    runner = asyncio.create_task(scheduler.run())
+    await asyncio.sleep(0.2)
+    scheduler.stop()
+    await runner
+
+    assert routed
+    first_route, message = routed[0]
+    assert first_route == ("http://peer/api/v1/peer/message",)
     assert message["result"] == "payload"


### PR DESCRIPTION
## Summary
- add peer telemetry payload schemas and HTTP endpoints so nodes can ingest and inspect shared scheduler metrics
- enhance the distributed scheduler and communicator to broadcast telemetry, cache peer load data, and select targets using richer heuristics
- cover the telemetry flow with new tests, refresh the OpenAPI lockfile, and document the completed roadmap item

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dea863e9dc8333afcbf10b7f14082a