### PR TITLE
Add asynchronous training workflow orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ user/token.
 | `WS_ALLOWED_ORIGINS` / `WS_ENABLE_EVENTS` | Comma-separated list of origins allowed to open WebSocket sessions and a feature flag to disable streaming entirely. |
 | `REDIS_URL`, `DATABASE_URL` | Connection strings for cache and persistence layers. |
 | `OPEN_TELEMETRY_EXPORTER` | Optional metrics exporter configuration for observability pipelines. |
+| `TRAINING_PIPELINE_ENABLED` / `TRAINING_CYCLE_INTERVAL_SECONDS` / `TRAINING_CYCLE_JITTER_SECONDS` | Control whether the background evolution training workflow runs and how often cycles are executed. |
+| `TRAINING_PIPELINE_USER_ID` / `TRAINING_PIPELINE_VERSION_PREFIX` | Identify background training cycles in telemetry and manifest updates. |
 
 Document any new environment variable or feature flag in this table and the
 relevant module docstrings. Model profiles live in `configs/llm_models.json` and
@@ -212,6 +214,10 @@ can be extended to register additional Ollama models or alternate providers.
   editing public APIs.
 - **Provisioning**: `python -m scripts.provision_models --json` ensures Ollama
   weights for the active profile are present before running integration tests.
+- **Evolution cadence**: The background pipeline launched from `main.py` uses
+  `monGARS.mlops.training_pipeline.training_workflow` to trigger adapter refresh
+  cycles. Tune cadence and identifiers with the `TRAINING_PIPELINE_*`
+  environment variables documented above.
 - **Database migrations**: define new SQLModel tables in `init_db.py`, generate an
   Alembic migration, and document schema changes.
 - **Worker tuning**: `monGARS.utils.hardware.recommended_worker_count()` auto-tunes

--- a/alembic/versions/20250304_01_align_sqlmodel_tables.py
+++ b/alembic/versions/20250304_01_align_sqlmodel_tables.py
@@ -44,17 +44,23 @@ def _fill_nulls(
     *,
     type_: sa.types.TypeEngine | None = None,
 ) -> None:
-    from sqlalchemy import column as sql_column, table as sql_table, update
+    from sqlalchemy import column as sql_column
+    from sqlalchemy import table as sql_table
+    from sqlalchemy import update
 
     table_obj = sql_table(table, sql_column(column))
 
     if type_ is not None:
-        stmt = update(table_obj).where(table_obj.c[column].is_(None)).values(
-            {column: sa.bindparam("value", value=value, type_=type_)}
+        stmt = (
+            update(table_obj)
+            .where(table_obj.c[column].is_(None))
+            .values({column: sa.bindparam("value", value=value, type_=type_)})
         )
     else:
-        stmt = update(table_obj).where(table_obj.c[column].is_(None)).values(
-            {column: sa.bindparam("value", value=value)}
+        stmt = (
+            update(table_obj)
+            .where(table_obj.c[column].is_(None))
+            .values({column: sa.bindparam("value", value=value)})
         )
     op.execute(stmt)
 

--- a/monGARS/config.py
+++ b/monGARS/config.py
@@ -274,6 +274,28 @@ class Settings(BaseSettings):
     default_language: str = "fr-CA"
     caption_prefix: str = Field(default="Description de l'image:")
     otel_logs_enabled: EnvBool = Field(default=True)
+    training_pipeline_enabled: EnvBool = Field(
+        default=True,
+        description="Flag controlling whether the background evolution training workflow runs.",
+    )
+    training_pipeline_user_id: str = Field(
+        default="system-training",
+        description="User identifier recorded for background training cycles.",
+    )
+    training_pipeline_version_prefix: str = Field(
+        default="enc-auto",
+        description="Prefix used when generating automatic training version identifiers.",
+    )
+    training_cycle_interval_seconds: int = Field(
+        default=7200,
+        ge=60,
+        description="Base interval in seconds between background training cycles.",
+    )
+    training_cycle_jitter_seconds: int = Field(
+        default=300,
+        ge=0,
+        description="Maximum random jitter in seconds applied to the training interval.",
+    )
     style_base_model: str = Field(default="hf-internal-testing/tiny-random-gpt2")
     style_adapter_dir: str = Field(default="/tmp/mongars_style")
     style_max_history: int = Field(default=20)

--- a/monGARS/mlops/__init__.py
+++ b/monGARS/mlops/__init__.py
@@ -1,0 +1,5 @@
+"""Operational tooling for background training workflows."""
+
+from .training_pipeline import training_workflow
+
+__all__ = ["training_workflow"]

--- a/monGARS/mlops/training_pipeline.py
+++ b/monGARS/mlops/training_pipeline.py
@@ -1,0 +1,174 @@
+"""Asynchronous orchestration for the evolution training pipeline."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from datetime import datetime
+
+try:  # Python 3.11+
+    from datetime import UTC
+except ImportError:  # pragma: no cover - Python 3.10 fallback
+    from datetime import timezone
+
+    UTC = timezone.utc  # type: ignore[assignment]
+
+from typing import Callable
+
+from monGARS.config import Settings, get_settings
+from monGARS.core.evolution_engine import EvolutionEngine
+
+logger = logging.getLogger(__name__)
+
+
+def _generate_version(prefix: str, iteration: int) -> str:
+    """Generate a unique training version identifier."""
+
+    sanitized = "-".join(part for part in prefix.strip().split() if part) or "enc"
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    return f"{sanitized}-{timestamp}-{iteration:04d}"
+
+
+def _compute_delay(interval: float, jitter: float) -> float:
+    """Return the delay before the next training cycle respecting jitter bounds."""
+
+    interval = max(0.0, float(interval))
+    jitter = max(0.0, float(jitter))
+    if interval == 0.0:
+        return 0.0
+    spread = min(jitter, interval)
+    if spread == 0.0:
+        return interval
+    return max(0.0, interval + random.uniform(-spread, spread))
+
+
+async def _wait_for_delay(
+    duration: float, shutdown_event: asyncio.Event | None
+) -> None:
+    """Sleep for ``duration`` seconds unless ``shutdown_event`` fires sooner."""
+
+    if duration <= 0:
+        return
+    if shutdown_event is None:
+        await asyncio.sleep(duration)
+        return
+    if shutdown_event.is_set():
+        return
+    try:
+        await asyncio.wait_for(shutdown_event.wait(), timeout=duration)
+    except asyncio.TimeoutError:
+        return
+
+
+async def training_workflow(
+    *,
+    engine_factory: Callable[[], EvolutionEngine] | None = None,
+    shutdown_event: asyncio.Event | None = None,
+    max_cycles: int | None = None,
+    settings_override: Settings | None = None,
+    interval_override: float | None = None,
+    jitter_override: float | None = None,
+) -> None:
+    """Run the background evolution training workflow.
+
+    The workflow coordinates :class:`~monGARS.core.evolution_engine.EvolutionEngine`
+    to periodically execute training cycles. The behaviour is primarily driven by
+    configuration returned from :func:`monGARS.config.get_settings`, but optional
+    overrides make the routine deterministic under tests.
+
+    Args:
+        engine_factory: Optional callable that returns an ``EvolutionEngine``
+            instance. Defaults to ``EvolutionEngine``.
+        shutdown_event: When provided, the workflow exits early once the event is
+            set. Useful for orderly shutdowns in service managers.
+        max_cycles: Optional hard limit on the number of cycles to execute. When
+            ``None`` the workflow runs indefinitely until cancelled or the
+            shutdown event is triggered.
+        settings_override: Supply a preconfigured ``Settings`` instance to avoid
+            polluting the global cache during tests.
+        interval_override: Explicit interval between cycles in seconds. When
+            omitted, ``training_cycle_interval_seconds`` from settings is used.
+        jitter_override: Explicit jitter window applied to the interval. When
+            omitted, ``training_cycle_jitter_seconds`` from settings is used.
+    """
+
+    settings = settings_override or get_settings()
+    if not settings.training_pipeline_enabled:
+        logger.info("Training pipeline disabled via configuration; skipping workflow.")
+        return
+
+    if max_cycles is not None and max_cycles <= 0:
+        logger.info(
+            "Training workflow requested with non-positive max_cycles; exiting immediately."
+        )
+        return
+
+    engine_ctor = engine_factory or EvolutionEngine
+    engine = engine_ctor()
+
+    interval = (
+        float(interval_override)
+        if interval_override is not None
+        else float(settings.training_cycle_interval_seconds)
+    )
+    jitter = (
+        float(jitter_override)
+        if jitter_override is not None
+        else float(settings.training_cycle_jitter_seconds)
+    )
+
+    user_id = settings.training_pipeline_user_id or None
+    prefix = settings.training_pipeline_version_prefix or "enc"
+
+    iteration = 0
+    while True:
+        if shutdown_event is not None and shutdown_event.is_set():
+            logger.info(
+                "Training workflow shutdown signal received; terminating loop before next cycle."
+            )
+            break
+        if max_cycles is not None and iteration >= max_cycles:
+            logger.info("Training workflow completed %s cycles; exiting.", iteration)
+            break
+
+        iteration += 1
+        version = _generate_version(prefix, iteration)
+        logger.info(
+            "Starting training cycle",
+            extra={"version": version, "iteration": iteration},
+        )
+        try:
+            await engine.train_cycle(user_id=user_id, version=version)
+        except asyncio.CancelledError:
+            logger.info(
+                "Training workflow cancelled during cycle; propagating cancellation."
+            )
+            raise
+        except (
+            Exception
+        ):  # pragma: no cover - defensive guard against unexpected failures
+            logger.exception(
+                "Training cycle failed",
+                extra={"version": version, "iteration": iteration},
+            )
+
+        if shutdown_event is not None and shutdown_event.is_set():
+            logger.info(
+                "Training workflow shutdown signal received after cycle %s; exiting.",
+                iteration,
+            )
+            break
+
+        if max_cycles is not None and iteration >= max_cycles:
+            logger.info("Training workflow completed %s cycles; exiting.", iteration)
+            break
+
+        delay = _compute_delay(interval, jitter)
+        try:
+            await _wait_for_delay(delay, shutdown_event)
+        except asyncio.CancelledError:
+            logger.info(
+                "Training workflow cancelled during backoff; propagating cancellation."
+            )
+            raise

--- a/monGARS/mlops/training_pipeline.py
+++ b/monGARS/mlops/training_pipeline.py
@@ -108,9 +108,7 @@ async def training_workflow(
         return
 
     if engine_factory is None:
-        from monGARS.core.evolution_engine import (
-            EvolutionEngine as _EvolutionEngine,
-        )
+        from monGARS.core.evolution_engine import EvolutionEngine as _EvolutionEngine
 
         engine_ctor = _EvolutionEngine
     else:

--- a/monGARS/mlops/training_pipeline.py
+++ b/monGARS/mlops/training_pipeline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
+import re
 from datetime import datetime
 
 try:  # Python 3.11+
@@ -14,10 +15,12 @@ except ImportError:  # pragma: no cover - Python 3.10 fallback
 
     UTC = timezone.utc  # type: ignore[assignment]
 
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 from monGARS.config import Settings, get_settings
-from monGARS.core.evolution_engine import EvolutionEngine
+
+if TYPE_CHECKING:  # pragma: no cover - import only for typing
+    from monGARS.core.evolution_engine import EvolutionEngine
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +28,7 @@ logger = logging.getLogger(__name__)
 def _generate_version(prefix: str, iteration: int) -> str:
     """Generate a unique training version identifier."""
 
-    sanitized = "-".join(part for part in prefix.strip().split() if part) or "enc"
+    sanitized = re.sub(r"[^A-Za-z0-9._-]+", "-", prefix).strip("-") or "enc"
     timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
     return f"{sanitized}-{timestamp}-{iteration:04d}"
 
@@ -33,14 +36,14 @@ def _generate_version(prefix: str, iteration: int) -> str:
 def _compute_delay(interval: float, jitter: float) -> float:
     """Return the delay before the next training cycle respecting jitter bounds."""
 
-    interval = max(0.0, float(interval))
-    jitter = max(0.0, float(jitter))
+    interval = max(0.0, interval)
+    jitter = max(0.0, jitter)
     if interval == 0.0:
         return 0.0
     spread = min(jitter, interval)
     if spread == 0.0:
         return interval
-    return max(0.0, interval + random.uniform(-spread, spread))
+    return max(0.0, interval + random.uniform(-spread, spread))  # noqa: S311
 
 
 async def _wait_for_delay(
@@ -63,7 +66,7 @@ async def _wait_for_delay(
 
 async def training_workflow(
     *,
-    engine_factory: Callable[[], EvolutionEngine] | None = None,
+    engine_factory: Callable[[], "EvolutionEngine"] | None = None,
     shutdown_event: asyncio.Event | None = None,
     max_cycles: int | None = None,
     settings_override: Settings | None = None,
@@ -104,7 +107,14 @@ async def training_workflow(
         )
         return
 
-    engine_ctor = engine_factory or EvolutionEngine
+    if engine_factory is None:
+        from monGARS.core.evolution_engine import (
+            EvolutionEngine as _EvolutionEngine,
+        )
+
+        engine_ctor = _EvolutionEngine
+    else:
+        engine_ctor = engine_factory
     engine = engine_ctor()
 
     interval = (
@@ -118,57 +128,67 @@ async def training_workflow(
         else float(settings.training_cycle_jitter_seconds)
     )
 
-    user_id = settings.training_pipeline_user_id or None
+    user_id = settings.training_pipeline_user_id
+    if not user_id:
+        logger.error(
+            "Missing or empty training_pipeline_user_id. Audit trails require a valid user_id."
+        )
+        raise ValueError(
+            "training_pipeline_user_id must be set and non-empty for audit purposes."
+        )
     prefix = settings.training_pipeline_version_prefix or "enc"
+
+    def _should_stop(iteration_count: int) -> bool:
+        if shutdown_event is not None and shutdown_event.is_set():
+            logger.info(
+                "Training workflow shutdown signal received; terminating at iteration %s.",
+                iteration_count,
+            )
+            return True
+        if max_cycles is not None and iteration_count >= max_cycles:
+            logger.info(
+                "Training workflow completed %s cycles; exiting.", iteration_count
+            )
+            return True
+        return False
 
     iteration = 0
     while True:
-        if shutdown_event is not None and shutdown_event.is_set():
-            logger.info(
-                "Training workflow shutdown signal received; terminating loop before next cycle."
-            )
-            break
-        if max_cycles is not None and iteration >= max_cycles:
-            logger.info("Training workflow completed %s cycles; exiting.", iteration)
+        if _should_stop(iteration):
             break
 
         iteration += 1
         version = _generate_version(prefix, iteration)
         logger.info(
-            "Starting training cycle",
-            extra={"version": version, "iteration": iteration},
+            "Starting training cycle %s (version %s)",
+            iteration,
+            version,
         )
         try:
             await engine.train_cycle(user_id=user_id, version=version)
         except asyncio.CancelledError:
             logger.info(
-                "Training workflow cancelled during cycle; propagating cancellation."
+                "Training workflow cancelled during cycle %s (version %s); propagating.",
+                iteration,
+                version,
             )
             raise
         except (
             Exception
         ):  # pragma: no cover - defensive guard against unexpected failures
             logger.exception(
-                "Training cycle failed",
-                extra={"version": version, "iteration": iteration},
-            )
-
-        if shutdown_event is not None and shutdown_event.is_set():
-            logger.info(
-                "Training workflow shutdown signal received after cycle %s; exiting.",
+                "Training cycle %s (version %s) failed",
                 iteration,
+                version,
             )
-            break
-
-        if max_cycles is not None and iteration >= max_cycles:
-            logger.info("Training workflow completed %s cycles; exiting.", iteration)
-            break
 
         delay = _compute_delay(interval, jitter)
         try:
             await _wait_for_delay(delay, shutdown_event)
         except asyncio.CancelledError:
             logger.info(
-                "Training workflow cancelled during backoff; propagating cancellation."
+                "Training workflow cancelled during backoff after cycle %s (version %s); propagating.",
+                iteration,
+                version,
             )
             raise

--- a/tests/test_training_pipeline.py
+++ b/tests/test_training_pipeline.py
@@ -1,0 +1,58 @@
+from typing import Any
+
+import pytest
+
+from monGARS.config import get_settings
+from monGARS.mlops.training_pipeline import training_workflow
+
+
+class _StubEngine:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def train_cycle(self, *, user_id: str | None = None, version: str) -> None:
+        self.calls.append({"user_id": user_id, "version": version})
+
+
+@pytest.mark.asyncio
+async def test_training_workflow_runs_requested_cycles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = get_settings().model_copy(update={"training_cycle_jitter_seconds": 0})
+    engine = _StubEngine()
+
+    await training_workflow(
+        engine_factory=lambda: engine,
+        max_cycles=2,
+        settings_override=settings,
+        interval_override=0,
+        jitter_override=0,
+    )
+
+    assert len(engine.calls) == 2
+    user_ids = {call["user_id"] for call in engine.calls}
+    assert user_ids == {settings.training_pipeline_user_id}
+    versions = [call["version"] for call in engine.calls]
+    assert len({v for v in versions}) == len(versions)
+    assert all(settings.training_pipeline_version_prefix in v for v in versions)
+
+
+@pytest.mark.asyncio
+async def test_training_workflow_skips_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TRAINING_PIPELINE_ENABLED", "false")
+    get_settings.cache_clear()
+    settings = get_settings()
+
+    called = False
+
+    def _factory() -> _StubEngine:
+        nonlocal called
+        called = True
+        return _StubEngine()
+
+    await training_workflow(engine_factory=_factory, settings_override=settings)
+
+    assert settings.training_pipeline_enabled is False
+    assert called is False

--- a/tests/test_training_pipeline.py
+++ b/tests/test_training_pipeline.py
@@ -1,23 +1,38 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
 from typing import Any
 
 import pytest
 
 from monGARS.config import get_settings
-from monGARS.mlops.training_pipeline import training_workflow
+from monGARS.mlops import training_pipeline
+from monGARS.mlops.training_pipeline import (
+    _compute_delay,
+    _generate_version,
+    training_workflow,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SECRET_KEY", "test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
 
 
 class _StubEngine:
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
 
-    async def train_cycle(self, *, user_id: str | None = None, version: str) -> None:
+    async def train_cycle(self, *, version: str, user_id: str | None = None) -> None:
         self.calls.append({"user_id": user_id, "version": version})
 
 
 @pytest.mark.asyncio
-async def test_training_workflow_runs_requested_cycles(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_training_workflow_runs_requested_cycles() -> None:
     settings = get_settings().model_copy(update={"training_cycle_jitter_seconds": 0})
     engine = _StubEngine()
 
@@ -33,7 +48,7 @@ async def test_training_workflow_runs_requested_cycles(
     user_ids = {call["user_id"] for call in engine.calls}
     assert user_ids == {settings.training_pipeline_user_id}
     versions = [call["version"] for call in engine.calls]
-    assert len({v for v in versions}) == len(versions)
+    assert len(set(versions)) == len(versions)
     assert all(settings.training_pipeline_version_prefix in v for v in versions)
 
 
@@ -55,4 +70,77 @@ async def test_training_workflow_skips_when_disabled(
     await training_workflow(engine_factory=_factory, settings_override=settings)
 
     assert settings.training_pipeline_enabled is False
-    assert called is False
+    assert not called
+
+
+@pytest.mark.asyncio
+async def test_training_workflow_exits_on_shutdown_event() -> None:
+    settings = get_settings().model_copy(update={"training_cycle_jitter_seconds": 0})
+    engine = _StubEngine()
+    shutdown_event = asyncio.Event()
+    shutdown_event.set()
+
+    await training_workflow(
+        engine_factory=lambda: engine,
+        max_cycles=2,
+        settings_override=settings,
+        interval_override=0,
+        jitter_override=0,
+        shutdown_event=shutdown_event,
+    )
+
+    assert engine.calls == []
+
+
+@pytest.mark.asyncio
+async def test_training_workflow_exits_immediately_on_non_positive_max_cycles() -> None:
+    settings = get_settings().model_copy(update={"training_cycle_jitter_seconds": 0})
+    for limit in (0, -1):
+        engine = _StubEngine()
+        await training_workflow(
+            engine_factory=lambda: engine,
+            max_cycles=limit,
+            settings_override=settings,
+            interval_override=0,
+            jitter_override=0,
+        )
+        assert engine.calls == []
+
+
+def test_compute_delay_respects_interval_and_jitter_bounds() -> None:
+    cases = (
+        {"interval": 10.0, "jitter": 0.0, "expected_min": 10.0, "expected_max": 10.0},
+        {"interval": 10.0, "jitter": 2.0, "expected_min": 8.0, "expected_max": 12.0},
+        {"interval": 5.0, "jitter": 5.0, "expected_min": 0.0, "expected_max": 10.0},
+        {"interval": 0.0, "jitter": 3.0, "expected_min": 0.0, "expected_max": 0.0},
+    )
+
+    for case in cases:
+        delays = {_compute_delay(case["interval"], case["jitter"]) for _ in range(100)}
+        assert min(delays) >= case["expected_min"]
+        assert max(delays) <= case["expected_max"]
+        if case["jitter"] > 0.0 and case["interval"] > 0.0:
+            assert len(delays) > 1
+
+
+@pytest.mark.parametrize(
+    ("raw_prefix", "expected_prefix"),
+    (
+        ("enc", "enc"),
+        ("  custom prefix  ", "custom-prefix"),
+        ("@@@", "enc"),
+    ),
+)
+def test_generate_version_sanitizes_prefix(
+    monkeypatch: pytest.MonkeyPatch, raw_prefix: str, expected_prefix: str
+) -> None:
+    class _FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            return datetime(2024, 1, 2, 3, 4, 5, tzinfo=tz)
+
+    monkeypatch.setattr(training_pipeline, "datetime", _FixedDatetime)
+
+    version = _generate_version(raw_prefix, 3)
+
+    assert version.startswith(f"{expected_prefix}-20240102T030405Z-0003")


### PR DESCRIPTION
### **User description**
## Summary
- implement the asynchronous training workflow module that coordinates the EvolutionEngine with configurable cadence and shutdown handling
- add training pipeline configuration flags and document the environment variables in the README
- cover the workflow with focused tests for cycle execution and disabled-mode behaviour

## Testing
- pytest -q
- SECRET_KEY=test pytest tests/test_training_pipeline.py -q

------
https://chatgpt.com/codex/tasks/task_e_68df677c19d08333b0bfefc8abf35614


___

### **PR Type**
Enhancement


___

### **Description**
- Add asynchronous training workflow orchestration module

- Configure training pipeline with environment variables

- Implement background evolution training with jitter control

- Add comprehensive test coverage for workflow behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Config["Configuration Settings"] --> Pipeline["Training Pipeline"]
  Pipeline --> Engine["Evolution Engine"]
  Engine --> Cycles["Training Cycles"]
  Cycles --> Jitter["Interval + Jitter"]
  Jitter --> Pipeline
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>Add training pipeline configuration settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

monGARS/config.py

<ul><li>Add five new training pipeline configuration fields<br> <li> Include flags for enabling/disabling background training<br> <li> Configure cycle intervals, jitter, user ID and version prefix</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/148/files#diff-01fc8dda074f75b5c7241199f62ad73a9d2fdada3c4653b08fddd4c52ce6ede8">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Initialize mlops package with training workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

monGARS/mlops/__init__.py

<ul><li>Create new mlops package for operational tooling<br> <li> Export training_workflow function as main interface</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/148/files#diff-4ff6c84aaeab49783db53ac473dd483e808a8511cc11e6b93912bd04e3d76652">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>training_pipeline.py</strong><dd><code>Implement asynchronous training workflow orchestration</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

monGARS/mlops/training_pipeline.py

<ul><li>Implement asynchronous training workflow orchestration<br> <li> Add version generation and delay computation utilities<br> <li> Support shutdown events and configurable cycle limits<br> <li> Handle cancellation and error scenarios gracefully</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/148/files#diff-867cf8b20ba242d54dd5ab1e5e5021efdcaf8874bfa2b8c210fc97f87b4d7715">+174/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_training_pipeline.py</strong><dd><code>Add training workflow test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_training_pipeline.py

<ul><li>Test workflow executes requested number of cycles<br> <li> Verify workflow skips when disabled via configuration<br> <li> Use stub engine to capture training calls</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/148/files#diff-996f7ebe4865c71190541f5b2bdcad13ea2417a6c670a969cb963afe38e4eecc">+58/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document training pipeline configuration and workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Document training pipeline environment variables<br> <li> Add evolution cadence section explaining background workflow<br> <li> Reference training_workflow module and configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/148/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a background training workflow with configurable cadence (enable/disable, interval, jitter), per-cycle user tagging and versioning.

- Documentation
  - Documented new environment variables for controlling the training pipeline (enable flag, user ID, version prefix, interval, jitter) and updated evolution cadence guidance.

- Tests
  - Added tests for cycle execution, disable/shutdown behavior, user/version tagging, unique version generation, and delay computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->