### PR TITLE
Fix Alembic migration coroutine warning

### DIFF
--- a/alembic_migrations/env.py
+++ b/alembic_migrations/env.py
@@ -72,7 +72,7 @@ def run_migrations_online() -> None:
         poolclass=pool.NullPool,
     )
 
-    async def do_run_migrations(connection: Connection) -> None:
+    def do_run_migrations(connection: Connection) -> None:
         context.configure(
             connection=connection, target_metadata=target_metadata, compare_type=True
         )


### PR DESCRIPTION
## Summary
- make the Alembic online migration runner use a synchronous callback with `run_sync`
- prevent the "coroutine was never awaited" runtime warning emitted during container startup

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e151b193dc8333a7d5ed1b656ece1e