### PR TITLE
Fix pgvector migration helper parsing bug

### DIFF
--- a/alembic/versions/20250308_01_restore_pgvector.py
+++ b/alembic/versions/20250308_01_restore_pgvector.py
@@ -54,11 +54,6 @@ def _normalise_vector(
         except ValueError:
             # Malformed JSON payloads should be ignored so the migration can continue.
             return None
-        payload = json.loads(candidate)
-        if not isinstance(payload, (list, tuple)):
-        payload = json.loads(candidate)
-        if not isinstance(payload, (list, tuple)):
-            return None
     if isinstance(payload, (list, tuple)):
         try:
             floats = [float(value) for value in payload]

--- a/tests/test_migration_restore_pgvector.py
+++ b/tests/test_migration_restore_pgvector.py
@@ -1,0 +1,79 @@
+"""Unit tests for the pgvector restoration migration helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+alembic_module = sys.modules.get("alembic")
+if alembic_module is None or not hasattr(alembic_module, "op"):
+    stub = types.ModuleType("alembic")
+    stub.__path__ = []  # type: ignore[attr-defined]
+    op_stub = types.ModuleType("alembic.op")
+    stub.op = op_stub
+    sys.modules["alembic"] = stub
+    sys.modules["alembic.op"] = op_stub
+
+spec = importlib.util.spec_from_file_location(
+    "restore_pgvector_migration",
+    Path(__file__).resolve().parents[1]
+    / "alembic"
+    / "versions"
+    / "20250308_01_restore_pgvector.py",
+)
+assert spec is not None and spec.loader is not None
+migration = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = migration
+spec.loader.exec_module(migration)
+
+
+@pytest.mark.parametrize(
+    "payload,dimensions,expected",
+    [
+        ("[1, 2, 3]", 4, [1.0, 2.0, 3.0, 0.0]),
+        ([0.1, 0.2, 0.3, 0.4, 0.5], 3, [0.1, 0.2, 0.3]),
+        (("1", "2"), 2, [1.0, 2.0]),
+    ],
+)
+def test_normalise_vector_success_cases(
+    payload: Any, dimensions: int, expected: list[float]
+) -> None:
+    result = migration._normalise_vector(payload, dimensions=dimensions)
+    assert result is not None
+    assert result == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [None, "", "not-json", "{}", object()],
+)
+def test_normalise_vector_invalid_payloads(payload: Any) -> None:
+    result = migration._normalise_vector(payload, dimensions=4)
+    assert result is None
+
+
+def test_normalise_vector_rejects_non_numeric_values() -> None:
+    with pytest.raises(TypeError):
+        migration._normalise_vector(["a", "b"], dimensions=2)
+
+
+def test_normalise_vector_handles_objects_with_tolist() -> None:
+    class ArrayLike:
+        def __init__(self, values: list[float]):
+            self._values = values
+
+        def tolist(self) -> list[float]:
+            return self._values
+
+    payload = ArrayLike([1.0, 2.0, 3.0])
+    result = migration._normalise_vector(payload, dimensions=5)
+    assert result is not None
+    assert len(result) == 5
+    assert result[:3] == pytest.approx([1.0, 2.0, 3.0])
+    assert all(math.isclose(value, 0.0) for value in result[3:])

--- a/tests/test_migration_restore_pgvector.py
+++ b/tests/test_migration_restore_pgvector.py
@@ -61,6 +61,8 @@ def test_normalise_vector_invalid_payloads(payload: Any) -> None:
 def test_normalise_vector_rejects_non_numeric_values() -> None:
     with pytest.raises(TypeError):
         migration._normalise_vector(["a", "b"], dimensions=2)
+    with pytest.raises(TypeError):
+        migration._normalise_vector([1, "a", 2], dimensions=3)
 
 
 def test_normalise_vector_handles_objects_with_tolist() -> None:


### PR DESCRIPTION
## Summary
- fix the `_normalise_vector` helper in the pgvector restoration migration so string payloads are parsed exactly once
- add regression tests that exercise valid, invalid, and array-like payloads without requiring the Alembic runtime

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e0655b5f94833398e88a75cca40d40

## Summary by Sourcery

Fix JSON parsing logic in the pgvector migration helper to avoid redundant loads and ensure proper handling of string inputs, and add comprehensive regression tests for the normalization function

Bug Fixes:
- Fix double JSON parsing in _normalise_vector to correctly handle string payloads

Tests:
- Add unit tests for _normalise_vector covering successful normalization, invalid payloads, non-numeric rejection, and array-like tolist handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Improved reliability when processing vector data from JSON and sequence inputs, reducing errors on invalid or empty payloads.
  - Ensures consistent float outputs and correct padding/trimming to target dimensions for vector fields.

- Tests
  - Added comprehensive test coverage for vector data handling across valid, invalid, and edge-case inputs to ensure stability and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->