### PR TITLE
Add Unsloth model slot manager with persistence snapshot

### DIFF
--- a/monGARS/core/model_slot_manager.py
+++ b/monGARS/core/model_slot_manager.py
@@ -1,0 +1,252 @@
+"""Model slot manager maintaining persistent VRAM allocations.
+
+The manager keeps a cache of Unsloth-backed language models mapped to logical
+"slots".  Each slot can be acquired via a context manager which guarantees that
+models are lazily instantiated, re-used across callers, and safely offloaded
+when GPU memory pressure exceeds the configured threshold.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+import torch
+
+try:  # pragma: no cover - optional dependency at runtime
+    from unsloth import FastLanguageModel  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - handled gracefully in __enter__
+    FastLanguageModel = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional helper for GPU diagnostics
+    import GPUtil  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    GPUtil = None  # type: ignore[assignment]
+
+from .persistence import PersistenceManager
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MODEL_ID = "unsloth/mistral-7b-instruct-v0.3-bnb-4bit"
+_TARGET_MODULES: tuple[str, ...] = (
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj",
+)
+
+
+@dataclass(slots=True)
+class _SlotState:
+    """In-memory representation of a managed model slot."""
+
+    lock: threading.RLock = field(default_factory=threading.RLock)
+    model: Any | None = None
+    tokenizer: Any | None = None
+    model_id: str | None = None
+    peft_applied: bool = False
+    last_usage_fraction: float | None = None
+
+
+class ModelSlotManager:
+    """Coordinate persistent VRAM slots for local LLM execution.
+
+    The manager behaves like a lightweight singleton: slot metadata is cached at
+    the class level, while each ``ModelSlotManager`` instance is a thin wrapper
+    bound to a specific slot name.
+    """
+
+    _slots: dict[str, _SlotState] = {}
+    _slots_lock = threading.Lock()
+
+    def __init__(
+        self,
+        slot_name: str,
+        *,
+        model_id: str | None = None,
+        max_seq_length: int = 2048,
+        offload_threshold: float = 0.8,
+    ) -> None:
+        if not slot_name:
+            raise ValueError("slot_name must be provided")
+        if not (0.0 < offload_threshold < 1.0):
+            raise ValueError("offload_threshold must be in the interval (0, 1)")
+        self.slot_name = slot_name
+        self.model_id = model_id or _DEFAULT_MODEL_ID
+        self.max_seq_length = max_seq_length
+        self.offload_threshold = offload_threshold
+        self._slot_state: _SlotState | None = None
+
+    # ------------------------------------------------------------------
+    # Context manager protocol
+    # ------------------------------------------------------------------
+    def __enter__(self) -> tuple[Any, Any]:
+        slot = self._acquire_slot()
+        try:
+            if slot.model is None or slot.model_id != self.model_id:
+                self._load_into_slot(slot)
+        except Exception:
+            slot.lock.release()
+            logger.exception(
+                "model.slot.load_failed",
+                extra={"slot": self.slot_name, "model_id": self.model_id},
+            )
+            raise
+        self._slot_state = slot
+        return slot.model, slot.tokenizer  # type: ignore[return-value]
+
+    def __exit__(self, exc_type, exc, exc_tb) -> None:
+        slot = self._slot_state
+        if slot is None:
+            return
+        try:
+            allocated, total = self._current_memory_usage()
+            if allocated is not None and total:
+                slot.last_usage_fraction = allocated / total
+                logger.debug(
+                    "model.slot.vram_usage",
+                    extra={
+                        "slot": self.slot_name,
+                        "allocated_bytes": allocated,
+                        "total_bytes": total,
+                        "usage_fraction": slot.last_usage_fraction,
+                    },
+                )
+                if slot.last_usage_fraction >= self.offload_threshold:
+                    self._snapshot_and_release(slot)
+        finally:
+            try:
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+            except Exception:  # pragma: no cover - defensive logging
+                logger.exception("model.slot.empty_cache_failed")
+            slot.lock.release()
+            self._slot_state = None
+
+    # ------------------------------------------------------------------
+    # Slot lifecycle helpers
+    # ------------------------------------------------------------------
+    def _acquire_slot(self) -> _SlotState:
+        with self._slots_lock:
+            slot = self._slots.get(self.slot_name)
+            if slot is None:
+                slot = _SlotState()
+                self._slots[self.slot_name] = slot
+        slot.lock.acquire()
+        return slot
+
+    def _load_into_slot(self, slot: _SlotState) -> None:
+        if FastLanguageModel is None:
+            raise RuntimeError(
+                "Unsloth is not installed. Install the 'unsloth' package to load models."
+            )
+        logger.info(
+            "model.slot.loading",
+            extra={
+                "slot": self.slot_name,
+                "model_id": self.model_id,
+                "max_seq_length": self.max_seq_length,
+            },
+        )
+        model, tokenizer = FastLanguageModel.from_pretrained(  # type: ignore[misc]
+            self.model_id,
+            max_seq_length=self.max_seq_length,
+            load_in_4bit=True,
+            dtype=torch.float32,
+        )
+        model = FastLanguageModel.get_peft_model(  # type: ignore[misc]
+            model,
+            r=8,
+            target_modules=list(_TARGET_MODULES),
+            lora_alpha=16,
+            use_gradient_checkpointing="unsloth",
+        )
+        if hasattr(model, "eval"):
+            model.eval()
+        if hasattr(model, "config") and getattr(model.config, "use_cache", True):
+            model.config.use_cache = False
+        slot.model = model
+        slot.tokenizer = tokenizer
+        slot.model_id = self.model_id
+        slot.peft_applied = True
+        logger.info(
+            "model.slot.ready",
+            extra={"slot": self.slot_name, "model_id": self.model_id},
+        )
+
+    def _snapshot_and_release(self, slot: _SlotState) -> None:
+        if slot.model is None or slot.tokenizer is None:
+            return
+        metadata = {
+            "slot": self.slot_name,
+            "model_id": slot.model_id,
+            "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        }
+        try:
+            PersistenceManager.snapshot_model(
+                slot.model,
+                slot.tokenizer,
+                slot_name=self.slot_name,
+                metadata=metadata,
+            )
+            logger.warning(
+                "model.slot.snapshot_created",
+                extra={
+                    "slot": self.slot_name,
+                    "model_id": slot.model_id,
+                    "usage_fraction": slot.last_usage_fraction,
+                },
+            )
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception(
+                "model.slot.snapshot_failed",
+                extra={"slot": self.slot_name, "model_id": slot.model_id},
+            )
+        finally:
+            slot.model = None
+            slot.tokenizer = None
+            slot.model_id = None
+            slot.peft_applied = False
+
+    # ------------------------------------------------------------------
+    # Diagnostics
+    # ------------------------------------------------------------------
+    def _current_memory_usage(self) -> tuple[int | None, int | None]:
+        """Return the current GPU memory usage in bytes."""
+
+        try:
+            if torch.cuda.is_available():
+                device = torch.cuda.current_device()
+                allocated = int(torch.cuda.memory_allocated(device))
+                properties = torch.cuda.get_device_properties(device)
+                total = int(getattr(properties, "total_memory", 0))
+                if total:
+                    return allocated, total
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception("model.slot.cuda_stats_failed")
+
+        if GPUtil is not None:
+            try:
+                gpus: Iterable[Any] = GPUtil.getGPUs()
+                gpu_list = list(gpus)
+                if gpu_list:
+                    gpu = gpu_list[0]
+                    total_mb = getattr(gpu, "memoryTotal", None)
+                    used_mb = getattr(gpu, "memoryUsed", None)
+                    if total_mb is not None and used_mb is not None:
+                        total = int(total_mb * 1024 * 1024)
+                        allocated = int(used_mb * 1024 * 1024)
+                        return allocated, total
+            except Exception:  # pragma: no cover - defensive logging
+                logger.exception("model.slot.gputil_stats_failed")
+        return None, None
+
+
+__all__ = ["ModelSlotManager"]

--- a/tests/test_model_slot_manager.py
+++ b/tests/test_model_slot_manager.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from monGARS.core import model_slot_manager
+from monGARS.core.model_slot_manager import ModelSlotManager
+
+
+class _DummyModel:
+    def __init__(self) -> None:
+        self.device = "cuda:0"
+        self.config = SimpleNamespace(use_cache=True)
+
+    def eval(self) -> None:  # pragma: no cover - simple setter
+        self.config.use_cache = False
+
+    def state_dict(self) -> dict[str, Any]:
+        return {"weights": 1}
+
+    def generate(self, **_: Any) -> list[list[int]]:
+        return [[0, 1, 2]]
+
+
+class _DummyTokenizer:
+    def __call__(self, prompt: str, return_tensors: str = "pt") -> dict[str, Any]:
+        assert return_tensors == "pt"
+        return {"input_ids": prompt}
+
+    def save_pretrained(
+        self, path: Any
+    ) -> None:  # pragma: no cover - not used directly
+        path.mkdir(parents=True, exist_ok=True)
+
+    def decode(self, token_ids: Any, skip_special_tokens: bool = True) -> str:
+        assert skip_special_tokens
+        return "decoded"
+
+
+class _DummyFastLanguageModel:
+    load_count = 0
+
+    @classmethod
+    def from_pretrained(cls, *_: Any, **__: Any) -> tuple[_DummyModel, _DummyTokenizer]:
+        cls.load_count += 1
+        return _DummyModel(), _DummyTokenizer()
+
+    @staticmethod
+    def get_peft_model(model: _DummyModel, **_: Any) -> _DummyModel:
+        return model
+
+
+@pytest.fixture(autouse=True)
+def reset_slots() -> None:
+    ModelSlotManager._slots.clear()
+    yield
+    ModelSlotManager._slots.clear()
+
+
+def _apply_patches(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        model_slot_manager, "FastLanguageModel", _DummyFastLanguageModel
+    )
+    monkeypatch.setattr(model_slot_manager.torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(model_slot_manager.torch.cuda, "empty_cache", lambda: None)
+
+
+def test_model_slot_reuses_loaded_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    _apply_patches(monkeypatch)
+
+    with ModelSlotManager("primary") as (model_a, tok_a):
+        assert isinstance(model_a, _DummyModel)
+        assert isinstance(tok_a, _DummyTokenizer)
+
+    with ModelSlotManager("primary") as (model_b, tok_b):
+        assert model_a is model_b
+        assert tok_a is tok_b
+
+    assert _DummyFastLanguageModel.load_count == 1
+
+
+def test_snapshot_triggered_on_high_vram(monkeypatch: pytest.MonkeyPatch) -> None:
+    _apply_patches(monkeypatch)
+
+    def _memory_allocated(_: int) -> int:
+        return int(7.0 * 1024**3)
+
+    class _Props:
+        total_memory = int(8.0 * 1024**3)
+
+    snapshot_calls: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(model_slot_manager.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(model_slot_manager.torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(
+        model_slot_manager.torch.cuda, "memory_allocated", _memory_allocated
+    )
+    monkeypatch.setattr(
+        model_slot_manager.torch.cuda, "get_device_properties", lambda _: _Props()
+    )
+    monkeypatch.setattr(model_slot_manager.torch.cuda, "empty_cache", lambda: None)
+
+    def _snapshot(model: Any, tokenizer: Any, **kwargs: Any) -> None:
+        snapshot_calls.append({"model": model, "tokenizer": tokenizer, **kwargs})
+
+    monkeypatch.setattr(
+        model_slot_manager.PersistenceManager,
+        "snapshot_model",
+        staticmethod(_snapshot),
+    )
+
+    with ModelSlotManager("primary") as (model, tokenizer):
+        assert isinstance(model, _DummyModel)
+        assert isinstance(tokenizer, _DummyTokenizer)
+
+    slot_state = ModelSlotManager._slots["primary"]
+    assert slot_state.model is None
+    assert slot_state.tokenizer is None
+    assert snapshot_calls, "snapshot should be recorded when VRAM threshold exceeded"
+
+
+def test_gpu_stats_via_gputil(monkeypatch: pytest.MonkeyPatch) -> None:
+    _apply_patches(monkeypatch)
+
+    class _GPU:
+        memoryTotal = 8192
+        memoryUsed = 4096
+
+    class _GPUModule:
+        @staticmethod
+        def getGPUs() -> list[_GPU]:
+            return [_GPU()]
+
+    monkeypatch.setattr(model_slot_manager, "GPUtil", _GPUModule)
+
+    with ModelSlotManager("primary") as _:
+        pass
+
+    slot_state = ModelSlotManager._slots["primary"]
+    assert slot_state.last_usage_fraction is not None
+    assert slot_state.last_usage_fraction < 0.7


### PR DESCRIPTION
### **User description**
## Summary
- add a Unsloth-backed ModelSlotManager that locks slots, applies LoRA, and snapshots on high VRAM usage
- extend the persistence layer with a PersistenceManager.snapshot_model helper for saving models and tokenizers
- integrate the slot manager into llm_integration and cover the workflow with dedicated tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e0b896160c8333ae7767070748dcc7


___

### **PR Type**
Enhancement


___

### **Description**
- Add Unsloth-backed model slot manager for VRAM management

- Implement fallback mechanism from Ollama to slot models

- Add persistence layer for model snapshots on high memory usage

- Integrate slot manager into LLM integration workflow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["LLM Integration"] --> B["Ollama Provider"]
  B --> C["Slot Manager Fallback"]
  C --> D["Model Slot Manager"]
  D --> E["Unsloth Model Loading"]
  D --> F["VRAM Monitoring"]
  F --> G["Persistence Snapshots"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>llm_integration.py</strong><dd><code>Add slot manager fallback to LLM integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

monGARS/core/llm_integration.py

<ul><li>Import <code>ModelSlotManager</code> and <code>torch</code> dependencies<br> <li> Add fallback mechanism to slot models when Ollama fails<br> <li> Implement <code>_slot_model_fallback</code> and <code>_generate_with_model_slot</code> methods<br> <li> Integrate slot-based generation with proper error handling</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/166/files#diff-61b8bef18961794dbc8434d91ef826d7f4c69d60d6bb7c40689ae37a4aa7649d">+143/-62</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>model_slot_manager.py</strong><dd><code>Implement Unsloth-backed model slot manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

monGARS/core/model_slot_manager.py

<ul><li>Create new <code>ModelSlotManager</code> class with context manager protocol<br> <li> Implement Unsloth model loading with LoRA configuration<br> <li> Add VRAM monitoring and automatic snapshot triggering<br> <li> Support thread-safe slot acquisition and release</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/166/files#diff-b13be77b12a8d2820b6abe50f7b84bad56abef3fefb6ed6aa21b78c581547b3e">+252/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>persistence.py</strong><dd><code>Add model snapshot persistence functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

monGARS/core/persistence.py

<ul><li>Add <code>PersistenceManager.snapshot_model</code> static method<br> <li> Implement model state dict and tokenizer persistence<br> <li> Support metadata storage with timestamps<br> <li> Create directory structure for organized snapshots</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/166/files#diff-8fd559fdb476612f641de3edd9263f4483828c3662fa9be22e14a727a4bbfa61">+62/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_model_slot_manager.py</strong><dd><code>Add comprehensive model slot manager tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_model_slot_manager.py

<ul><li>Create comprehensive test suite for <code>ModelSlotManager</code><br> <li> Mock Unsloth dependencies and CUDA operations<br> <li> Test model reuse, VRAM monitoring, and snapshot triggering<br> <li> Verify GPU statistics collection via multiple backends</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/166/files#diff-3ad6a04f7db5d4454ca438d864cf66d8fd961b9823be366fb70624e1d94945b4">+143/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Automatic local AI fallback when the primary local provider is unavailable, maintaining responses without interruptions.
  * Faster, more efficient local inference via VRAM-managed model slots for improved performance.
  * Automatic model snapshotting when GPU memory is high to prevent crashes and stabilize sessions.

* Tests
  * Added tests for model slot reuse, GPU memory-triggered snapshot behavior, and GPU usage metrics to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->