### PR TITLE
Refresh docs and agent charters for current platform capabilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,20 +17,21 @@ highlights the non-negotiable guardrails and shared context.
 ## Roadmap Alignment
 
 - **Security & Stability Hotlist**
-  - 🔐 Align JWT algorithm with deployed secrets (HS256 today). Implement asymmetric keys only when the infrastructure supports managed key storage.
+  - ✅ Align JWT algorithm with deployed secrets (HS256 enforced until managed key storage is available).
   - 🔒 Store runtime secrets in Vault/Sealed Secrets instead of raw `k8s/secrets.yaml`.
-  - 🛡️ Update Dockerfiles to run as non-root and add a `.dockerignore` to exclude secrets and build artefacts.
+  - ✅ Update Dockerfiles to run as non-root and add a `.dockerignore` to exclude secrets and build artefacts.
   - 👤 Replace demo users in `web_api.py` with the database-backed authentication flow and migrations.
 - **Phase 3 – Hardware & Performance**
   - ✅ Worker auto-tuning for Pi/Jetson (`recommended_worker_count`).
   - ✅ Multi-architecture build scripts and cache metrics.
   - ✅ Hardened RBAC manifests.
-  - 🔄 Implement real masked next-token training in `MNTPTrainer` and wire Ray Serve HTTP requests in `LLMIntegration`.
-  - 🔄 Pin container image versions in `docker-compose.yml` and extend Alembic migrations.
+  - ✅ Ray Serve HTTP integration with circuit breaking plus MNTP trainer support for LoRA and curated adapters.
+  - 🔄 Extend Alembic migrations for the newest SQLModel tables, including legacy tables created outside the current ORM layer.
+  - ✅ Expose Ray Serve success/failure counters via OpenTelemetry (`llm.ray.*` metrics emitted by `LLMIntegration`).
 - **Phase 5 – Web/API Refinement**
   - ✅ FastAPI chat/history/token endpoints with validation.
   - ✅ Django chat UI with progressive enhancement.
-  - 🔄 Implement FastAPI WebSocket handler to match frontend expectations.
+  - ✅ FastAPI WebSocket handler with ticket verification, history replay, and streaming guarded by `WS_ENABLE_EVENTS`.
   - 🔄 Replace hard-coded credential stores with database-backed auth flows.
   - 🚧 Publish polished SDKs and reference clients.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ required to reach production readiness.
 
 - ✅ Align JWT algorithm with deployed secrets (HS256 enforced until managed key storage is available).
 - 🔒 Store runtime secrets in Vault/Sealed Secrets instead of raw `k8s/secrets.yaml`.
-- 🛡️ Update Dockerfiles to run as non-root and add a `.dockerignore` to exclude
+- ✅ Update Dockerfiles to run as non-root and add a `.dockerignore` to exclude
   secrets and build artefacts.
 - 👤 Replace demo users in `web_api.py` with the database-backed authentication
   flow and migrations.
@@ -31,8 +31,10 @@ required to reach production readiness.
 - ✅ Hardened RBAC manifests.
 - ✅ Ray Serve HTTP integration with circuit breaking plus MNTP trainer support
   for LoRA and curated adapters.
-- 🔄 Extend Alembic migrations for the newest SQLModel tables and expose Ray Serve
-  success/failure counters via OpenTelemetry.
+- 🔄 Extend Alembic migrations for the newest SQLModel tables, including legacy
+  tables created outside the current ORM layer.
+- ✅ Expose Ray Serve success/failure counters via OpenTelemetry (`llm.ray.*`
+  metrics emitted by `LLMIntegration`).
 
 ## Phase 4 – Collaborative Networking (🔄 In Progress, Target Q4 2025)
 

--- a/docs/advanced_fine_tuning.md
+++ b/docs/advanced_fine_tuning.md
@@ -6,8 +6,9 @@ curated-dataset pipeline, and Ray Serve deployment from "operational" to
 
 ## Current Capabilities
 - `LLMIntegration` streams responses from local Ollama models and performs real
-  Ray Serve round-trips with endpoint rotation, scaling-aware retries, and
-  adapter manifest tracking (`monGARS/core/llm_integration.py`).
+  Ray Serve round-trips with endpoint rotation, scaling-aware retries, adapter
+  manifest tracking, and OpenTelemetry counters/histograms for `llm.ray.*`
+  metrics (`monGARS/core/llm_integration.py`).
 - `SelfTrainingEngine` batches curated conversation records, persists anonymised
   datasets, and launches `modules.neurons.training.mntp_trainer.MNTPTrainer` to
   train either deterministic linear adapters or LoRA/QLoRA weights depending on
@@ -30,8 +31,8 @@ curated-dataset pipeline, and Ray Serve deployment from "operational" to
    - Parallelise curated linear adapter training to speed up deterministic
      fallbacks on CPU-only hardware.
 3. **Distributed Inference Operations**
-   - Expose Ray Serve health counters (`llm.ray.*`) via OpenTelemetry and
-     integrate them with the existing scheduler telemetry.
+   - Feed the emitted Ray Serve metrics (`llm.ray.requests`, `llm.ray.failures`,
+     etc.) into dashboards and alerting alongside scheduler telemetry.
    - Publish a hardened Helm chart referencing `modules/ray_service.py` so teams
      can deploy inference clusters alongside monGARS core services.
    - Automate adapter rollouts by wiring SelfTrainingEngine summaries to the Ray

--- a/docs/api/clients/python.md
+++ b/docs/api/clients/python.md
@@ -58,6 +58,11 @@ async def main() -> None:
         chat = ChatResponse.model_validate_json(response.text)
         print(chat.response)
 
+        # For WebSocket streaming request a signed ticket first, then connect to
+        # /ws/chat/?t=<ticket> using the same Authorization header if needed:
+        # ticket = await client.post("/api/v1/auth/ws/ticket", headers=headers)
+        # connect using websockets.connect("wss://.../ws/chat/?t=" + ticket.json()["ticket"])
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/docs/api/clients/typescript.md
+++ b/docs/api/clients/typescript.md
@@ -46,6 +46,9 @@ async function run() {
 run().catch((error) => {
   console.error('monGARS client error', error);
 });
+
+// For streaming support, request a signed WebSocket ticket before connecting to
+// /ws/chat/?t=<ticket>. Use the same bearer token you already configured above.
 ```
 
 ## React Native Notes

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -151,6 +151,53 @@
         ]
       }
     },
+    "/api/v1/review/rag-context": {
+      "post": {
+        "tags": [
+          "review"
+        ],
+        "summary": "Fetch Rag Context",
+        "description": "Return contextual code references relevant to the supplied query.",
+        "operationId": "fetch_rag_context_api_v1_review_rag_context_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RagContextRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RagContextResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
     "/token": {
       "post": {
         "summary": "Login",
@@ -562,6 +609,76 @@
           }
         ]
       }
+    },
+    "/api/v1/peer/telemetry": {
+      "get": {
+        "summary": "Peer Telemetry Snapshot",
+        "description": "Return cached telemetry for local and remote schedulers.",
+        "operationId": "peer_telemetry_snapshot_api_v1_peer_telemetry_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PeerTelemetryEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "post": {
+        "summary": "Peer Telemetry Ingest",
+        "description": "Accept telemetry published by peer schedulers.",
+        "operationId": "peer_telemetry_ingest_api_v1_peer_telemetry_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PeerTelemetryPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Peer Telemetry Ingest Api V1 Peer Telemetry Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
     }
   },
   "components": {
@@ -666,13 +783,17 @@
           "processing_time": {
             "type": "number",
             "title": "Processing Time"
+          },
+          "speech_turn": {
+            "$ref": "#/components/schemas/SpeechTurnSchema"
           }
         },
         "type": "object",
         "required": [
           "response",
           "confidence",
-          "processing_time"
+          "processing_time",
+          "speech_turn"
         ],
         "title": "ChatResponse",
         "description": "Canonical response body returned by the chat endpoint."
@@ -967,6 +1088,292 @@
         ],
         "title": "PeerRegistration",
         "description": "Model describing a peer registration request."
+      },
+      "PeerTelemetryEnvelope": {
+        "properties": {
+          "telemetry": {
+            "items": {
+              "$ref": "#/components/schemas/PeerTelemetryPayload"
+            },
+            "type": "array",
+            "title": "Telemetry"
+          }
+        },
+        "type": "object",
+        "title": "PeerTelemetryEnvelope",
+        "description": "Aggregated telemetry view returned by the peer telemetry endpoint."
+      },
+      "PeerTelemetryPayload": {
+        "properties": {
+          "scheduler_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scheduler Id"
+          },
+          "queue_depth": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Queue Depth",
+            "default": 0
+          },
+          "active_workers": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Active Workers",
+            "default": 0
+          },
+          "concurrency": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Concurrency",
+            "default": 0
+          },
+          "load_factor": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Load Factor",
+            "default": 0.0
+          },
+          "worker_uptime_seconds": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Worker Uptime Seconds",
+            "default": 0.0
+          },
+          "tasks_processed": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Tasks Processed",
+            "default": 0
+          },
+          "tasks_failed": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Tasks Failed",
+            "default": 0
+          },
+          "task_failure_rate": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Task Failure Rate",
+            "default": 0.0
+          },
+          "observed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Observed At"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2048
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          }
+        },
+        "type": "object",
+        "title": "PeerTelemetryPayload",
+        "description": "Detailed telemetry snapshot propagated between schedulers."
+      },
+      "RagContextRequest": {
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 4000,
+            "minLength": 1,
+            "title": "Query"
+          },
+          "repositories": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Repositories"
+          },
+          "max_results": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 50.0,
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Results"
+          }
+        },
+        "type": "object",
+        "required": [
+          "query"
+        ],
+        "title": "RagContextRequest",
+        "description": "Request payload for the RAG context enrichment endpoint."
+      },
+      "RagContextResponse": {
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled",
+            "default": true
+          },
+          "focus_areas": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Focus Areas"
+          },
+          "references": {
+            "items": {
+              "$ref": "#/components/schemas/RagReferenceSchema"
+            },
+            "type": "array",
+            "title": "References"
+          }
+        },
+        "type": "object",
+        "title": "RagContextResponse",
+        "description": "Response payload for the RAG context enrichment endpoint."
+      },
+      "RagReferenceSchema": {
+        "properties": {
+          "repository": {
+            "type": "string",
+            "title": "Repository"
+          },
+          "file_path": {
+            "type": "string",
+            "title": "File Path"
+          },
+          "summary": {
+            "type": "string",
+            "title": "Summary"
+          },
+          "score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Score"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "repository",
+          "file_path",
+          "summary"
+        ],
+        "title": "RagReferenceSchema",
+        "description": "Single reference entry returned by the RAG service."
+      },
+      "SpeechSegmentSchema": {
+        "properties": {
+          "text": {
+            "type": "string",
+            "title": "Text"
+          },
+          "estimated_duration": {
+            "type": "number",
+            "title": "Estimated Duration"
+          },
+          "pause_after": {
+            "type": "number",
+            "title": "Pause After"
+          }
+        },
+        "type": "object",
+        "required": [
+          "text",
+          "estimated_duration",
+          "pause_after"
+        ],
+        "title": "SpeechSegmentSchema",
+        "description": "Schema describing a single speech segment."
+      },
+      "SpeechTurnSchema": {
+        "properties": {
+          "turn_id": {
+            "type": "string",
+            "title": "Turn Id"
+          },
+          "text": {
+            "type": "string",
+            "title": "Text"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "segments": {
+            "items": {
+              "$ref": "#/components/schemas/SpeechSegmentSchema"
+            },
+            "type": "array",
+            "title": "Segments"
+          },
+          "average_words_per_second": {
+            "type": "number",
+            "title": "Average Words Per Second"
+          },
+          "tempo": {
+            "type": "number",
+            "title": "Tempo"
+          }
+        },
+        "type": "object",
+        "required": [
+          "turn_id",
+          "text",
+          "created_at",
+          "segments",
+          "average_words_per_second",
+          "tempo"
+        ],
+        "title": "SpeechTurnSchema",
+        "description": "Schema describing the structure of a conversational speech turn."
       },
       "SuggestRequest": {
         "properties": {

--- a/docs/implementation_status.md
+++ b/docs/implementation_status.md
@@ -1,6 +1,6 @@
 # Implementation Status Overview
 
-_Last updated: 2025-05-20_
+_Last updated: 2025-10-20_
 
 This report reconciles the roadmap with the current codebase. Each phase notes
 what has shipped, what remains, and any discrepancies between historical plans
@@ -41,8 +41,12 @@ and reality.
   `monGARS/core/llm_integration.py`.
 - ✅ Docker Compose pins images for Postgres/Redis/MLflow and defaults to a tagged
   application image (`mongars-app:0.1.0`).
-- 🔄 Outstanding: expand Alembic migrations for the latest SQLModel tables and add
-  Ray Serve health telemetry to OpenTelemetry exporters.
+- ✅ `LLMIntegration` now emits `llm.ray.requests`, `llm.ray.failures`,
+  `llm.ray.scaling_events`, and latency histograms via OpenTelemetry, unlocking
+  distributed inference dashboards without parsing logs.
+- 🔄 Outstanding: expand Alembic migrations for the latest SQLModel tables,
+  including legacy `conversation_sessions` and `emotion_trends` artefacts that
+  the ORM no longer materialises.
 
 ## Phase 4 – Collaborative Networking (In Progress – Target Q4 2025)
 
@@ -60,8 +64,9 @@ and reality.
   `/api/v1/conversation/history`, `/api/v1/review/rag-context`, and peer
   management are implemented with Pydantic validation.
 - Django chat UI renders progressive templates, and the FastAPI WebSocket handler
-  (`monGARS/api/ws_manager.py`) now authenticates tickets, replays history, and
-  streams responses when `WS_ENABLE_EVENTS` is true.
+  (`monGARS/api/ws_manager.py`) now authenticates signed tickets issued by
+  `/api/v1/auth/ws/ticket`, replays history, and streams responses when
+  `WS_ENABLE_EVENTS` is true.
 - Planned work: consolidate validation rules, migrate demo credentials to the
   database-backed auth flow, and publish polished client SDKs.
 
@@ -91,9 +96,11 @@ and reality.
 - ✅ **JWT alignment**: configuration and security manager now enforce HS256,
   deferring asymmetric keys until managed storage is available.
 - **Schema evolution**: add Alembic migrations for new persistence tables so
-  deployments avoid relying on `init_db.py` bootstrap runs.
-- **Telemetry**: emit Ray Serve success/failure counters through OpenTelemetry to
-  complement structured logs.
+  deployments avoid relying on `init_db.py` bootstrap runs, and reconcile
+  historical tables (`conversation_sessions`, `emotion_trends`) with the current
+  ORM.
+- **Telemetry integration**: forward the existing `llm.ray.*` metrics to
+  dashboards/alerts so distributed inference regressions surface quickly.
 - **Credential hardening**: replace demo admin bootstrapping with the
   database-backed auth workflow before exposing the stack beyond trusted labs.
 - **RAG operations**: document retention policies for the curated datasets stored

--- a/docs/incomplete_logic_audit.md
+++ b/docs/incomplete_logic_audit.md
@@ -1,6 +1,6 @@
 # Incomplete Logic Audit
 
-## Date: 2025-09-30
+## Date: 2025-10-20
 
 This follow-up audit re-runs and expands the repository-wide scan for patterns
 that typically signal unfinished implementations. The review covered the core
@@ -14,7 +14,7 @@ service surface, CLI entry points, and test support utilities.
 | `rg "TODO"` | Track high-level work markers left in code comments. | No matches. |
 | `rg "FIXME"` / `rg "XXX"` | Catch lower-level bug markers or temporary hacks. | No matches. |
 | `rg "NotImplemented"` | Identify deliberate stubs raising `NotImplementedError`. | One test double (documented below). |
-| `rg "\\bpass\\b" monGARS` | Locate `pass` statements inside runtime modules. | Five runtime locations reviewed. |
+| `rg "\\bpass\\b" monGARS` | Locate `pass` statements inside runtime modules. | Four runtime locations reviewed. |
 | Manual inspection | Review each match in surrounding context to confirm intent and downstream behaviour. | Completed. |
 
 The search excludes vendor directories and build artefacts. For each match, the
@@ -36,11 +36,10 @@ No runtime modules raise `NotImplementedError`.
 
 | Location | Scenario | Rationale |
 | --- | --- | --- |
-| `monGARS/api/ws_manager.py:245` | `except WebSocketDisconnect` in the connection loop. | The no-op acknowledges normal client disconnects; cleanup runs in the `finally` block immediately after the exception handler. |
-| `monGARS/core/distributed_scheduler.py:217` | `except asyncio.CancelledError` in worker coroutine. | Cancellation during shutdown is expected; worker finalisation (metrics + deregistration) executes in the enclosing `finally` block. |
-| `monGARS/core/sommeil.py:49` | `except asyncio.CancelledError` in background optimisation loop. | Allows cooperative cancellation when stopping the idle optimisation task. |
-| `monGARS/core/sommeil.py:77` | `except asyncio.CancelledError` while awaiting task cancellation during shutdown. | Mirrors the background loop handling to treat cancellation as non-fatal. |
-| `monGARS/core/security.py:71` | `except ModuleNotFoundError` when probing for `bcrypt`. | Falls back to the pure-Python `pbkdf2_sha256` hashing scheme when the optional `bcrypt` dependency is missing. |
+| `monGARS/core/distributed_scheduler.py:219` | `except asyncio.CancelledError` in worker coroutine. | Cancellation during shutdown is expected; worker finalisation (metrics + deregistration) executes in the enclosing `finally` block. |
+| `monGARS/core/sommeil.py:65` | `except asyncio.CancelledError` in background optimisation loop. | Allows cooperative cancellation when stopping the idle optimisation task. |
+| `monGARS/core/sommeil.py:87` | `except asyncio.CancelledError` while awaiting task cancellation during shutdown. | Mirrors the background loop handling to treat cancellation as non-fatal. |
+| `monGARS/core/security.py:73` | `except ModuleNotFoundError` when probing for `bcrypt`. | Falls back to the pure-Python `pbkdf2_sha256` hashing scheme when the optional `bcrypt` dependency is missing. |
 
 During review, every `pass` lands in expected defensive branches: cancellation,
 resource teardown, or optional dependency probing. No branch was left without a

--- a/docs/ray_serve_deployment.md
+++ b/docs/ray_serve_deployment.md
@@ -97,3 +97,12 @@ background workers have the expected persistence schema:
 The conversion away from the `pgvector` column type is backward-compatible; the
 new JSON payloads preserve existing embedding data while avoiding hard
 dependencies on the extension in environments that lack it.
+
+## 7. Observability & Telemetry
+
+- `LLMIntegration` publishes `llm.ray.requests`, `llm.ray.failures`,
+  `llm.ray.scaling_events`, and `llm.ray.latency` metrics via OpenTelemetry.
+- Forward these counters/histograms to your metrics backend (Prometheus, OTLP
+  collector, etc.) and alert when failure ratios or latency percentiles drift.
+- Combine Ray metrics with scheduler gauges to understand whether throttling
+  originates from inference, queuing, or upstream cognition workloads.

--- a/docs/repo_memory_alignment.md
+++ b/docs/repo_memory_alignment.md
@@ -11,7 +11,7 @@ architecture or naming conventions change.
 | Security model | `monGARS/api/authentication.py`, `monGARS/core/security.py` | OAuth2 password flow, JWT issuance, Fernet utilities. |
 | Backend scaffolding | `monGARS/api/dependencies.py` | Dependency injection helpers for FastAPI routes. |
 | Speech/Browser clients | `monGARS/api/ws_manager.py` | WebSocket fan-out with connection bookkeeping. |
-| RAG enrichment API | `monGARS/api/review.py`, `monGARS/core/rag/context_enricher.py` | `/api/v1/review/rag-context` endpoint, typed client, and enrichment fallbacks. |
+| RAG enrichment API | `monGARS/api/rag.py`, `monGARS/core/rag/context_enricher.py` | `/api/v1/review/rag-context` endpoint, typed client, and enrichment fallbacks. |
 
 ## Core Services
 | Memory Term | Repository Target | Notes |
@@ -19,7 +19,7 @@ architecture or naming conventions change.
 | Cortex + Bouche orchestration | `monGARS/core/conversation.py` | ConversationalModule coordinating memory, curiosity, LLM, mimicry. |
 | Hippocampus | `monGARS/core/hippocampus.py` | In-memory, lock-guarded conversation history. |
 | Evolution Engine / Sommeil Paradoxal | `monGARS/core/evolution_engine.py`, `monGARS/core/sommeil.py` | Diagnostics, safe optimisation, idle-time triggers. |
-| Mémoire Autobiographique | `monGARS/core/logging.py`, `monGARS/core/ui_events.py` | Structured logging and typed event bus. |
+| Mémoire Autobiographique | `monGARS/core/monitor.py`, `monGARS/core/ui_events.py` | Structured logging hooks plus the typed event bus powering UI streams. |
 | Tronc (neuro-symbolic reasoning) | `monGARS/core/neuro_symbolic/advanced_reasoner.py` | Heuristic reasoning hints for the LLM pipeline. |
 | Self-training loop | `monGARS/core/self_training.py`, `modules/neurons/training/mntp_trainer.py` | Curated dataset batching plus MNTP/LoRA training with fallbacks. |
 | Distributed inference | `monGARS/core/llm_integration.py`, `modules/ray_service.py` | Ray Serve HTTP client, adapter manifest sync, and Serve deployment. |

--- a/modules/AGENTS.md
+++ b/modules/AGENTS.md
@@ -14,9 +14,9 @@ Covers optional subsystems under `modules/`, including evolution and neuron trai
 
 - **Self-Improvement Focus**
   - ✅ Personality profiles persisted via SQLModel with live adapter updates.
-  - 🔄 Execute real self-training cycles instead of simulated versioning.
+  - ✅ Self-training cycles produce real adapter artefacts via `modules.neurons.training.mntp_trainer.MNTPTrainer` with deterministic fallbacks.
   - 🚧 Explore reinforcement learning loops and advanced scaling strategies.
-  - 🔄 Expand tests for WebSockets, hardware utilities, and distributed workflows.
+  - 🔄 Expand tests for long-running MNTP jobs, multi-replica Ray Serve rollouts, and distributed workflows.
 
 ## Design Tenets
 

--- a/modules/evolution_engine/AGENTS.md
+++ b/modules/evolution_engine/AGENTS.md
@@ -15,9 +15,9 @@ Defines how retraining orchestration and self-healing pipelines behave under
 
 - **Self-Training Execution**
   - ✅ Personality profiles persisted via SQLModel with live adapter updates.
-  - 🔄 Execute real self-training cycles instead of simulated versioning.
+  - ✅ Self-training cycles produce real adapter artefacts via `modules.neurons.training.mntp_trainer.MNTPTrainer` with deterministic fallbacks.
   - 🚧 Explore reinforcement learning loops and advanced scaling strategies.
-  - 🔄 Expand tests for WebSockets, hardware utilities, and distributed workflows.
+  - 🔄 Expand tests for long-running MNTP jobs, multi-replica Ray Serve rollouts, and distributed workflows.
 
 ## Pipeline Discipline
 

--- a/modules/neurons/AGENTS.md
+++ b/modules/neurons/AGENTS.md
@@ -14,9 +14,9 @@ Applies to neuron trainers and utilities under `modules/neurons/`.
 
 - **Training Cadence**
   - ✅ Personality profiles persisted via SQLModel with live adapter updates.
-  - 🔄 Execute real self-training cycles instead of simulated versioning.
+  - ✅ Self-training cycles produce real adapter artefacts via `modules.neurons.training.mntp_trainer.MNTPTrainer` with deterministic fallbacks.
   - 🚧 Explore reinforcement learning loops and advanced scaling strategies.
-  - 🔄 Expand tests for WebSockets, hardware utilities, and distributed workflows.
+  - 🔄 Expand tests for long-running MNTP jobs, multi-replica Ray Serve rollouts, and distributed workflows.
 
 ## Runtime Expectations
 

--- a/monGARS/AGENTS.md
+++ b/monGARS/AGENTS.md
@@ -16,8 +16,9 @@ Covers the primary FastAPI app, cognition services, persistence layer, and share
   - ✅ Worker auto-tuning for Pi/Jetson (`recommended_worker_count`).
   - ✅ Multi-architecture build scripts and cache metrics.
   - ✅ Hardened RBAC manifests.
-  - 🔄 Implement real masked next-token training in `MNTPTrainer` and wire Ray Serve HTTP requests in `LLMIntegration`.
-  - 🔄 Pin container image versions in `docker-compose.yml` and extend Alembic migrations.
+  - ✅ Ray Serve HTTP integration with circuit breaking plus MNTP trainer support for LoRA and curated adapters.
+  - 🔄 Extend Alembic migrations for the newest SQLModel tables, including legacy tables created outside the current ORM layer.
+  - ✅ Expose Ray Serve success/failure counters via OpenTelemetry (`llm.ray.*` metrics emitted by `LLMIntegration`).
 - **Networking & Collaboration**
   - ✅ Encrypted peer registry, admin-guarded endpoints, and distributed scheduler.
   - ✅ Sommeil Paradoxal idle-time optimisation and safe apply pipeline.

--- a/monGARS/api/AGENTS.md
+++ b/monGARS/api/AGENTS.md
@@ -15,7 +15,7 @@ Applies to routers, schemas, WebSocket helpers, and auth utilities under `monGAR
 - **API Refinement**
   - ✅ FastAPI chat/history/token endpoints with validation.
   - ✅ Django chat UI with progressive enhancement.
-  - 🔄 Implement FastAPI WebSocket handler to match frontend expectations.
+  - ✅ FastAPI WebSocket handler with ticket verification, history replay, and streaming guarded by `WS_ENABLE_EVENTS`.
   - 🔄 Replace hard-coded credential stores with database-backed auth flows.
   - 🚧 Publish polished SDKs and reference clients.
 

--- a/monGARS/core/AGENTS.md
+++ b/monGARS/core/AGENTS.md
@@ -16,13 +16,14 @@ Guides orchestrators, schedulers, and memory abstractions under `monGARS/core/`.
   - ✅ Worker auto-tuning for Pi/Jetson (`recommended_worker_count`).
   - ✅ Multi-architecture build scripts and cache metrics.
   - ✅ Hardened RBAC manifests.
-  - 🔄 Implement real masked next-token training in `MNTPTrainer` and wire Ray Serve HTTP requests in `LLMIntegration`.
-  - 🔄 Pin container image versions in `docker-compose.yml` and extend Alembic migrations.
+  - ✅ Ray Serve HTTP integration with circuit breaking plus MNTP trainer support for LoRA and curated adapters.
+  - 🔄 Extend Alembic migrations for the newest SQLModel tables, including legacy tables created outside the current ORM layer.
+  - ✅ Expose Ray Serve success/failure counters via OpenTelemetry (`llm.ray.*` metrics emitted by `LLMIntegration`).
 - **Self-Improvement**
   - ✅ Personality profiles persisted via SQLModel with live adapter updates.
-  - 🔄 Execute real self-training cycles instead of simulated versioning.
+  - ✅ Self-training cycles produce real adapter artefacts via `modules.neurons.training.mntp_trainer.MNTPTrainer` with deterministic fallbacks.
   - 🚧 Explore reinforcement learning loops and advanced scaling strategies.
-  - 🔄 Expand tests for WebSockets, hardware utilities, and distributed workflows.
+  - 🔄 Expand tests for long-running MNTP jobs, multi-replica Ray Serve rollouts, and distributed workflows.
 
 ## Architectural Principles
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -14,15 +14,15 @@ suites.
 ## Roadmap Alignment
 
 - **Stability Assurance**
-  - 🔐 Align JWT algorithm with deployed secrets (HS256 today). Implement asymmetric keys only when the infrastructure supports managed key storage.
+  - ✅ Align JWT algorithm with deployed secrets (HS256 enforced until managed key storage is available).
   - 🔒 Store runtime secrets in Vault/Sealed Secrets instead of raw `k8s/secrets.yaml`.
-  - 🛡️ Update Dockerfiles to run as non-root and add a `.dockerignore` to exclude secrets and build artefacts.
+  - ✅ Update Dockerfiles to run as non-root and add a `.dockerignore` to exclude secrets and build artefacts.
   - 👤 Replace demo users in `web_api.py` with the database-backed authentication flow and migrations.
 - **Research Coverage**
   - ✅ Personality profiles persisted via SQLModel with live adapter updates.
-  - 🔄 Execute real self-training cycles instead of simulated versioning.
+  - ✅ Self-training cycles produce real adapter artefacts via `modules.neurons.training.mntp_trainer.MNTPTrainer` with deterministic fallbacks.
   - 🚧 Explore reinforcement learning loops and advanced scaling strategies.
-  - 🔄 Expand tests for WebSockets, hardware utilities, and distributed workflows.
+  - 🔄 Expand tests for long-running MNTP jobs, multi-replica Ray Serve rollouts, and distributed workflows.
 
 ## Structure & Conventions
 

--- a/webapp/AGENTS.md
+++ b/webapp/AGENTS.md
@@ -16,7 +16,7 @@ middleware.
 - **Web Interface Goals**
   - ✅ FastAPI chat/history/token endpoints with validation.
   - ✅ Django chat UI with progressive enhancement.
-  - 🔄 Implement FastAPI WebSocket handler to match frontend expectations.
+  - ✅ FastAPI WebSocket handler with ticket verification, history replay, and streaming guarded by `WS_ENABLE_EVENTS`.
   - 🔄 Replace hard-coded credential stores with database-backed auth flows.
   - 🚧 Publish polished SDKs and reference clients.
 

--- a/webapp/chat/AGENTS.md
+++ b/webapp/chat/AGENTS.md
@@ -15,7 +15,7 @@ Covers views, services, forms, and templates for `webapp/chat/`.
 - **Chat UX Alignment**
   - ✅ FastAPI chat/history/token endpoints with validation.
   - ✅ Django chat UI with progressive enhancement.
-  - 🔄 Implement FastAPI WebSocket handler to match frontend expectations.
+  - ✅ FastAPI WebSocket handler with ticket verification, history replay, and streaming guarded by `WS_ENABLE_EVENTS`.
   - 🔄 Replace hard-coded credential stores with database-backed auth flows.
   - 🚧 Publish polished SDKs and reference clients.
 


### PR DESCRIPTION
## Summary
- Regenerated the roadmap-driven AGENTS charters to reflect the completed WebSocket handler, Ray Serve telemetry, and self-training capabilities.
- Updated the implementation status, fine-tuning, conversation workflow, and RAG documentation to match the current FastAPI/WebSocket behaviour and training pipeline.
- Refreshed the published OpenAPI specification and client examples so they document the WebSocket ticket workflow and latest endpoints.

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68df55d7a1348333946c0ae4e8b35e50