### PR TITLE
Expand MNTP energy and Ray Serve rollout tests

### DIFF
--- a/tests/test_ray_service.py
+++ b/tests/test_ray_service.py
@@ -336,11 +336,35 @@ async def test_ray_deployment_accepts_multi_replica_payload_once(
         "version": payload["version"],
     }
 
-    results = await asyncio.gather(
-        deployment._refresh_adapter(replica_payload),
-        deployment._refresh_adapter(replica_payload),
-    )
+    first_switch_started = asyncio.Event()
+    allow_first_switch = asyncio.Event()
 
-    assert all(result == replica_payload for result in results)
+    original_to_thread = ray_service.asyncio.to_thread
+
+    def _is_switch_call(func: Any) -> bool:
+        bound_self = getattr(func, "__self__", None)
+        bound_func = getattr(func, "__func__", None)
+        return bound_self is manager and bound_func is DummyNeuronManager.switch_encoder
+
+    async def deterministic_to_thread(func, /, *args, **kwargs):
+        if _is_switch_call(func) and not first_switch_started.is_set():
+            first_switch_started.set()
+            await allow_first_switch.wait()
+            return func(*args, **kwargs)
+        return await original_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(ray_service.asyncio, "to_thread", deterministic_to_thread)
+
+    first_task = asyncio.create_task(deployment._refresh_adapter(replica_payload))
+    await asyncio.wait_for(first_switch_started.wait(), timeout=1.0)
+    second_task = asyncio.create_task(deployment._refresh_adapter(replica_payload))
+    assert not second_task.done()
+
+    allow_first_switch.set()
+    results = await asyncio.gather(first_task, second_task)
+
+    for result in results:
+        assert result["adapter_path"] == payload["adapter_path"]
+        assert result["version"] == payload["version"]
     assert manager.switch_calls.count(replica_payload["adapter_path"]) == 1
     assert deployment._adapter_version == payload["version"]


### PR DESCRIPTION
### **User description**
## Summary
- add an energy-tracker focused regression test covering long running MNTP orchestration runs
- exercise Ray Serve deployment refresh logic for multi-replica payload rollouts
- extend distributed scheduler coverage for telemetry registration and peer targeting heuristics

## Testing
- pytest -q tests/test_mntp_trainer.py::test_orchestrator_records_energy_metrics_for_long_running_jobs tests/test_ray_service.py::test_ray_deployment_accepts_multi_replica_payload_once tests/test_distributed_scheduler.py::test_scheduler_registers_load_provider_for_telemetry tests/test_distributed_scheduler.py::test_scheduler_dispatch_targets_low_load_peers


------
https://chatgpt.com/codex/tasks/task_e_68e0296c60c08333b1ded19eefcb8134


___

### **PR Type**
Tests


___

### **Description**
- Add energy tracking test for long-running MNTP orchestration jobs

- Test Ray Serve multi-replica deployment refresh logic

- Expand distributed scheduler telemetry and peer targeting coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Suite"] --> B["MNTP Energy Tests"]
  A --> C["Ray Serve Tests"]
  A --> D["Distributed Scheduler Tests"]
  B --> E["Energy Tracker Lifecycle"]
  C --> F["Multi-Replica Deployment"]
  D --> G["Load Provider Registration"]
  D --> H["Peer Targeting Logic"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_distributed_scheduler.py</strong><dd><code>Add distributed scheduler telemetry and targeting tests</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests/test_distributed_scheduler.py

<ul><li>Add import for <code>Iterable</code> type annotation<br> <li> Add test for scheduler load provider telemetry registration<br> <li> Add test for peer targeting based on load factors<br> <li> Mock peer telemetry data and verify dispatch targeting</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/155/files#diff-554cffebad698a33454cc896554cf33349e6e86afa1b90354cc824c4abb9ddff">+82/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_mntp_trainer.py</strong><dd><code>Add MNTP orchestrator energy tracking test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_mntp_trainer.py

<ul><li>Import <code>EnergyUsageReport</code> for energy tracking tests<br> <li> Add comprehensive test for orchestrator energy metrics collection<br> <li> Create stub energy tracker with lifecycle verification<br> <li> Verify energy report persistence and telemetry integration</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/155/files#diff-2a8bc11000400222d66dddfb1fe2a190945af73d7d57bf27c70687eccfa3325c">+71/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_ray_service.py</strong><dd><code>Add Ray Serve multi-replica deployment test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_ray_service.py

<ul><li>Import <code>asyncio</code> for concurrent testing<br> <li> Add test for multi-replica deployment refresh logic<br> <li> Verify single adapter switch call across concurrent requests<br> <li> Test payload deduplication in Ray deployment scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/155/files#diff-63b41feef6d1ef8df9efd64a6024937d4f0555dd44570fb8f7a1f41dc1d47622">+44/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests for scheduler telemetry registration and dispatch to least-loaded peers.
  * Added tests to verify energy metrics are recorded for long-running training jobs and saved to reports.
  * Added test ensuring idempotent adapter refresh under concurrent multi-replica updates.
  * Minor typing improvements in tests.

* **Chores**
  * No user-facing changes; improves reliability and confidence in scheduling, energy reporting, and deployment refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->