### PR TITLE
Fix Ray Serve dashboard startup configuration

### DIFF
--- a/Dockerfile.rayserve
+++ b/Dockerfile.rayserve
@@ -32,6 +32,7 @@ RUN pip install --no-cache-dir \
 # Return to the default ray user for runtime safety.
 USER ray
 
-ENV PYTHONUNBUFFERED=1
+ENV PYTHONUNBUFFERED=1 \
+    RAY_DASHBOARD_ADDRESS=http://0.0.0.0:8265
 
-CMD ["python","-m","ray.serve.scripts","start","--http-host","0.0.0.0","--http-port","8002","--dashboard-host","0.0.0.0","--dashboard-port","8265","--include-dashboard","true"]
+CMD ["python","-m","ray.serve.scripts","start","--http-host","0.0.0.0","--http-port","8002","--include-dashboard","true"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -259,6 +259,7 @@ services:
       - ray
     environment:
       - PYTHONUNBUFFERED=1
+      - RAY_DASHBOARD_ADDRESS=http://0.0.0.0:8265
     command:
       - serve
       - start
@@ -266,8 +267,6 @@ services:
       - 0.0.0.0
       - --http-port
       - "8002"
-      - --dashboard-host
-      - 0.0.0.0
     ports:
       - "${RAY_HTTP_PORT:-8002}:8002"
       - "${RAY_DASHBOARD_PORT:-8265}:8265"


### PR DESCRIPTION
### **User description**
## Summary
- remove unsupported `serve start` flags and rely on environment variables for dashboard binding
- ensure Docker and compose environments expose the Ray dashboard without CLI errors

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e0946403fc8333b2c252ceeac8f1ee


___

### **PR Type**
Bug fix


___

### **Description**
- Remove unsupported `--dashboard-host` and `--dashboard-port` flags from Ray Serve startup

- Replace CLI dashboard configuration with `RAY_DASHBOARD_ADDRESS` environment variable

- Fix Docker container startup errors in Ray Serve deployment


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI flags"] -- "remove unsupported" --> B["--dashboard-host/port removed"]
  C["Environment variables"] -- "add" --> D["RAY_DASHBOARD_ADDRESS=http://0.0.0.0:8265"]
  B --> E["Fixed Ray Serve startup"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.rayserve</strong><dd><code>Replace dashboard CLI flags with environment variable</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile.rayserve

<ul><li>Add <code>RAY_DASHBOARD_ADDRESS</code> environment variable for dashboard binding<br> <li> Remove <code>--dashboard-host</code> and <code>--dashboard-port</code> flags from CMD<br> <li> Keep <code>--include-dashboard</code> flag for dashboard functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/163/files#diff-49fd53d9be4a00e7fd3c9c9663764f3e05402cfd567bb60e464ba8e303805d03">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Update compose service dashboard configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<ul><li>Add <code>RAY_DASHBOARD_ADDRESS</code> environment variable to rayserve service<br> <li> Remove <code>--dashboard-host</code> argument from command configuration<br> <li> Maintain port mappings for dashboard access</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/163/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

