### PR TITLE
Align docker compose project defaults with network configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -302,7 +302,7 @@ services:
 
 networks:
   mongars:
-    name: mongars-1_mongars
+    name: ${COMPOSE_PROJECT_NAME:-mongars-1}_mongars
     driver: bridge
     driver_opts:
       com.docker.network.enable_ipv4: "true"

--- a/scripts/deploy_docker.sh
+++ b/scripts/deploy_docker.sh
@@ -14,7 +14,11 @@ fi
 PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 COMPOSE_FILE="${PROJECT_ROOT}/docker-compose.yml"
 ENV_FILE="${PROJECT_ROOT}/.env"
-PROJECT_NAME=${COMPOSE_PROJECT_NAME:-mongars}
+# Keep the default project name aligned with the docker-compose network alias
+# so that the generated network name matches the expectation inside
+# docker-compose.yml. Users can still override COMPOSE_PROJECT_NAME in their
+# environment.
+PROJECT_NAME=${COMPOSE_PROJECT_NAME:-mongars-1}
 
 # Colors (only if stdout is a TTY)
 if [[ -t 1 ]]; then


### PR DESCRIPTION
### **User description**
## Summary
- align the deployment script's default compose project name with the compose network alias expectations
- allow the docker-compose network name to inherit COMPOSE_PROJECT_NAME with a mongars-1 fallback for consistency

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e12cc88f7c83338553a0c8b0d2d419


___

### **PR Type**
Bug fix


___

### **Description**
- Align default compose project name with network configuration

- Fix docker network naming consistency between deployment script and compose file

- Allow COMPOSE_PROJECT_NAME environment variable to control network naming


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["deploy_docker.sh"] -- "sets PROJECT_NAME" --> B["mongars-1 default"]
  B -- "generates network name" --> C["mongars-1_mongars"]
  D["docker-compose.yml"] -- "uses COMPOSE_PROJECT_NAME" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy_docker.sh</strong><dd><code>Update default project name to mongars-1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/deploy_docker.sh

<ul><li>Changed default PROJECT_NAME from <code>mongars</code> to <code>mongars-1</code><br> <li> Added explanatory comments about network alignment<br> <li> Maintains COMPOSE_PROJECT_NAME override capability</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/172/files#diff-02df3a51bd9b1b3c4374668ff1cc14fe24208d19cb7724ece1f637b9aed36dfe">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Make network name configurable via environment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<ul><li>Changed hardcoded network name to use COMPOSE_PROJECT_NAME variable<br> <li> Added fallback to <code>mongars-1</code> for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/172/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

