### PR TITLE
Add Ray Serve telemetry counters and align Alembic indexes

### DIFF
--- a/alembic/versions/20250108_03_extend_sqlmodel_indexes.py
+++ b/alembic/versions/20250108_03_extend_sqlmodel_indexes.py
@@ -1,0 +1,61 @@
+"""Align indexes with SQLModel persistence tables."""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20250108_03"
+down_revision = "20250108_02"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create indexes expected by the SQLModel metadata."""
+
+    op.create_index(
+        op.f("ix_conversation_history_user_id"),
+        "conversation_history",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_conversation_history_timestamp"),
+        "conversation_history",
+        ["timestamp"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_interactions_user_id"),
+        "interactions",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_interactions_session_id"),
+        "interactions",
+        ["session_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_interactions_created_at"),
+        "interactions",
+        ["created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop SQLModel-aligned indexes."""
+
+    op.drop_index(op.f("ix_interactions_created_at"), table_name="interactions")
+    op.drop_index(op.f("ix_interactions_session_id"), table_name="interactions")
+    op.drop_index(op.f("ix_interactions_user_id"), table_name="interactions")
+    op.drop_index(
+        op.f("ix_conversation_history_timestamp"),
+        table_name="conversation_history",
+    )
+    op.drop_index(
+        op.f("ix_conversation_history_user_id"),
+        table_name="conversation_history",
+    )

--- a/monGARS/core/llm_integration.py
+++ b/monGARS/core/llm_integration.py
@@ -4,11 +4,14 @@ import asyncio
 import hashlib
 import logging
 import os
+import time
 from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
 from typing import Any, TypeVar
+from urllib.parse import urlparse
 
 import httpx
+from opentelemetry import metrics
 
 try:  # pragma: no cover - optional dependency during tests
     import ollama
@@ -34,6 +37,29 @@ logger = logging.getLogger(__name__)
 STREAM_CHUNK_SIZE = 64
 
 T = TypeVar("T")
+
+
+meter = metrics.get_meter(__name__)
+_RAY_REQUEST_COUNTER = meter.create_counter(
+    "llm.ray.requests",
+    unit="1",
+    description="Number of Ray Serve inference attempts",
+)
+_RAY_FAILURE_COUNTER = meter.create_counter(
+    "llm.ray.failures",
+    unit="1",
+    description="Number of Ray Serve inference attempts that failed",
+)
+_RAY_SCALING_COUNTER = meter.create_counter(
+    "llm.ray.scaling_events",
+    unit="1",
+    description="Number of Ray Serve scaling or throttling events",
+)
+_RAY_LATENCY_HISTOGRAM = meter.create_histogram(
+    "llm.ray.latency",
+    unit="s",
+    description="Latency distribution for Ray Serve responses",
+)
 
 
 class AsyncTTLCache:
@@ -138,6 +164,9 @@ class LLMIntegration:
         self.coding_model = coding_definition.name
         self._ensure_models_lock = asyncio.Lock()
         self._models_ready = False
+        self._metrics_enabled = bool(
+            getattr(self._settings, "otel_metrics_enabled", False)
+        )
         use_ray_env = os.getenv("USE_RAY_SERVE")
         # Default to Ray Serve to activate distributed inference once configured.
         self.use_ray = (
@@ -564,17 +593,21 @@ class LLMIntegration:
                 payload["adapter"] = adapter
             endpoints = await self._prepare_ray_endpoints()
             if not endpoints:
+                self._record_ray_failure("configuration", endpoint=None)
                 raise RuntimeError("No Ray Serve endpoints configured")
             max_attempts = max(
                 len(endpoints) * self._ray_max_scale_cycles, len(endpoints)
             )
             last_exception: Exception | None = None
+            last_endpoint: str | None = None
             async with httpx.AsyncClient(
                 timeout=self._ray_client_timeout,
                 limits=self._ray_client_limits,
             ) as client:
                 for attempt in range(max_attempts):
                     endpoint = endpoints[attempt % len(endpoints)]
+                    last_endpoint = endpoint
+                    start_time = time.perf_counter()
                     try:
                         resp = await client.post(endpoint, json=payload)
                         resp.raise_for_status()
@@ -590,6 +623,9 @@ class LLMIntegration:
                                     "delay_seconds": delay,
                                 },
                             )
+                            self._record_ray_scaling_event(
+                                endpoint, status_code=status_code
+                            )
                             await asyncio.sleep(delay)
                             last_exception = exc
                             continue
@@ -601,15 +637,26 @@ class LLMIntegration:
                                     "status_code": status_code,
                                 },
                             )
+                            self._record_ray_failure(
+                                "server_error",
+                                endpoint=endpoint,
+                                status_code=status_code,
+                            )
                             await asyncio.sleep(min(2**attempt, 5))
                             last_exception = exc
                             continue
+                        self._record_ray_failure(
+                            "client_error",
+                            endpoint=endpoint,
+                            status_code=status_code,
+                        )
                         raise
                     except httpx.RequestError as exc:
                         logger.warning(
                             "llm.ray.transport_error",
                             extra={"endpoint": endpoint, "error": str(exc)},
                         )
+                        self._record_ray_failure("transport_error", endpoint=endpoint)
                         await asyncio.sleep(min(2**attempt, 5))
                         last_exception = exc
                         continue
@@ -621,10 +668,17 @@ class LLMIntegration:
                             "llm.ray.invalid_json",
                             extra={"status_code": resp.status_code},
                         )
+                        self._record_ray_failure(
+                            "invalid_json",
+                            endpoint=endpoint,
+                            status_code=getattr(resp, "status_code", None),
+                        )
                         raise RuntimeError("Ray Serve returned invalid JSON") from exc
 
                     await self._record_ray_success(endpoint)
+                    self._record_ray_latency(endpoint, time.perf_counter() - start_time)
                     return data
+            self._record_ray_failure("exhausted", endpoint=last_endpoint)
             raise RuntimeError("Ray Serve request failed") from last_exception
 
         return await self._ray_cb.call(call_api)
@@ -646,6 +700,70 @@ class LLMIntegration:
             except ValueError:
                 return
             self._ray_endpoint_index = (index + 1) % len(self._ray_endpoints)
+
+        attributes = self._ray_metric_attributes(endpoint, status="success")
+        if attributes:
+            _RAY_REQUEST_COUNTER.add(1, attributes)
+
+    def _ray_metric_attributes(
+        self,
+        endpoint: str | None,
+        **extra: str | int | float | bool | None,
+    ) -> dict[str, str | int | float | bool] | None:
+        if not self._metrics_enabled:
+            return None
+        host = "unknown"
+        path = ""
+        if endpoint:
+            parsed = urlparse(endpoint)
+            host = parsed.netloc or parsed.path or endpoint
+            path = parsed.path or ""
+        attributes: dict[str, str | int | float | bool] = {
+            "endpoint": host or "unknown"
+        }
+        if path and path != "/":
+            attributes["path"] = path
+        for key, value in extra.items():
+            if value is None:
+                continue
+            if isinstance(value, (str, int, float, bool)):
+                attributes[key] = value
+            else:  # pragma: no cover - defensive conversion
+                attributes[key] = str(value)
+        return attributes
+
+    def _record_ray_failure(
+        self,
+        reason: str,
+        *,
+        endpoint: str | None = None,
+        status_code: int | None = None,
+    ) -> None:
+        attributes = self._ray_metric_attributes(
+            endpoint,
+            status="failure",
+            reason=reason,
+            status_code=status_code,
+        )
+        if attributes:
+            _RAY_FAILURE_COUNTER.add(1, attributes)
+
+    def _record_ray_latency(self, endpoint: str, duration: float) -> None:
+        attributes = self._ray_metric_attributes(endpoint, status="success")
+        if attributes:
+            _RAY_LATENCY_HISTOGRAM.record(duration, attributes)
+
+    def _record_ray_scaling_event(
+        self, endpoint: str, *, status_code: int | None = None
+    ) -> None:
+        attributes = self._ray_metric_attributes(
+            endpoint,
+            status="scaling",
+            reason="status_code",
+            status_code=status_code,
+        )
+        if attributes:
+            _RAY_SCALING_COUNTER.add(1, attributes)
 
     def _scale_delay(self, attempt: int, response: httpx.Response | None) -> float:
         if response is not None:

--- a/monGARS/core/llm_integration.py
+++ b/monGARS/core/llm_integration.py
@@ -717,10 +717,10 @@ class LLMIntegration:
         path = ""
         if endpoint:
             parsed = urlparse(endpoint)
-            host = parsed.netloc or parsed.path or endpoint
+            host = parsed.netloc or "unknown"
             path = parsed.path or ""
         attributes: dict[str, str | int | float | bool] = {
-            "endpoint": host or "unknown"
+            "endpoint": host
         }
         if path and path != "/":
             attributes["path"] = path

--- a/monGARS/core/llm_integration.py
+++ b/monGARS/core/llm_integration.py
@@ -607,6 +607,11 @@ class LLMIntegration:
                 for attempt in range(max_attempts):
                     endpoint = endpoints[attempt % len(endpoints)]
                     last_endpoint = endpoint
+                    attributes = self._ray_metric_attributes(
+                        endpoint, status="attempt", attempt=attempt + 1
+                    )
+                    if attributes:
+                        _RAY_REQUEST_COUNTER.add(1, attributes)
                     start_time = time.perf_counter()
                     try:
                         resp = await client.post(endpoint, json=payload)
@@ -700,10 +705,6 @@ class LLMIntegration:
             except ValueError:
                 return
             self._ray_endpoint_index = (index + 1) % len(self._ray_endpoints)
-
-        attributes = self._ray_metric_attributes(endpoint, status="success")
-        if attributes:
-            _RAY_REQUEST_COUNTER.add(1, attributes)
 
     def _ray_metric_attributes(
         self,

--- a/tests/test_llm_ray_metrics.py
+++ b/tests/test_llm_ray_metrics.py
@@ -1,0 +1,164 @@
+import httpx
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_ray_metrics_success_records(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    monkeypatch.setenv("USE_RAY_SERVE", "true")
+    monkeypatch.setenv("RAY_SERVE_URL", "http://ray/generate")
+
+    from monGARS.core import llm_integration as module
+
+    latency_records: list[tuple[float, dict[str, object] | None]] = []
+    captured_attrs: list[tuple[str | None, dict[str, object]]] = []
+
+    monkeypatch.setattr(module, "_RESPONSE_CACHE", module.AsyncTTLCache())
+    monkeypatch.setattr(
+        module._RAY_REQUEST_COUNTER,
+        "add",
+        lambda amount, attributes=None: None,
+    )
+    monkeypatch.setattr(
+        module._RAY_FAILURE_COUNTER,
+        "add",
+        lambda amount, attributes=None: None,
+    )
+    monkeypatch.setattr(
+        module._RAY_SCALING_COUNTER,
+        "add",
+        lambda amount, attributes=None: None,
+    )
+    monkeypatch.setattr(
+        module._RAY_LATENCY_HISTOGRAM,
+        "record",
+        lambda value, attributes=None: latency_records.append((value, attributes)),
+    )
+
+    def fake_metric_attributes(
+        self, endpoint: str | None, **extra: object
+    ) -> dict[str, object]:
+        captured_attrs.append((endpoint, dict(extra)))
+        base_endpoint = endpoint or "unknown"
+        attributes: dict[str, object] = {"endpoint": base_endpoint}
+        attributes.update(extra)
+        return attributes
+
+    monkeypatch.setattr(
+        module.LLMIntegration, "_ray_metric_attributes", fake_metric_attributes
+    )
+
+    class SuccessfulClient:
+        def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - shim
+            pass
+
+        async def __aenter__(self) -> "SuccessfulClient":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def post(self, url: str, *, json: dict[str, object]) -> object:
+            class Response:
+                status_code = 200
+                headers: dict[str, str] = {}
+
+                def raise_for_status(self) -> None:
+                    return None
+
+                def json(self) -> dict[str, str]:
+                    return {"content": "ray"}
+
+            return Response()
+
+    monkeypatch.setattr(httpx, "AsyncClient", SuccessfulClient)
+
+    llm = module.LLMIntegration()
+    llm._metrics_enabled = True
+    result = await llm.generate_response("hello")
+
+    assert result["text"] == "ray"
+    assert any(extra.get("status") == "success" for _, extra in captured_attrs)
+    assert latency_records
+    assert all(extra.get("status") != "failure" for _, extra in captured_attrs)
+
+
+@pytest.mark.asyncio
+async def test_ray_metrics_failure_records(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    monkeypatch.setenv("USE_RAY_SERVE", "true")
+    monkeypatch.setenv("RAY_SERVE_URL", "http://ray/generate")
+
+    from monGARS.core import llm_integration as module
+
+    latency_records: list[tuple[float, dict[str, object] | None]] = []
+    captured_attrs: list[tuple[str | None, dict[str, object]]] = []
+    failure_records: list[tuple[int, dict[str, object] | None]] = []
+
+    monkeypatch.setattr(module, "_RESPONSE_CACHE", module.AsyncTTLCache())
+    monkeypatch.setattr(
+        module._RAY_REQUEST_COUNTER,
+        "add",
+        lambda amount, attributes=None: None,
+    )
+    monkeypatch.setattr(
+        module._RAY_FAILURE_COUNTER,
+        "add",
+        lambda amount, attributes=None: failure_records.append((amount, attributes)),
+    )
+    monkeypatch.setattr(
+        module._RAY_SCALING_COUNTER,
+        "add",
+        lambda amount, attributes=None: None,
+    )
+    monkeypatch.setattr(
+        module._RAY_LATENCY_HISTOGRAM,
+        "record",
+        lambda value, attributes=None: latency_records.append((value, attributes)),
+    )
+
+    def fake_metric_attributes(
+        self, endpoint: str | None, **extra: object
+    ) -> dict[str, object]:
+        captured_attrs.append((endpoint, dict(extra)))
+        base_endpoint = endpoint or "unknown"
+        attributes: dict[str, object] = {"endpoint": base_endpoint}
+        attributes.update(extra)
+        return attributes
+
+    monkeypatch.setattr(
+        module.LLMIntegration, "_ray_metric_attributes", fake_metric_attributes
+    )
+
+    class FailingClient:
+        def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - shim
+            pass
+
+        async def __aenter__(self) -> "FailingClient":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def post(self, url: str, *, json: dict[str, object]) -> httpx.Response:
+            raise httpx.RequestError("boom", request=httpx.Request("POST", url))
+
+    async def fake_local(self, prompt: str, task_type: str) -> dict[str, str]:
+        return {"content": f"local-{task_type}"}
+
+    monkeypatch.setattr(httpx, "AsyncClient", FailingClient)
+    monkeypatch.setattr(
+        module.LLMIntegration, "_call_local_provider", fake_local, raising=False
+    )
+
+    llm = module.LLMIntegration()
+    llm._ray_max_scale_cycles = 1
+    llm._metrics_enabled = True
+
+    response = await llm.generate_response("prompt")
+
+    assert response["text"] == "local-general"
+    assert not latency_records
+    assert failure_records
+    assert any(extra.get("reason") == "transport_error" for _, extra in captured_attrs)
+    assert any(extra.get("reason") == "exhausted" for _, extra in captured_attrs)


### PR DESCRIPTION
### **User description**
## Summary
- instrument the Ray Serve client with OpenTelemetry request, failure, scaling, and latency telemetry hooks
- add an Alembic migration to create the missing SQLModel-aligned indexes for conversation and interaction tables
- cover the new telemetry logic with dedicated Ray Serve regression tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68def5e7bf788333b5fef7e9ea4d5b0d


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Add OpenTelemetry metrics for Ray Serve requests

- Create Alembic migration for SQLModel table indexes

- Implement telemetry counters for failures and latency

- Add comprehensive test coverage for metrics


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Ray Serve Client"] --> B["OpenTelemetry Metrics"]
  B --> C["Request Counter"]
  B --> D["Failure Counter"] 
  B --> E["Latency Histogram"]
  B --> F["Scaling Events"]
  G["Database"] --> H["Alembic Migration"]
  H --> I["SQLModel Indexes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>20250108_03_extend_sqlmodel_indexes.py</strong><dd><code>Add SQLModel table indexes migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

alembic/versions/20250108_03_extend_sqlmodel_indexes.py

<ul><li>Create new Alembic migration for SQLModel table indexes<br> <li> Add indexes for <code>conversation_history</code> and <code>interactions</code> tables<br> <li> Include upgrade and downgrade functions for index management</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/139/files#diff-e996c20d1df4d651e251330d4370e593dcee15cad1964fecb2ed4f8ef05a9d0c">+61/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>llm_integration.py</strong><dd><code>Instrument Ray Serve with OpenTelemetry metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

monGARS/core/llm_integration.py

<ul><li>Import OpenTelemetry metrics and create telemetry counters<br> <li> Add metrics recording for Ray Serve requests, failures, and latency<br> <li> Implement <code>_ray_metric_attributes</code> helper for metric labeling<br> <li> Add telemetry hooks throughout Ray Serve client error handling</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/139/files#diff-61b8bef18961794dbc8434d91ef826d7f4c69d60d6bb7c40689ae37a4aa7649d">+118/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_llm_ray_metrics.py</strong><dd><code>Add Ray Serve metrics test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_llm_ray_metrics.py

<ul><li>Add comprehensive test suite for Ray Serve telemetry<br> <li> Test successful request metric recording with latency tracking<br> <li> Test failure scenarios with transport errors and exhaustion<br> <li> Mock OpenTelemetry counters and histograms for verification</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/139/files#diff-c6a55e269e0919366ad04a57a4d716f965e8c0507162a3dfe626f5a2b25ced30">+164/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds telemetry for Ray request outcomes, scaling events, and latency, with metrics collection toggle via settings.
- Performance
  - Introduces additional database indexes on conversation and interaction data to reduce query times and improve responsiveness.
- Tests
  - Adds tests covering success and failure paths for Ray telemetry, validating counters and latency recording behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->