### PR TITLE
Fix pgvector Docker image tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,7 @@ services:
       - mongars
 
   postgres:
-    image: ankane/pgvector:0.5.1
+    image: ankane/pgvector:pg16
     container_name: mongars-postgres
     ports:
       - "${POSTGRES_PORT:-5432}:5432"


### PR DESCRIPTION
## Summary
- update the postgres service to use the ankane/pgvector:pg16 image tag that exists upstream

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68defeef3c44833397a20e97eed2f9c7

## Summary by Sourcery

Bug Fixes:
- Update postgres service in docker-compose to use the correct ankane/pgvector:pg16 image tag