### PR TITLE
Add comprehensive codebase status report and refresh roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,17 @@ modules so contributors can experiment end-to-end without bespoke tooling.
 
 ## Table of Contents
 1. [Project Snapshot](#project-snapshot)
-2. [Architecture at a Glance](#architecture-at-a-glance)
-3. [Functional Snapshots](#functional-snapshots)
-4. [Service Breakdown](#service-breakdown)
-5. [Getting Started](#getting-started)
-6. [Configuration Keys](#configuration-keys)
-7. [Operational Workflows](#operational-workflows)
-8. [Deployment Options](#deployment-options)
-9. [Security & Observability](#security--observability)
-10. [Documentation Map](#documentation-map)
-11. [Contributing](#contributing)
+2. [Project Health](#project-health)
+3. [Architecture at a Glance](#architecture-at-a-glance)
+4. [Functional Snapshots](#functional-snapshots)
+5. [Service Breakdown](#service-breakdown)
+6. [Getting Started](#getting-started)
+7. [Configuration Keys](#configuration-keys)
+8. [Operational Workflows](#operational-workflows)
+9. [Deployment Options](#deployment-options)
+10. [Security & Observability](#security--observability)
+11. [Documentation Map](#documentation-map)
+12. [Contributing](#contributing)
 
 ## Project Snapshot
 - **Conversational engine** with memory-backed context, curiosity-driven
@@ -36,6 +37,20 @@ modules so contributors can experiment end-to-end without bespoke tooling.
   container build scripts for multiple architectures, and Kubernetes manifests.
 - **Repository-aware RAG enrichment** that augments `/ask`, `/review`, and
   compliance flows when `rag_enabled` is set.
+
+## Project Health
+- **Phase 5 – Web/API Refinement**: REST, WebSocket, and Django operator flows
+  are production-ready, but default bootstrap accounts remain (`DEFAULT_USERS`)
+  and the SDK publishing milestone is still open.【F:monGARS/api/web_api.py†L41-L84】【F:docs/codebase_status_report.md†L76-L108】
+- **Phase 6 – Self-Improvement & Research**: Automated MNTP self-training and
+  reinforcement-learning loops exist, yet integration with operational rollout
+  controls and long-haul observability keeps the milestone in progress.【F:monGARS/core/self_training.py†L1-L160】【F:modules/neurons/training/reinforcement_loop.py†L320-L520】【F:docs/codebase_status_report.md†L109-L144】
+- **Open Risks**: Prioritise removing bootstrap credentials, packaging the
+  Python/TypeScript SDKs, and defining reinforcement-learning rollout guardrails
+  before closing the remaining roadmap items.【F:docs/codebase_status_report.md†L145-L188】
+
+See [docs/codebase_status_report.md](docs/codebase_status_report.md) for the full
+audit of runtime modules, tests, and deployment assets.【F:docs/codebase_status_report.md†L1-L188】
 
 ## Architecture at a Glance
 ![System overview diagram](docs/images/system-overview.svg)
@@ -253,6 +268,7 @@ can be extended to register additional Ollama models or alternate providers.
 | Implementation status & roadmap alignment | [docs/implementation_status.md](docs/implementation_status.md) |
 | Advanced fine-tuning plan | [docs/advanced_fine_tuning.md](docs/advanced_fine_tuning.md) |
 | Code audit notes | [docs/code_audit_summary.md](docs/code_audit_summary.md) |
+| Codebase status audit | [docs/codebase_status_report.md](docs/codebase_status_report.md) |
 | Ray Serve deployment | [docs/ray_serve_deployment.md](docs/ray_serve_deployment.md) |
 | Repository vs. memory mapping | [docs/repo_memory_alignment.md](docs/repo_memory_alignment.md) |
 | RAG context enrichment | [docs/rag_context_enrichment.md](docs/rag_context_enrichment.md) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,7 +60,9 @@ required to reach production readiness.
 - ✅ Personality profiles persisted via SQLModel with live adapter updates.
 - ✅ Self-training cycles produce real adapter artefacts via
   `modules.neurons.training.mntp_trainer.MNTPTrainer` with deterministic fallbacks.
-- 🚧 Explore reinforcement learning loops and advanced scaling strategies.
+- 🔄 Reinforcement-learning research loops ship under
+  `modules/neurons/training/reinforcement_loop.py`; integrate telemetry,
+  rollout, and operator controls before calling the milestone complete.
 - 🔄 Expand tests for long-running MNTP jobs, multi-replica Ray Serve rollouts,
   and distributed workflows.
 

--- a/docs/codebase_status_report.md
+++ b/docs/codebase_status_report.md
@@ -1,0 +1,119 @@
+# Codebase Status Report
+
+## Purpose
+This document captures the verified state of the monGARS repository as of the
+current audit. It cross-references runtime modules, optional research tooling,
+tests, and operations assets so the roadmap can be reconciled with concrete
+implementation details.
+
+## Runtime & API Surface
+- **FastAPI application** – `monGARS/api/web_api.py` exposes authentication,
+  chat, conversation history, and peer-management endpoints with typed
+  responses and dependency-injected services.【F:monGARS/api/web_api.py†L63-L200】【F:monGARS/api/web_api.py†L203-L331】
+- **Bootstrap users** – demo credentials are still seeded at startup via
+  `DEFAULT_USERS`, which keeps the credential-hardening milestone open until the
+  bootstrap flow is replaced with persisted accounts only.【F:monGARS/api/web_api.py†L41-L62】
+- **WebSocket streaming** – `monGARS/api/ws_manager.py` enforces ticket
+  verification, manages per-user rate limiting, and fans out UI events through
+  a token-bucket protected broadcaster.【F:monGARS/api/ws_manager.py†L1-L144】【F:monGARS/api/ws_manager.py†L145-L250】
+- **RAG, ticketing, and model-management routers** extend the API surface with
+  review context enrichment and administrative provisioning workflows, all wired
+  through dependency providers declared in `monGARS/api/dependencies.py`.
+
+## Cognition Pipeline
+- `monGARS/core/conversation.py` assembles Hippocampus memory, curiosity gap
+  detection, neuro-symbolic reasoning, adaptive response generation, mimicry,
+  and speech synthesis, persisting every interaction for downstream analysis.【F:monGARS/core/conversation.py†L1-L122】
+- The pipeline persists structured interaction metadata and history snapshots
+  through `PersistenceRepository`, keeping the chat stack stateless at the API
+  layer.【F:monGARS/core/conversation.py†L123-L178】
+
+## Memory & Persistence
+- Hippocampus blends in-memory caching with SQL-backed history management and
+  Redis integrations, while `monGARS/core/persistence.py` offers transactional
+  helpers for user, interaction, and adapter state records.【F:monGARS/core/hippocampus.py†L1-L160】【F:monGARS/core/persistence.py†L1-L160】
+- Alembic revisions under `alembic/versions/` align SQLModel schemas with
+  production deployments, including the 20250304 migration that backfills legacy
+  conversation tables.【F:alembic/versions/20250304_01_align_sqlmodel_tables.py†L1-L200】
+
+## LLM & Serving Layer
+- `monGARS/core/llm_integration.py` negotiates between local Ollama inference
+  and Ray Serve replicas with circuit breakers, endpoint rotation, TTL caches,
+  and OpenTelemetry counters/histograms for `llm.ray.*` metrics.【F:monGARS/core/llm_integration.py†L1-L160】【F:monGARS/core/llm_integration.py†L161-L320】
+- Model provisioning and manifest management live in
+  `monGARS/core/model_manager.py` and `modules/neurons/registry.py`, ensuring
+  adapters are installed and tracked before inference attempts occur.【F:monGARS/core/model_manager.py†L1-L200】【F:modules/neurons/registry.py†L1-L200】
+
+## Research & Training Modules
+- The **Evolution Orchestrator** coordinates MNTP training runs, energy usage
+  tracking, and manifest updates, raising errors if artefacts fall outside the
+  expected output tree.【F:modules/evolution_engine/orchestrator.py†L1-L160】
+- `modules/neurons/training/mntp_trainer.py` provides curated dataset handling,
+  deterministic linear adapters, and optional LoRA/QLoRA fine-tuning when heavy
+  dependencies are available.【F:modules/neurons/training/mntp_trainer.py†L1-L160】【F:modules/neurons/training/mntp_trainer.py†L161-L320】
+- Reinforcement-learning research loops are implemented in
+  `modules/neurons/training/reinforcement_loop.py`, including adaptive scaling
+  strategies and summary telemetry, though integration with production
+  deployment workflows remains optional for now.【F:modules/neurons/training/reinforcement_loop.py†L1-L160】【F:modules/neurons/training/reinforcement_loop.py†L320-L520】
+- `monGARS/core/self_training.py` orchestrates automated self-improvement by
+  curating records, persisting anonymised datasets, and launching MNTP training
+  runs on a schedule.【F:monGARS/core/self_training.py†L1-L160】【F:monGARS/core/self_training.py†L161-L320】
+
+## Web Operator Console
+- The Django chat console delegates HTTP calls to
+  `webapp/chat/services.py`, which handles authentication, chat submission, and
+  history retrieval against the FastAPI backend with structured error handling.【F:webapp/chat/services.py†L1-L120】
+- Templates and async views (see `webapp/chat/views.py`) integrate WebSocket
+  tickets and progressive enhancement so operators can monitor and interact with
+  conversations without JavaScript dependencies.【F:webapp/chat/views.py†L1-L200】
+
+## Observability & Peer Collaboration
+- `monGARS/core/distributed_scheduler.py` exports queue depth, uptime, and
+  failure-rate gauges via OpenTelemetry, broadcasting telemetry snapshots to
+  peers through `PeerCommunicator` for load-aware routing.【F:monGARS/core/distributed_scheduler.py†L1-L200】【F:monGARS/core/distributed_scheduler.py†L200-L400】
+- `monGARS/core/peer.py` encrypts inter-node messages, caches telemetry, and
+  supports dynamic bearer token rotation to keep distributed coordination secure
+  and observable.【F:monGARS/core/peer.py†L1-L200】【F:monGARS/core/peer.py†L200-L360】
+
+## Tests & Guardrails
+- The suite covers API contracts (`tests/test_api_chat.py`), scheduler load
+  sharing (`tests/test_distributed_scheduler.py`), reinforcement-learning loops
+  (`tests/test_reinforcement_loop.py`), and module-specific guardrails to ensure
+  TODO/NotImplemented markers do not regress.【F:tests/test_api_chat.py†L1-L200】【F:tests/test_distributed_scheduler.py†L1-L200】【F:tests/test_reinforcement_loop.py†L1-L200】【F:tests/test_incomplete_logic_guardrails.py†L1-L160】
+- Property-based and chaos experiments supplement deterministic tests to stress
+  caching, persistence, and failure-handling behaviour.【F:tests/property_test.py†L1-L200】【F:tests/chaos_test.py†L1-L160】
+
+## Deployment & Operations
+- Docker, Compose, and multi-architecture build scripts sit alongside Kubernetes
+  manifests and a Vault-backed secret store so operators can run the stack on
+  laptops or clusters.【F:Dockerfile†L1-L200】【F:build_native.sh†L1-L160】【F:k8s/secrets.yaml†L1-L120】
+- `scripts/deploy_docker.sh` automates profile selection, secret rotation, and
+  container lifecycle management to streamline developer onboarding.【F:scripts/deploy_docker.sh†L1-L200】
+
+## Known Gaps & Risks
+- **Credential Hardening** – remove the bootstrap accounts and migrate existing
+  installs to database-backed credentials only.【F:monGARS/api/web_api.py†L41-L84】
+- **SDK Publication** – Python and TypeScript SDKs exist under `sdks/`, but they
+  have not been packaged or distributed, leaving the roadmap milestone open.【F:sdks/python/README.md†L1-L160】【F:sdks/typescript/README.md†L1-L160】
+- **Reinforcement Learning Integration** – the research loop is functional yet
+  not wired into production automation, so observability and rollout policies
+  need definition before declaring the phase complete.【F:modules/neurons/training/reinforcement_loop.py†L320-L520】
+
+## Roadmap Phase Summary
+| Phase | Status | Evidence |
+| --- | --- | --- |
+| 1 – Core Infrastructure | ✅ Complete | FastAPI/Django services, persistence, and container assets are in place.【F:monGARS/api/web_api.py†L63-L200】【F:README.md†L1-L120】 |
+| 2 – Functional Expansion | ✅ Complete | Adaptive response, mimicry, curiosity, and captioning modules run end-to-end.【F:monGARS/core/conversation.py†L1-L122】【F:monGARS/core/mimicry.py†L1-L200】 |
+| 3 – Hardware & Performance | ✅ Complete | Scheduler metrics, worker tuning, and Ray Serve integration are implemented.【F:monGARS/utils/hardware.py†L1-L120】【F:monGARS/core/distributed_scheduler.py†L1-L200】【F:monGARS/core/llm_integration.py†L1-L200】 |
+| 4 – Collaborative Networking | ✅ Complete | Peer telemetry, load-aware scheduling, and Sommeil optimisation loops are shipping.【F:monGARS/core/peer.py†L1-L200】【F:monGARS/core/sommeil.py†L1-L160】 |
+| 5 – Web/API Refinement | 🔄 In Progress | Core endpoints and WebSocket handling are live, but demo credential bootstrap persists and SDKs remain unpublished.【F:monGARS/api/web_api.py†L41-L84】【F:monGARS/api/ws_manager.py†L1-L144】【F:sdks/python/README.md†L1-L160】 |
+| 6 – Self-Improvement & Research | 🔄 In Progress | Self-training and RL tooling exist, yet reinforcement runs are not integrated and long-haul tests are pending.【F:monGARS/core/self_training.py†L1-L200】【F:modules/neurons/training/reinforcement_loop.py†L320-L520】 |
+| 7 – Sustainability & Longevity | 🌱 Planned | Evolution engine and energy tracking are present, but cross-node artefact sharing and energy dashboards remain design items.【F:modules/evolution_engine/orchestrator.py†L1-L160】【F:modules/evolution_engine/energy.py†L1-L160】 |
+
+## Recommended Next Steps
+1. Retire `DEFAULT_USERS` and migrate existing deployments to persisted
+   credentials, closing the last security loophole in Phase 5.【F:monGARS/api/web_api.py†L41-L84】
+2. Package and publish the Python/TypeScript SDKs with automated CI builds so
+   partner teams can integrate against a supported client surface.【F:sdks/python/pyproject.toml†L1-L80】【F:sdks/typescript/package.json†L1-L120】
+3. Define an integration plan for reinforcement-learning loops, including
+   telemetry, rollback, and operator controls, before marking Phase 6 complete.【F:modules/neurons/training/reinforcement_loop.py†L320-L520】

--- a/docs/implementation_status.md
+++ b/docs/implementation_status.md
@@ -1,6 +1,6 @@
 # Implementation Status Overview
 
-Last updated: 2025-12-04
+Last updated: 2025-12-11
 
 This report reconciles the roadmap with the current codebase. Each phase notes
 what has shipped, what remains, and any discrepancies between historical plans
@@ -85,9 +85,11 @@ and reality.
 - ✅ SelfTrainingEngine batches curated records, persists anonymised datasets, and
   launches `modules.neurons.training.mntp_trainer.MNTPTrainer` for both curated
   linear adapters and LoRA fine-tuning when dependencies are available.
-- 🚧 Reinforcement learning experiments remain future work. Open design notes in
-  `docs/advanced_fine_tuning.md` describe candidate reward signals and replay
-  buffers, but no executable pipeline exists yet.
+- 🔄 Reinforcement learning research loops now live in
+  `modules/neurons/training/reinforcement_loop.py`, complete with adaptive
+  scaling strategies and summary telemetry. Integration with production
+  automation and long-haul observability remains outstanding, so the milestone
+  stays in progress until rollout controls land.
 - ⚠️ Testing coverage for cognition and scheduling modules is solid; expand
   end-to-end evaluations for long-running MNTP jobs and multi-replica Ray Serve
   rollouts before declaring the phase complete.
@@ -116,5 +118,6 @@ and reality.
 - **RAG governance**: document retention policies for curated datasets stored
   under `models/datasets/curated/` and ensure operators scrub sensitive context
   before exporting artefacts.
-- **Advanced research loops**: continue designing reinforcement-learning-driven
-  optimisation once the SDK and governance work land.
+- **Advanced research loops**: wire the reinforcement-learning utilities into
+  production workflows (telemetry, rollback, operator approval) before closing
+  the milestone.


### PR DESCRIPTION
## Summary
- add a codebase status report detailing runtime modules, training loops, telemetry, and deployment assets
- surface project health in the README and roadmap, highlighting remaining credential and SDK milestones
- refresh the implementation status narrative to acknowledge the reinforcement-learning tooling now in the tree

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e0322a3df08333b14362b772a123fe