### PR TITLE
Use persisted accounts for FastAPI authentication

### DIFF
--- a/monGARS/api/web_api.py
+++ b/monGARS/api/web_api.py
@@ -16,6 +16,7 @@ from fastapi.security import OAuth2PasswordRequestForm
 
 from monGARS.api.authentication import (
     authenticate_user,
+    ensure_bootstrap_users,
     get_current_admin_user,
     get_current_user,
 )
@@ -107,12 +108,12 @@ async def login(
     form_data: OAuth2PasswordRequestForm = Depends(),
 ) -> dict:
     """Return a simple access token."""
+    await ensure_bootstrap_users(repo, DEFAULT_USERS)
     user = await authenticate_user(
         repo,
         form_data.username,
         form_data.password,
         sec_manager,
-        DEFAULT_USERS,
     )
     token = sec_manager.create_access_token(
         {

--- a/tests/api/test_contract.py
+++ b/tests/api/test_contract.py
@@ -23,6 +23,7 @@ from monGARS.api.dependencies import (  # noqa: E402  # isort:skip
 from monGARS.api.web_api import (  # noqa: E402  # isort:skip
     app,
     get_conversational_module,
+    sec_manager,
 )
 from monGARS.api.schemas import (  # noqa: E402  # isort:skip
     ChatRequest,
@@ -236,7 +237,7 @@ async def test_chat_invalid_payload_returns_422(
     contract_client: Iterable[Tuple[TestClient, _FakePersistenceRepository]],
 ):
     client, repo = contract_client
-    await repo.create_user("u1", "hashed_password")
+    await repo.create_user("u1", sec_manager.get_password_hash("x"))
     token = client.post("/token", data={"username": "u1", "password": "x"}).json()[
         "access_token"
     ]


### PR DESCRIPTION
## Summary
- remove the in-memory credential fallback in the FastAPI auth helper and add a bootstrap routine for demo users
- have the token endpoint seed default accounts before verifying credentials
- update contract and user management tests to reflect the database-backed flow

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dfddd8b07483339e145c67d63d53d7