### PR TITLE
Handle invalid JSON from RAG enrichment service

### DIFF
--- a/monGARS/core/rag/context_enricher.py
+++ b/monGARS/core/rag/context_enricher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from collections.abc import AsyncIterator, Mapping, Sequence
 from contextlib import asynccontextmanager
@@ -123,8 +124,8 @@ class RagContextEnricher:
 
         try:
             data = response.json()
-        except ValueError as exc:
-            log.debug(
+        except json.JSONDecodeError as exc:
+            log.warning(
                 "rag.context_enrichment.invalid_json",
                 extra={"error": str(exc)},
             )


### PR DESCRIPTION
### **User description**
## Summary
- return empty focus areas and references when the upstream RAG service responds with invalid JSON
- log enrichment JSON parsing failures for observability
- extend the enrichment unit test harness to cover JSON errors and expose configurable fake responses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68df347e70488333b6e00763eb2ccc4b


___

### **PR Type**
Bug fix


___

### **Description**
- Handle invalid JSON responses from RAG enrichment service

- Return empty focus areas and references on JSON parsing errors

- Add logging for JSON parsing failures for observability

- Extend test harness to cover JSON error scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RAG Service Response"] --> B["JSON Parsing"]
  B --> C{"Valid JSON?"}
  C -->|Yes| D["Process Data"]
  C -->|No| E["Log Error"]
  E --> F["Return Empty Result"]
  D --> G["Return Enriched Result"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>context_enricher.py</strong><dd><code>Add JSON parsing error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

monGARS/core/rag/context_enricher.py

<ul><li>Wrap <code>response.json()</code> call in try-catch block<br> <li> Handle <code>ValueError</code> exceptions from JSON parsing<br> <li> Log JSON parsing failures with debug level<br> <li> Return empty <code>RagEnrichmentResult</code> on JSON errors</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/143/files#diff-129c56e6a2593f887f4edec9cfe84842464fb7b067dd053d2c1ca4b2bad83718">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_rag_context_enricher.py</strong><dd><code>Extend test harness for JSON errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_rag_context_enricher.py

<ul><li>Add <code>json_exception</code> parameter to <code>FakeResponse</code> constructor<br> <li> Modify <code>json()</code> method to raise configurable exceptions<br> <li> Add new test case for invalid JSON response handling<br> <li> Import <code>Any</code> type for broader type annotations</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/143/files#diff-6248f1e8cb6668cab0259c53e0b761b195ce50498da2b35afe2e3e5a61fce21f">+33/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Handles malformed or non-JSON responses from the context enrichment service without crashing — now returns empty focus areas and references and logs a clear warning.

* **Tests**
  * Added tests that simulate invalid JSON and non-mapping responses to verify graceful handling and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->