### PR TITLE
Ensure database URL honours discrete credentials

### DIFF
--- a/init_db.py
+++ b/init_db.py
@@ -13,43 +13,7 @@ from alembic.config import Config
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import URL, make_url
 
-
-def _override_url_components(url: URL) -> URL:
-    """Apply environment overrides from discrete DB_* environment variables."""
-
-    overrides: dict[str, object] = {}
-
-    db_user = os.getenv("DB_USER")
-    if db_user and db_user != url.username:
-        overrides["username"] = db_user
-
-    db_password = os.getenv("DB_PASSWORD")
-    if db_password and db_password != url.password:
-        overrides["password"] = db_password
-
-    db_host = os.getenv("DB_HOST")
-    if db_host and db_host != url.host:
-        overrides["host"] = db_host
-
-    db_port = os.getenv("DB_PORT")
-    if db_port:
-        try:
-            port_int = int(db_port)
-        except ValueError:
-            logger.warning("Invalid DB_PORT value %s; ignoring override", db_port)
-        else:
-            if port_int != (url.port or port_int):
-                overrides["port"] = port_int
-
-    db_name = os.getenv("DB_NAME")
-    if db_name and db_name != url.database:
-        overrides["database"] = db_name
-
-    if overrides:
-        url = url.set(**overrides)
-
-    return url
-
+from monGARS.utils.database import apply_database_url_overrides
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -61,7 +25,22 @@ def build_sync_url() -> URL:
     raw = os.getenv("DATABASE_URL") or os.getenv("DJANGO_DATABASE_URL")
     if raw:
         url = make_url(raw)
-        url = _override_url_components(url)
+        url = apply_database_url_overrides(
+            url,
+            username=os.getenv("DB_USER"),
+            password=os.getenv("DB_PASSWORD"),
+            host=os.getenv("DB_HOST"),
+            port=os.getenv("DB_PORT"),
+            database=os.getenv("DB_NAME"),
+            logger=logger,
+            field_sources={
+                "username": "DB_USER",
+                "password": "DB_PASSWORD",
+                "host": "DB_HOST",
+                "port": "DB_PORT",
+                "database": "DB_NAME",
+            },
+        )
         return url.set(drivername="postgresql+psycopg2")
 
     return URL.create(

--- a/monGARS/config.py
+++ b/monGARS/config.py
@@ -148,7 +148,7 @@ class Settings(BaseSettings):
     db_user: str | None = Field(default=None)
     db_password: str | None = Field(default=None)
     db_host: str | None = Field(default=None)
-    db_port: int | None = Field(default=None)
+    db_port: int | str | None = Field(default=None)
     db_name: str | None = Field(default=None)
     db_pool_size: int = Field(default=5)
     db_max_overflow: int = Field(default=10)

--- a/monGARS/utils/database.py
+++ b/monGARS/utils/database.py
@@ -1,0 +1,95 @@
+"""Database URL helpers."""
+
+from __future__ import annotations
+
+import logging
+from typing import Mapping
+
+from sqlalchemy.engine import URL
+
+
+def _normalize_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def apply_database_url_overrides(
+    url: URL,
+    *,
+    username: str | None = None,
+    password: str | None = None,
+    host: str | None = None,
+    port: int | str | None = None,
+    database: str | None = None,
+    logger: logging.Logger | None = None,
+    field_sources: Mapping[str, str] | None = None,
+) -> URL:
+    """Return a URL with discrete overrides applied.
+
+    Parameters mirror PostgreSQL connection attributes. Values that are ``None`` or empty
+    strings are ignored. When ``logger`` is provided, debug statements indicate which
+    components were overridden and invalid port inputs are reported at warning level
+    without echoing the original value.
+    """
+
+    field_sources = field_sources or {}
+
+    overrides: dict[str, object] = {}
+
+    norm_username = _normalize_text(username)
+    if norm_username and norm_username != url.username:
+        overrides["username"] = norm_username
+        if logger:
+            logger.debug(
+                "Applying %s override to database username.",
+                field_sources.get("username", "username"),
+            )
+
+    norm_password = _normalize_text(password)
+    if norm_password and norm_password != url.password:
+        overrides["password"] = norm_password
+        if logger:
+            logger.debug(
+                "Applying %s override to database password.",
+                field_sources.get("password", "password"),
+            )
+
+    norm_host = _normalize_text(host)
+    if norm_host and norm_host != url.host:
+        overrides["host"] = norm_host
+        if logger:
+            logger.debug(
+                "Applying %s override to database host.",
+                field_sources.get("host", "host"),
+            )
+
+    if port is not None:
+        try:
+            port_int = int(port)
+        except (TypeError, ValueError):
+            if logger:
+                logger.warning("Invalid database port override provided; ignoring.")
+        else:
+            if url.port != port_int:
+                overrides["port"] = port_int
+                if logger:
+                    logger.debug(
+                        "Applying %s override to database port.",
+                        field_sources.get("port", "port"),
+                    )
+
+    norm_database = _normalize_text(database)
+    if norm_database and norm_database != url.database:
+        overrides["database"] = norm_database
+        if logger:
+            logger.debug(
+                "Applying %s override to database name.",
+                field_sources.get("database", "database"),
+            )
+
+    if not overrides:
+        return url
+
+    return url.set(**overrides)

--- a/monGARS/utils/database.py
+++ b/monGARS/utils/database.py
@@ -30,8 +30,8 @@ def apply_database_url_overrides(
 
     Parameters mirror PostgreSQL connection attributes. Values that are ``None`` or empty
     strings are ignored. When ``logger`` is provided, debug statements indicate which
-    components were overridden and invalid port inputs are reported at warning level
-    without echoing the original value.
+    non-sensitive components were overridden and invalid port inputs are reported at
+    warning level without echoing the original value.
     """
 
     field_sources = field_sources or {}
@@ -50,11 +50,6 @@ def apply_database_url_overrides(
     norm_password = _normalize_text(password)
     if norm_password and norm_password != url.password:
         overrides["password"] = norm_password
-        if logger:
-            logger.debug(
-                "Applying %s override to database password.",
-                field_sources.get("password", "password"),
-            )
 
     norm_host = _normalize_text(host)
     if norm_host and norm_host != url.host:

--- a/tests/test_init_db.py
+++ b/tests/test_init_db.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import importlib.util
 import os
+import sys
+import types
+from pathlib import Path
 
 import pytest
 from sqlalchemy.engine import make_url
 
+os.environ.setdefault("SECRET_KEY", "unit-test-secret")
 from monGARS import init_db
 
 
@@ -55,3 +60,26 @@ def test_resolve_database_url_rejects_remote_without_override(monkeypatch):
         None,
         "",
     }
+
+
+def test_build_sync_url_honours_password_override(monkeypatch):
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql+asyncpg://mongars:changeme@postgres:5432/mongars_db",
+    )
+    monkeypatch.setenv("DB_PASSWORD", "override-secret")
+    script_path = Path(__file__).resolve().parents[1] / "init_db.py"
+    fake_alembic = types.ModuleType("alembic")
+    fake_alembic.command = types.SimpleNamespace(upgrade=lambda *args, **kwargs: None)
+    fake_config_module = types.ModuleType("alembic.config")
+    fake_config_module.Config = object
+    monkeypatch.setitem(sys.modules, "alembic", fake_alembic)
+    monkeypatch.setitem(sys.modules, "alembic.config", fake_config_module)
+    spec = importlib.util.spec_from_file_location("mongars_init_db_script", script_path)
+    assert spec and spec.loader  # pragma: no cover - sanity check
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    url = module.build_sync_url()
+
+    assert url.password == "override-secret"

--- a/tests/test_init_db.py
+++ b/tests/test_init_db.py
@@ -91,6 +91,21 @@ def test_build_sync_url_honours_password_override(monkeypatch):
     assert url.password == "override-secret"
 
 
+def test_build_sync_url_password_override_suppresses_logging(monkeypatch, caplog):
+    caplog.set_level(logging.DEBUG)
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql+asyncpg://mongars:changeme@postgres:5432/mongars_db",
+    )
+    monkeypatch.setenv("DB_PASSWORD", "override-secret")
+    module = _load_init_db_script(monkeypatch)
+
+    module.build_sync_url()
+
+    assert "database password" not in caplog.text
+    assert "password override" not in caplog.text
+
+
 def test_build_sync_url_invalid_port_logging(monkeypatch, caplog):
     caplog.set_level(logging.WARNING)
     monkeypatch.setenv(


### PR DESCRIPTION
### **User description**
## Summary
- ensure init_db build_sync_url replaces credentials with DB_* overrides
- apply the same DB_* reconciliation in Settings and log debug overrides
- add coverage verifying Settings and init_db respect discrete database environment values

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e0a913c2708333a2eaf28326aae776


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add database URL credential override functionality

- Support discrete DB_* environment variables for connection parameters

- Implement override logic in both Settings and init_db modules

- Add comprehensive test coverage for credential overrides


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Environment Variables"] --> B["_override_url_components()"]
  B --> C["Updated Database URL"]
  D["Settings.apply_database_overrides()"] --> C
  E["init_db.build_sync_url()"] --> B
  F["Test Coverage"] --> G["Validation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>init_db.py</strong><dd><code>Database URL override functionality for init_db</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

init_db.py

<ul><li>Add <code>_override_url_components()</code> function to apply DB_* environment <br>overrides<br> <li> Integrate override logic into <code>build_sync_url()</code> function<br> <li> Handle port validation with error logging for invalid values</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/164/files#diff-afbad83f55f3f9198cacb2babfbaf1ed39f72665cf12175fadb613c37ecfc17b">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>Settings class database credential override support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

monGARS/config.py

<ul><li>Add discrete database credential fields (<code>db_user</code>, <code>db_password</code>, etc.)<br> <li> Implement <code>apply_database_overrides()</code> model validator<br> <li> Add debug logging for applied overrides<br> <li> Import SQLAlchemy URL utilities for URL manipulation</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/164/files#diff-01fc8dda074f75b5c7241199f62ad73a9d2fdada3c4653b08fddd4c52ce6ede8">+48/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_config_settings.py</strong><dd><code>Test coverage for Settings database overrides</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_config_settings.py

<ul><li>Add test for database password override functionality<br> <li> Add comprehensive test for multiple database component overrides<br> <li> Verify username, host, port, and database name overrides work <br>correctly</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/164/files#diff-6f128bf71829c2b7b75dc697d0996b17d64865db635cc32b676648f763be246f">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_init_db.py</strong><dd><code>Test coverage for init_db database overrides</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_init_db.py

<ul><li>Add test for <code>build_sync_url()</code> password override functionality<br> <li> Use dynamic module loading to test init_db script behavior<br> <li> Mock Alembic dependencies for isolated testing</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/164/files#diff-3b230e64a923f1d8868fa24725b0141b24cd7430d38a44ddc2ede00dfb692cfa">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support overriding DB connection pieces via DB_USER, DB_PASSWORD, DB_HOST, DB_PORT, DB_NAME; Settings expose optional fields and validate the composed database URL.
  * DB initialization uses these overrides when building the connection URL.

* **Bug Fixes**
  * Invalid numeric DB_PORT now emits a warning and is ignored (does not leak invalid value).

* **Tests**
  * Added tests covering password/component overrides and invalid-port logging/behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->