### PR TITLE
Refine Ray Serve stack in Docker Compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,9 @@ REDIS_PORT=6379
 MLFLOW_PORT=5000
 VAULT_PORT=8200
 OLLAMA_PORT=11434
-RAY_HTTP_PORT=8002
+RAY_HTTP_PORT=8000
 RAY_DASHBOARD_PORT=8265
+RAY_CLIENT_PORT=10001
 # Use HS256 when signing tokens with SECRET_KEY. To enable RS256, set
 # JWT_ALGORITHM=RS256 and provide JWT_PRIVATE_KEY/JWT_PUBLIC_KEY entries in Vault.
 JWT_ALGORITHM=HS256
@@ -44,7 +45,7 @@ FASTAPI_URL=http://api:8000
 
 # Distributed inference toggles
 USE_RAY_SERVE=false
-RAY_SERVE_URL=http://rayserve:8002/generate
+RAY_SERVE_URL=http://rayserve:8000/generate
 
 # Ollama connectivity
 OLLAMA_HOST=http://ollama:11434

--- a/Dockerfile.rayserve
+++ b/Dockerfile.rayserve
@@ -1,4 +1,4 @@
-FROM rayproject/ray:2.48.0-py311
+FROM rayproject/ray:2.9.3-py311
 
 # Elevate to root to install system level dependencies, then drop back to the
 # default non-root user for runtime execution.
@@ -22,7 +22,7 @@ RUN git lfs install --system
 
 # Python dependencies required for LLM inference within Ray Serve deployments.
 RUN pip install --no-cache-dir \
-        "ray[serve]==2.48.0" \
+        "ray[serve]==2.9.3" \
         "accelerate>=0.33.0" \
         "llm2vec>=0.2.3" \
         "peft>=0.13.2" \
@@ -35,4 +35,4 @@ USER ray
 ENV PYTHONUNBUFFERED=1 \
     RAY_DASHBOARD_ADDRESS=http://0.0.0.0:8265
 
-CMD ["python","-m","ray.serve.scripts","start","--http-host","0.0.0.0","--http-port","8002","--include-dashboard","true"]
+CMD ["serve","start","--http-host","0.0.0.0","--http-port","8000"]

--- a/README.md
+++ b/README.md
@@ -156,8 +156,10 @@ development secrets, and keeps your Compose project name consistent. Optional
 profiles:
 
 - `--with-ollama` downloads and runs the Ollama runtime for local LLMs.
-- `--with-ray` provisions a Ray Serve control plane listening on
-  `${RAY_HTTP_PORT:-8002}`; toggle `USE_RAY_SERVE=true` and update
+- `--with-ray` provisions a Ray head node and Serve deployment. The Serve HTTP
+  endpoint binds to `${RAY_HTTP_PORT:-8000}`, the dashboard is exposed via
+  `${RAY_DASHBOARD_PORT:-8265}`, and the Ray Client API is forwarded to
+  `${RAY_CLIENT_PORT:-10001}`. Toggle `USE_RAY_SERVE=true` and update
   `RAY_SERVE_URL` in `.env` if you expose a different port.
 - Base images (now built from the public
   `pytorch/pytorch:2.1.2-cuda12.1-cudnn8-runtime` image—no NVIDIA Container
@@ -187,9 +189,9 @@ user/token.
 | --- | --- |
 | `SECRET_KEY` | Required for JWT signing and Fernet encryption. Never leave empty. |
 | `API_PORT` / `WEBAPP_PORT` | Host ports exposed for the FastAPI service and Django operator console. |
-| `POSTGRES_PORT`, `REDIS_PORT`, `MLFLOW_PORT`, `VAULT_PORT`, `OLLAMA_PORT`, `RAY_HTTP_PORT`, `RAY_DASHBOARD_PORT` | Host bindings for stateful and optional services managed by Compose. |
+| `POSTGRES_PORT`, `REDIS_PORT`, `MLFLOW_PORT`, `VAULT_PORT`, `OLLAMA_PORT`, `RAY_HTTP_PORT`, `RAY_DASHBOARD_PORT`, `RAY_CLIENT_PORT` | Host bindings for stateful and optional services managed by Compose. |
 | `DB_PASSWORD` | Password applied to the Postgres user `mongars`; rotated automatically by the deploy script when left as `changeme`. |
-| `USE_RAY_SERVE` / `RAY_SERVE_URL` | Enable distributed inference and point at Ray Serve HTTP endpoints (defaults to `http://rayserve:8002/generate`). |
+| `USE_RAY_SERVE` / `RAY_SERVE_URL` | Enable distributed inference and point at Ray Serve HTTP endpoints (defaults to `http://rayserve:8000/generate`). |
 | `DJANGO_SECRET_KEY`, `DJANGO_DEBUG`, `DJANGO_ALLOWED_HOSTS`, `DJANGO_DEBUG_HOSTS`, `FASTAPI_URL` | Settings used by the Django operator console when running inside Compose. When `DJANGO_ALLOWED_HOSTS` is unset the console now trusts `localhost`, loopback addresses, `0.0.0.0`, and Compose provided `WEBAPP_HOST`/`HOST` values automatically. `DJANGO_DEBUG_HOSTS` appends comma-separated hostnames/IPs that should be trusted automatically when `DJANGO_DEBUG=true`. |
 | `OLLAMA_HOST` | URL for the Ollama runtime; defaults to the local container (`http://ollama:11434`). |
 | `LLM_MODELS_CONFIG_PATH` | Path to the JSON manifest listing model profiles and download preferences. |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ x-app-environment: &app-environment
   HOST: 0.0.0.0
   PORT: ${API_PORT:-8000}
   USE_RAY_SERVE: ${USE_RAY_SERVE:-false}
-  RAY_SERVE_URL: ${RAY_SERVE_URL:-http://rayserve:8002/generate}
+  RAY_SERVE_URL: ${RAY_SERVE_URL:-http://rayserve:8000/generate}
   REDIS_URL: redis://redis:6379/0
   MLFLOW_TRACKING_URI: http://mlflow:5000
   OLLAMA_HOST: ${OLLAMA_HOST:-http://ollama:11434}
@@ -249,6 +249,30 @@ services:
     networks:
       - mongars
 
+  ray-head:
+    image: rayproject/ray:2.9.3-py311
+    container_name: mongars-ray-head
+    profiles:
+      - ray
+    command: >-
+      bash -lc "ray stop --force || true; ray start --head
+        --dashboard-host 0.0.0.0
+        --port=7000
+        --ray-client-server-port=10001
+        --num-cpus=2
+        --block"
+    ports:
+      - "${RAY_DASHBOARD_PORT:-8265}:8265"
+      - "${RAY_CLIENT_PORT:-10001}:10001"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8265 || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 30
+    restart: unless-stopped
+    networks:
+      - mongars
+
   rayserve:
     build:
       context: .
@@ -257,26 +281,21 @@ services:
     container_name: mongars-rayserve
     profiles:
       - ray
+    depends_on:
+      ray-head:
+        condition: service_healthy
     environment:
       - PYTHONUNBUFFERED=1
-      - RAY_DASHBOARD_ADDRESS=http://0.0.0.0:8265
-    command:
-      - serve
-      - start
-      - --http-host
-      - 0.0.0.0
-      - --http-port
-      - "8002"
+      - RAY_ADDRESS=ray://ray-head:10001
+    command: >-
+      bash -lc "serve start --address ray://ray-head:10001 --http-host 0.0.0.0 --http-port 8000"
     ports:
-      - "${RAY_HTTP_PORT:-8002}:8002"
-      - "${RAY_DASHBOARD_PORT:-8265}:8265"
+      - "${RAY_HTTP_PORT:-8000}:8000"
     healthcheck:
-      test:
-        - "CMD-SHELL"
-        - "curl -fsS http://127.0.0.1:8265 >/dev/null"
-      interval: 30s
-      timeout: 10s
-      retries: 5
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8000/-/healthz || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 30
     restart: unless-stopped
     networks:
       - mongars


### PR DESCRIPTION
## Summary
- add a dedicated `ray-head` service to docker-compose and rewire the Serve container to the new 8000/10001 ports
- align `.env.example` and README defaults with the updated Ray Serve endpoints and document the exposed client port
- retarget the Ray Serve image to 2.9.3 and standardise the startup command to `serve start`

## Testing
- pytest -q *(fails: `tests/test_incomplete_logic_guardrails.py::test_incomplete_logic_markers_absent` due to existing NotImplemented guard entries)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c724d32c8333a9c715cbc745d52b