### PR TITLE
Pin pytest-asyncio to maintain Docker build compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,6 @@ requests-oauthlib>=2.0.0
 websocket-client>=1.8.0
 websockets>=12.0
 pytest
-pytest-asyncio
+pytest-asyncio>=0.23.8,<0.25
 alembic>=1.13.2
 psycopg2-binary>=2.9.9


### PR DESCRIPTION
## Summary
- constrain pytest-asyncio to the 0.23 release line so Python 3.10 images can install dependencies during Docker builds

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e0e209bdf48333a6673bd4593e4fd2

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/monGARS/170)
<!-- GitContextEnd -->