### PR TITLE
Implement scheduled evolution orchestrator cycles

### DIFF
--- a/modules/evolution_engine/orchestrator.py
+++ b/modules/evolution_engine/orchestrator.py
@@ -1,24 +1,34 @@
-"""Background scheduler orchestrating evolution training cycles."""
+"""Workflow-managed orchestration for evolution engine training cycles."""
 
 from __future__ import annotations
 
 import json
 import logging
 import os
+import random
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, Mapping, Protocol, Sequence
 from uuid import uuid4
 
 import psutil
-from apscheduler.schedulers.background import BackgroundScheduler
 
-try:  # pragma: no cover - optional dependency at runtime
+try:  # pragma: no cover - optional dependency in lightweight environments
     import torch
-except ModuleNotFoundError:  # pragma: no cover - torch is optional in some environments
+except ModuleNotFoundError:  # pragma: no cover - torch may be absent in CI
     torch = None  # type: ignore[assignment]
 
+try:  # pragma: no cover - Prefect is optional but preferred for orchestration
+    from prefect import flow as prefect_flow
+    from prefect.deployments import Deployment
+    from prefect.server.schemas.schedules import IntervalSchedule
+except Exception:  # pragma: no cover - gracefully degrade when Prefect missing
+    prefect_flow = None  # type: ignore[assignment]
+    Deployment = None  # type: ignore[assignment]
+    IntervalSchedule = None  # type: ignore[assignment]
+
+from modules.evolution_engine.energy import EnergyTracker, EnergyUsageReport
 from modules.evolution_engine.self_training import collect_curated_data
 from modules.neurons.registry import update_manifest
 from modules.neurons.training.mntp_trainer import MNTPTrainer, TrainingStatus
@@ -32,16 +42,120 @@ DEFAULT_MODEL_ID = "unsloth/mistral-7b-instruct-v0.3-bnb-4bit"
 DEFAULT_REGISTRY_PATH = Path("models/encoders")
 DEFAULT_CONFIG_PATH = Path("configs/training/mntp_mistral_config.json")
 TRAINING_SUMMARY_FILENAME = "training_summary.json"
+ENERGY_REPORT_FILENAME = "energy_report.json"
 MAX_VRAM_GB = 6.0
 CPU_IDLE_THRESHOLD = 20.0
 MEMORY_IDLE_THRESHOLD = 70.0
-SCHEDULER_JOB_ID = "evolution-engine-training-cycle"
+WORKFLOW_NAME = "evolution-training-flow"
+WORKFLOW_DEPLOYMENT_NAME = "evolution-training-deployment"
 
 CuratedDataset = Sequence[dict[str, Any]] | Any
+EnergyTrackerFactory = Callable[[], EnergyTracker]
+
+
+class WorkflowBackend(Protocol):
+    """Protocol describing the minimal workflow backend surface area."""
+
+    def build_flow(
+        self, func: Callable[..., Any], *, name: str
+    ) -> Callable[..., Any]:
+        """Return a callable representing the orchestrated flow."""
+
+    def ensure_schedule(
+        self, flow: Callable[..., Any], *, parameters: Mapping[str, Any]
+    ) -> None:
+        """Register or update the recurring schedule for ``flow``."""
+
+    def run(
+        self, flow: Callable[..., Any], *, parameters: Mapping[str, Any]
+    ) -> Any:
+        """Execute ``flow`` with ``parameters`` and return its result."""
+
+
+class InlineWorkflowBackend:
+    """A lightweight backend that executes flows synchronously."""
+
+    def __init__(self) -> None:
+        self.last_schedule: dict[str, Any] | None = None
+
+    def build_flow(
+        self, func: Callable[..., Any], *, name: str
+    ) -> Callable[..., Any]:  # noqa: D401 - signature enforced by protocol
+        return func
+
+    def ensure_schedule(
+        self, flow: Callable[..., Any], *, parameters: Mapping[str, Any]
+    ) -> None:
+        self.last_schedule = {"flow": flow, "parameters": dict(parameters)}
+
+    def run(
+        self, flow: Callable[..., Any], *, parameters: Mapping[str, Any]
+    ) -> Any:
+        return flow(**parameters)
+
+
+class PrefectWorkflowBackend:
+    """Workflow backend leveraging Prefect deployments for scheduling."""
+
+    def __init__(
+        self,
+        *,
+        flow_name: str,
+        deployment_name: str,
+        interval_minutes: int,
+        jitter_seconds: float,
+    ) -> None:
+        if (
+            prefect_flow is None
+            or Deployment is None
+            or IntervalSchedule is None
+        ):  # pragma: no cover - optional dependency branch
+            raise RuntimeError("Prefect is not available in this environment")
+
+        self._flow_decorator = prefect_flow
+        self._deployment_cls = Deployment
+        self._schedule_cls = IntervalSchedule
+        self._flow_name = flow_name
+        self._deployment_name = deployment_name
+        self._interval = timedelta(minutes=max(1, int(interval_minutes)))
+        self._anchor_offset = max(0.0, float(jitter_seconds))
+
+    def build_flow(
+        self, func: Callable[..., Any], *, name: str
+    ) -> Callable[..., Any]:
+        return self._flow_decorator(name=name)(func)
+
+    def ensure_schedule(
+        self, flow: Callable[..., Any], *, parameters: Mapping[str, Any]
+    ) -> None:
+        anchor = datetime.now(timezone.utc)
+        if self._anchor_offset > 0:
+            anchor += timedelta(seconds=random.uniform(0.0, self._anchor_offset))
+
+        schedule = self._schedule_cls(interval=self._interval, anchor_date=anchor)
+        deployment = self._deployment_cls.build_from_flow(
+            flow=flow,
+            name=self._deployment_name,
+            schedule=schedule,
+            parameters=dict(parameters),
+            tags=["evolution-engine", "training"],
+        )
+        try:
+            deployment.apply()  # type: ignore[no-untyped-call]
+        except Exception as exc:  # pragma: no cover - Prefect server optional
+            logger.warning(
+                "prefect.deployment.apply_failed",
+                extra={"deployment": self._deployment_name, "error": str(exc)},
+            )
+
+    def run(
+        self, flow: Callable[..., Any], *, parameters: Mapping[str, Any]
+    ) -> Any:
+        return flow(**parameters)
 
 
 class EvolutionOrchestrator:
-    """Coordinate background MNTP training cycles with resource safeguards."""
+    """Coordinate MNTP training cycles using a workflow orchestrator."""
 
     def __init__(
         self,
@@ -52,9 +166,12 @@ class EvolutionOrchestrator:
         trainer_cls: type[MNTPTrainer] = MNTPTrainer,
         slot_manager_cls: type[ModelSlotManager] | None = ModelSlotManager,
         data_collector: Callable[[], CuratedDataset] = collect_curated_data,
-        scheduler: BackgroundScheduler | None = None,
-        autostart: bool = True,
-        scheduler_job_id: str = SCHEDULER_JOB_ID,
+        workflow_backend: WorkflowBackend | None = None,
+        schedule_interval_minutes: int = 20,
+        schedule_jitter_seconds: float = 300.0,
+        flow_name: str = WORKFLOW_NAME,
+        deployment_name: str = WORKFLOW_DEPLOYMENT_NAME,
+        energy_tracker_factory: EnergyTrackerFactory | None = None,
     ) -> None:
         self.registry_path = Path(model_registry_path)
         self.registry_path.mkdir(parents=True, exist_ok=True)
@@ -63,27 +180,25 @@ class EvolutionOrchestrator:
         self._trainer_cls = trainer_cls
         self._slot_manager_cls = slot_manager_cls
         self._data_collector = data_collector
-        self._scheduler = scheduler or BackgroundScheduler()
-        self._scheduler_job = self._scheduler.add_job(
-            self.run_training_cycle,
-            "interval",
-            minutes=20,
-            jitter=300,
-            id=scheduler_job_id,
-            max_instances=1,
-            coalesce=True,
-            replace_existing=True,
+        self._energy_tracker_factory = energy_tracker_factory
+        self._schedule_interval_minutes = int(schedule_interval_minutes)
+        self._schedule_jitter_seconds = max(0.0, float(schedule_jitter_seconds))
+        self._flow_name = flow_name
+        self._deployment_name = deployment_name
+
+        self._workflow_backend = (
+            workflow_backend
+            if workflow_backend is not None
+            else self._default_backend()
         )
-        if autostart and not self._scheduler.running:
-            self._scheduler.start()
+        self._flow = self._workflow_backend.build_flow(
+            self._run_flow, name=self._flow_name
+        )
+        self._register_schedule()
 
     @property
-    def scheduler(self) -> BackgroundScheduler:
-        return self._scheduler
-
-    def shutdown(self, *, wait: bool = False) -> None:
-        if self._scheduler.running:
-            self._scheduler.shutdown(wait=wait)
+    def workflow_backend(self) -> WorkflowBackend:
+        return self._workflow_backend
 
     def trigger_encoder_training_pipeline(self) -> str:
         run_dir = self.run_training_cycle(force=True)
@@ -92,59 +207,18 @@ class EvolutionOrchestrator:
         return str(run_dir)
 
     def run_training_cycle(self, *, force: bool = False) -> Path | None:
-        if not force and not self._system_is_idle():
-            logger.info("Skipping training cycle because the host is busy")
-            return None
-
-        dataset = self._collect_dataset()
-        if self._dataset_empty(dataset):
-            logger.info("Skipping training cycle because no curated data is available")
-            return None
-
-        run_dir = self._prepare_run_directory()
-        trainer = self._instantiate_trainer(run_dir)
-
         try:
-            with self._acquire_model_slot():
-                summary = trainer.fit(dataset)
-        except Exception:
-            logger.exception("Evolution training cycle failed during MNTP fitting")
-            raise
-
-        status = str(summary.get("status") or "").lower()
-        if status != TrainingStatus.SUCCESS.value:
-            raise RuntimeError(
-                f"MNTP trainer reported unsuccessful status: {summary.get('status')!r}"
-            )
-
-        summary.setdefault("version", summary.get("version") or uuid4().hex)
-        summary.setdefault("completed_at", datetime.now(timezone.utc).isoformat())
-
-        try:
-            self._write_summary(run_dir, summary)
-        except Exception:  # pragma: no cover - defensive persistence guard
-            logger.exception(
-                "Failed to persist training summary", extra={"run_dir": str(run_dir)}
-            )
-
-        try:
-            manifest = update_manifest(self.registry_path, summary)
-            logger.info(
-                "Adapter manifest updated",
-                extra={"manifest_path": str(manifest.path)},
+            result = self._workflow_backend.run(
+                self._flow, parameters={"force": force}
             )
         except Exception:
-            logger.exception("Failed to update adapter manifest")
+            logger.exception("Workflow execution failed")
             raise
 
-        try:
-            self.rollout_adapter(summary)
-        except (
-            Exception
-        ):  # pragma: no cover - rollout should never crash the orchestrator
-            logger.exception("Adapter rollout failed")
+        if result is None:
+            return None
 
-        return run_dir
+        return Path(result)
 
     def rollout_adapter(self, summary: dict[str, Any]) -> None:
         if not self._ray_rollout_enabled():
@@ -162,7 +236,7 @@ class EvolutionOrchestrator:
             logger.warning("Training summary missing adapter path; skipping rollout")
             return
 
-        payload = {
+        payload: dict[str, Any] = {
             "adapter_path": str(adapter_path),
             "version": str(summary.get("version") or ""),
         }
@@ -177,10 +251,115 @@ class EvolutionOrchestrator:
                 "Failed to update Ray Serve deployment",
                 extra={"reason": str(exc)},
             )
-        except (
-            Exception
-        ):  # pragma: no cover - defensive guard for unexpected Ray errors
+        except Exception:  # pragma: no cover - unexpected Ray exceptions
             logger.exception("Unexpected Ray Serve deployment failure")
+
+    def _default_backend(self) -> WorkflowBackend:
+        try:
+            return PrefectWorkflowBackend(
+                flow_name=self._flow_name,
+                deployment_name=self._deployment_name,
+                interval_minutes=self._schedule_interval_minutes,
+                jitter_seconds=self._schedule_jitter_seconds,
+            )
+        except RuntimeError:
+            logger.info(
+                "Prefect not available; using synchronous workflow backend instead."
+            )
+            return InlineWorkflowBackend()
+
+    def _register_schedule(self) -> None:
+        try:
+            self._workflow_backend.ensure_schedule(
+                self._flow, parameters={"force": False}
+            )
+        except Exception:
+            logger.exception("Failed to register evolution workflow schedule")
+
+    def _run_flow(self, *, force: bool = False) -> str | None:
+        run_dir = self._execute_training_cycle(force=force)
+        return str(run_dir) if run_dir is not None else None
+
+    def _execute_training_cycle(self, *, force: bool) -> Path | None:
+        if not force and not self._system_is_idle():
+            logger.info("Skipping training cycle because the host is busy")
+            return None
+
+        dataset = self._collect_dataset()
+        if self._dataset_empty(dataset):
+            logger.info(
+                "Skipping training cycle because no curated data is available"
+            )
+            return None
+
+        run_dir = self._prepare_run_directory()
+        trainer = self._instantiate_trainer(run_dir)
+        tracker = self._energy_tracker_factory() if self._energy_tracker_factory else None
+        energy_report: EnergyUsageReport | None = None
+
+        try:
+            with self._acquire_model_slot():
+                if tracker is not None:
+                    with tracker.track():
+                        summary = trainer.fit(dataset)
+                    energy_report = tracker.last_report
+                else:
+                    summary = trainer.fit(dataset)
+        except Exception:
+            logger.exception("Evolution training cycle failed during MNTP fitting")
+            raise
+
+        status = str(summary.get("status") or "").lower()
+        if status != TrainingStatus.SUCCESS.value:
+            raise RuntimeError(
+                f"MNTP trainer reported unsuccessful status: {summary.get('status')!r}"
+            )
+
+        summary.setdefault("version", summary.get("version") or uuid4().hex)
+        summary.setdefault("completed_at", datetime.now(timezone.utc).isoformat())
+
+        self._persist_run_artifacts(run_dir, summary, energy_report)
+        self._update_manifest(summary)
+        try:
+            self.rollout_adapter(summary)
+        except Exception:  # pragma: no cover - rollout failures must not crash
+            logger.exception("Adapter rollout failed")
+
+        return run_dir
+
+    def _persist_run_artifacts(
+        self,
+        run_dir: Path,
+        summary: dict[str, Any],
+        energy_report: EnergyUsageReport | None,
+    ) -> None:
+        try:
+            self._write_summary(run_dir, summary)
+        except Exception:  # pragma: no cover - defensive persistence guard
+            logger.exception(
+                "Failed to persist training summary", extra={"run_dir": str(run_dir)}
+            )
+
+        if energy_report is None:
+            return
+
+        try:
+            self._write_energy_report(run_dir, energy_report)
+        except Exception:  # pragma: no cover - defensive persistence guard
+            logger.exception(
+                "Failed to persist energy report", extra={"run_dir": str(run_dir)}
+            )
+
+    def _update_manifest(self, summary: dict[str, Any]) -> None:
+        try:
+            manifest = update_manifest(self.registry_path, summary)
+            logger.info(
+                "Adapter manifest updated",
+                extra={"manifest_path": str(manifest.path)},
+            )
+        except Exception:
+            logger.exception("Failed to update adapter manifest")
+            raise
 
     def _collect_dataset(self) -> CuratedDataset:
         try:
@@ -213,6 +392,13 @@ class EvolutionOrchestrator:
     def _write_summary(self, run_dir: Path, summary: dict[str, Any]) -> None:
         path = run_dir / TRAINING_SUMMARY_FILENAME
         path.write_text(json.dumps(summary, indent=2, sort_keys=True))
+
+    def _write_energy_report(
+        self, run_dir: Path, report: EnergyUsageReport
+    ) -> None:
+        payload = report.to_dict() if hasattr(report, "to_dict") else dict(report)
+        path = run_dir / ENERGY_REPORT_FILENAME
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True))
 
     @contextmanager
     def _acquire_model_slot(self) -> Any:
@@ -288,7 +474,7 @@ class EvolutionOrchestrator:
                 cuda.get_device_properties(index)
             except Exception as exc:  # pragma: no cover - defensive guard
                 logger.warning(
-                    "Failed to access CUDA device properties",  # pragma: no cover
+                    "Failed to access CUDA device properties",
                     extra={"device_index": index},
                     exc_info=exc,
                 )
@@ -299,7 +485,7 @@ class EvolutionOrchestrator:
                     allocated = float(cuda.memory_allocated())
             except Exception as exc:  # pragma: no cover - defensive guard
                 logger.warning(
-                    "Failed to inspect CUDA memory allocation",  # pragma: no cover
+                    "Failed to inspect CUDA memory allocation",
                     extra={"device_index": index},
                     exc_info=exc,
                 )
@@ -309,6 +495,7 @@ class EvolutionOrchestrator:
 
         if not allocations:
             return None
+
         return max(allocations) / float(1024**3)
 
     def _ray_rollout_enabled(self) -> bool:
@@ -331,4 +518,5 @@ class EvolutionOrchestrator:
         return env_flag.strip().lower() in {"true", "1", "yes", "on"}
 
 
-__all__ = ["EvolutionOrchestrator"]
+__all__ = ["EvolutionOrchestrator", "InlineWorkflowBackend", "PrefectWorkflowBackend"]
+

--- a/modules/evolution_engine/orchestrator.py
+++ b/modules/evolution_engine/orchestrator.py
@@ -403,7 +403,7 @@ class EvolutionOrchestrator:
 
     def _system_is_idle(self) -> bool:
         try:
-            cpu_percent = float(psutil.cpu_percent(interval=1.0))
+            cpu_percent = float(psutil.cpu_percent(interval=1))
         except Exception as exc:
             logger.warning("Failed to measure CPU utilisation", exc_info=exc)
             return False

--- a/modules/evolution_engine/orchestrator.py
+++ b/modules/evolution_engine/orchestrator.py
@@ -1,207 +1,310 @@
+"""Background scheduler orchestrating evolution training cycles."""
+
 from __future__ import annotations
 
 import json
 import logging
+import os
+from contextlib import contextmanager
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable, Protocol, runtime_checkable
+from typing import Any, Callable, Sequence
 from uuid import uuid4
 
+import psutil
+from apscheduler.schedulers.background import BackgroundScheduler
+
+try:  # pragma: no cover - optional dependency at runtime
+    import torch
+except ModuleNotFoundError:  # pragma: no cover - torch is optional in some environments
+    torch = None  # type: ignore[assignment]
+
+from modules.evolution_engine.self_training import collect_curated_data
 from modules.neurons.registry import update_manifest
 from modules.neurons.training.mntp_trainer import MNTPTrainer, TrainingStatus
-
-from .energy import EnergyTracker, EnergyUsageReport
+from modules.ray_service import update_ray_deployment
+from monGARS.config import get_settings
+from monGARS.core.model_slot_manager import ModelSlotManager
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_MODEL_ID = "unsloth/mistral-7b-instruct-v0.3-bnb-4bit"
+DEFAULT_REGISTRY_PATH = Path("models/encoders")
+DEFAULT_CONFIG_PATH = Path("configs/training/mntp_mistral_config.json")
+TRAINING_SUMMARY_FILENAME = "training_summary.json"
+MAX_VRAM_GB = 6.0
+CPU_IDLE_THRESHOLD = 20.0
+MEMORY_IDLE_THRESHOLD = 70.0
+SCHEDULER_JOB_ID = "evolution-engine-training-cycle"
 
-@runtime_checkable
-class TrainerProtocol(Protocol):
-    """Protocol describing the trainer expected by the orchestrator."""
-
-    def __init__(self, training_config_path: str, output_dir: str) -> None:
-        """Construct a trainer bound to the provided config and output path."""
-
-    def train(self) -> dict[str, object]:
-        """Execute the training pipeline and return a summary payload."""
+CuratedDataset = Sequence[dict[str, Any]] | Any
 
 
 class EvolutionOrchestrator:
-    """Coordinate encoder refresh pipelines built around :class:`MNTPTrainer`."""
+    """Coordinate background MNTP training cycles with resource safeguards."""
 
     def __init__(
         self,
-        model_registry_path: str = "models/encoders/",
-        config_path: str | None = None,
         *,
-        trainer_cls: type[TrainerProtocol] = MNTPTrainer,
-        energy_tracker_factory: Callable[[], EnergyTracker] | None = None,
+        model_registry_path: str | os.PathLike[str] = DEFAULT_REGISTRY_PATH,
+        training_config_path: str | os.PathLike[str] = DEFAULT_CONFIG_PATH,
+        model_id: str = DEFAULT_MODEL_ID,
+        trainer_cls: type[MNTPTrainer] = MNTPTrainer,
+        slot_manager_cls: type[ModelSlotManager] | None = ModelSlotManager,
+        data_collector: Callable[[], CuratedDataset] = collect_curated_data,
+        scheduler: BackgroundScheduler | None = None,
+        autostart: bool = True,
+        scheduler_job_id: str = SCHEDULER_JOB_ID,
     ) -> None:
-        self.model_registry_path = Path(model_registry_path)
-        self.config_path = (
-            Path(config_path)
-            if config_path
-            else Path("configs/training/mntp_mistral_config.json")
+        self.registry_path = Path(model_registry_path)
+        self.registry_path.mkdir(parents=True, exist_ok=True)
+        self.training_config_path = Path(training_config_path)
+        self.model_id = model_id
+        self._trainer_cls = trainer_cls
+        self._slot_manager_cls = slot_manager_cls
+        self._data_collector = data_collector
+        self._scheduler = scheduler or BackgroundScheduler()
+        self._scheduler_job = self._scheduler.add_job(
+            self.run_training_cycle,
+            "interval",
+            minutes=20,
+            jitter=300,
+            id=scheduler_job_id,
+            max_instances=1,
+            coalesce=True,
+            replace_existing=True,
         )
-        self._trainer_cls: type[TrainerProtocol] = trainer_cls
-        if energy_tracker_factory is None:
-            self._energy_tracker_factory = lambda: EnergyTracker()
-        else:
-            self._energy_tracker_factory = energy_tracker_factory
+        if autostart and not self._scheduler.running:
+            self._scheduler.start()
+
+    @property
+    def scheduler(self) -> BackgroundScheduler:
+        return self._scheduler
+
+    def shutdown(self, *, wait: bool = False) -> None:
+        if self._scheduler.running:
+            self._scheduler.shutdown(wait=wait)
 
     def trigger_encoder_training_pipeline(self) -> str:
-        """Launch the MNTP pipeline and return the produced artifact directory."""
+        run_dir = self.run_training_cycle(force=True)
+        if run_dir is None:
+            raise RuntimeError("Training cycle did not produce any artifacts")
+        return str(run_dir)
 
-        logger.info("Starting training pipeline for a new encoder")
-        self.model_registry_path.mkdir(parents=True, exist_ok=True)
-        unique_dir = self.model_registry_path / f"temp-mistral-mntp-step-{uuid4()}"
-        trainer = self._trainer_cls(
-            training_config_path=str(self.config_path),
-            output_dir=str(unique_dir),
-        )
-        tracker = (
-            self._energy_tracker_factory() if self._energy_tracker_factory else None
-        )
-        energy_report: EnergyUsageReport | None = None
-        if tracker:
-            tracker.start()
-        try:
-            summary = trainer.train()
-        except Exception as exc:  # pragma: no cover - unexpected training error
-            logger.error("Training failed: %s", exc, exc_info=True)
-            if tracker:
-                try:
-                    energy_report = tracker.stop()
-                    self._persist_energy_report(unique_dir, energy_report)
-                except Exception:  # pragma: no cover - defensive guard
-                    logger.exception(
-                        "Failed to persist energy report after training failure",
-                        extra={"output_dir": str(unique_dir)},
-                    )
-            raise
-        finally:
-            if tracker and energy_report is None:
-                try:
-                    energy_report = tracker.stop()
-                except Exception:  # pragma: no cover - defensive guard
-                    logger.exception("Energy tracker stop failed", exc_info=True)
-                    energy_report = None
+    def run_training_cycle(self, *, force: bool = False) -> Path | None:
+        if not force and not self._system_is_idle():
+            logger.info("Skipping training cycle because the host is busy")
+            return None
 
-        status_value = summary.get("status")
-        status = str(status_value).lower() if status_value is not None else ""
-        if status != TrainingStatus.SUCCESS.value:
-            logger.error(
-                "Trainer returned non-success status",
-                extra={
-                    "status": status_value,
-                    "artifacts": summary.get("artifacts", {}),
-                    "metrics": summary.get("metrics", {}),
-                    "encoder_path": str(unique_dir),
-                },
-            )
-            raise RuntimeError(
-                f"MNTP trainer reported unsuccessful status: {status_value!r}"
-            )
+        dataset = self._collect_dataset()
+        if self._dataset_empty(dataset):
+            logger.info("Skipping training cycle because no curated data is available")
+            return None
 
-        artifacts = summary.get("artifacts") or {}
-        adapter_path_raw = artifacts.get("adapter")
-        if not adapter_path_raw:
-            raise RuntimeError("Trainer did not return an adapter artifact path")
-
-        adapter_path = Path(adapter_path_raw)
-        if not adapter_path.exists():
-            raise RuntimeError(f"Adapter artifact path '{adapter_path}' does not exist")
+        run_dir = self._prepare_run_directory()
+        trainer = self._instantiate_trainer(run_dir)
 
         try:
-            adapter_path.resolve().relative_to(unique_dir.resolve())
-        except Exception as exc:
-            raise RuntimeError(
-                "Trainer produced adapter artifact outside orchestrator output directory"
-            ) from exc
-
-        if weights_path_raw := artifacts.get("weights"):
-            weights_path = Path(weights_path_raw)
-            if not weights_path.exists():
-                raise RuntimeError(
-                    f"Adapter weights path '{weights_path}' does not exist"
-                )
-            try:
-                weights_path.resolve().relative_to(unique_dir.resolve())
-            except Exception as exc:
-                raise RuntimeError(
-                    "Trainer produced adapter weights outside orchestrator output directory"
-                ) from exc
-
-        if energy_report is not None:
-            self._augment_summary_with_energy(unique_dir, summary, energy_report)
-
-        try:
-            manifest = update_manifest(self.model_registry_path, summary)
+            with self._acquire_model_slot():
+                summary = trainer.fit(dataset)
         except Exception:
-            logger.error(
-                "Adapter manifest update failed",
-                extra={
-                    "encoder_path": str(unique_dir),
-                    "status": summary.get("status"),
-                    "artifacts": summary.get("artifacts", {}),
-                },
-                exc_info=True,
-            )
+            logger.exception("Evolution training cycle failed during MNTP fitting")
             raise
-        logger.info(
-            "Pipeline finished",
-            extra={
-                "encoder_path": str(unique_dir),
-                "status": summary.get("status"),
-                "artifacts": summary.get("artifacts", {}),
-                "manifest_path": str(manifest.path),
-            },
-        )
-        return str(unique_dir)
 
-    def _augment_summary_with_energy(
-        self,
-        run_dir: Path,
-        summary: dict[str, object],
-        report: EnergyUsageReport,
-    ) -> None:
-        if not isinstance(summary.get("metrics"), dict):
-            summary["metrics"] = {}
-
-        metrics = summary["metrics"]
-        metrics.update(
-            {
-                "energy_wh": round(report.energy_wh, 4),
-                "energy_backend": report.backend,
-                "cpu_seconds": round(report.cpu_seconds, 4),
-                "run_duration_seconds": round(report.duration_seconds, 4),
-            }
-        )
-        telemetry = summary.setdefault("telemetry", {})
-        if isinstance(telemetry, dict):
-            telemetry["energy"] = report.to_dict()
-        self._persist_energy_report(run_dir, report)
-        try:
-            (run_dir / "training_summary.json").write_text(
-                json.dumps(summary, indent=2, sort_keys=True)
+        status = str(summary.get("status") or "").lower()
+        if status != TrainingStatus.SUCCESS.value:
+            raise RuntimeError(
+                f"MNTP trainer reported unsuccessful status: {summary.get('status')!r}"
             )
+
+        summary.setdefault("version", summary.get("version") or uuid4().hex)
+        summary.setdefault("completed_at", datetime.now(timezone.utc).isoformat())
+
+        try:
+            self._write_summary(run_dir, summary)
         except Exception:  # pragma: no cover - defensive persistence guard
             logger.exception(
-                "Failed to update training summary with energy metrics",
-                extra={"run_dir": str(run_dir)},
+                "Failed to persist training summary", extra={"run_dir": str(run_dir)}
             )
 
-    def _persist_energy_report(self, run_dir: Path, report: EnergyUsageReport) -> None:
         try:
-            run_dir.mkdir(parents=True, exist_ok=True)
-            (run_dir / "energy_report.json").write_text(
-                json.dumps(report.to_dict(), indent=2, sort_keys=True)
+            manifest = update_manifest(self.registry_path, summary)
+            logger.info(
+                "Adapter manifest updated",
+                extra={"manifest_path": str(manifest.path)},
             )
-        except Exception:  # pragma: no cover - defensive persistence guard
-            logger.exception(
-                "Failed to write energy report", extra={"run_dir": str(run_dir)}
+        except Exception:
+            logger.exception("Failed to update adapter manifest")
+            raise
+
+        try:
+            self.rollout_adapter(summary)
+        except (
+            Exception
+        ):  # pragma: no cover - rollout should never crash the orchestrator
+            logger.exception("Adapter rollout failed")
+
+        return run_dir
+
+    def rollout_adapter(self, summary: dict[str, Any]) -> None:
+        if not self._ray_rollout_enabled():
+            return
+
+        artifacts = summary.get("artifacts")
+        if not isinstance(artifacts, dict):
+            logger.warning(
+                "Training summary missing artifacts payload; skipping rollout"
             )
+            return
+
+        adapter_path = artifacts.get("adapter")
+        if not adapter_path:
+            logger.warning("Training summary missing adapter path; skipping rollout")
+            return
+
+        payload = {
+            "adapter_path": str(adapter_path),
+            "version": str(summary.get("version") or ""),
+        }
+        weights_path = artifacts.get("weights")
+        if weights_path:
+            payload["weights_path"] = str(weights_path)
+
+        try:
+            update_ray_deployment(payload)
+        except RuntimeError as exc:
+            logger.warning(
+                "Failed to update Ray Serve deployment",
+                extra={"reason": str(exc)},
+            )
+        except (
+            Exception
+        ):  # pragma: no cover - defensive guard for unexpected Ray errors
+            logger.exception("Unexpected Ray Serve deployment failure")
+
+    def _collect_dataset(self) -> CuratedDataset:
+        try:
+            return self._data_collector()
+        except Exception:  # pragma: no cover - defensive guard around data ingestion
+            logger.exception("Failed to collect curated dataset")
+            return []
+
+    def _dataset_empty(self, dataset: CuratedDataset) -> bool:
+        if dataset is None:
+            return True
+        try:
+            length = len(dataset)  # type: ignore[arg-type]
+        except Exception:
+            return False
+        return length == 0
+
+    def _instantiate_trainer(self, run_dir: Path) -> MNTPTrainer:
+        return self._trainer_cls(
+            training_config_path=str(self.training_config_path),
+            output_dir=str(run_dir),
+        )
+
+    def _prepare_run_directory(self) -> Path:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+        run_dir = self.registry_path / f"cycle-{timestamp}-{uuid4().hex[:6]}"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        return run_dir
+
+    def _write_summary(self, run_dir: Path, summary: dict[str, Any]) -> None:
+        path = run_dir / TRAINING_SUMMARY_FILENAME
+        path.write_text(json.dumps(summary, indent=2, sort_keys=True))
+
+    @contextmanager
+    def _acquire_model_slot(self) -> Any:
+        if self._slot_manager_cls is None:
+            yield None
+            return
+        try:
+            manager = self._slot_manager_cls("primary", model_id=self.model_id)
+        except Exception as exc:  # pragma: no cover - optional dependency failure
+            logger.warning(
+                "model.slot.unavailable",
+                extra={"model_id": self.model_id, "error": str(exc)},
+            )
+            yield None
+            return
+        with manager:  # type: ignore[misc]
+            yield manager
+
+    def _system_is_idle(self) -> bool:
+        try:
+            cpu_percent = float(psutil.cpu_percent(interval=None))
+        except Exception as exc:
+            logger.warning("Failed to measure CPU utilisation", exc_info=exc)
+            return False
+
+        try:
+            memory_percent = float(psutil.virtual_memory().percent)
+        except Exception as exc:
+            logger.warning("Failed to measure memory utilisation", exc_info=exc)
+            return False
+
+        if cpu_percent >= CPU_IDLE_THRESHOLD or memory_percent >= MEMORY_IDLE_THRESHOLD:
+            logger.info(
+                "System not idle",
+                extra={"cpu_percent": cpu_percent, "memory_percent": memory_percent},
+            )
+            return False
+
+        vram_usage = self._current_vram_usage_gb()
+        if vram_usage is not None and vram_usage > MAX_VRAM_GB:
+            logger.info(
+                "Skipping training due to VRAM pressure",
+                extra={"vram_gb": round(vram_usage, 2)},
+            )
+            return False
+
+        return True
+
+    def _current_vram_usage_gb(self) -> float | None:
+        if torch is None or not hasattr(torch, "cuda"):
+            return None
+        try:
+            if not torch.cuda.is_available():  # type: ignore[union-attr]
+                return None
+        except Exception:  # pragma: no cover - defensive guard
+            return None
+
+        try:
+            device_count = torch.cuda.device_count()  # type: ignore[union-attr]
+        except Exception:  # pragma: no cover - defensive guard
+            device_count = 1
+
+        allocations: list[float] = []
+        for index in range(max(1, device_count)):
+            try:
+                allocated = torch.cuda.memory_allocated(index)  # type: ignore[union-attr]
+            except Exception:  # pragma: no cover - defensive guard
+                continue
+            allocations.append(allocated)
+
+        if not allocations:
+            return None
+        return max(allocations) / (1024**3)
+
+    def _ray_rollout_enabled(self) -> bool:
+        try:
+            settings = get_settings()
+        except Exception:  # pragma: no cover - defensive guard for config access
+            settings = None
+
+        for attr in ("use_ray_serve", "USE_RAY_SERVE", "use_ray"):
+            if settings is not None and hasattr(settings, attr):
+                value = getattr(settings, attr)
+                if isinstance(value, bool):
+                    return value
+                if isinstance(value, str):
+                    return value.strip().lower() in {"true", "1", "yes", "on"}
+
+        env_flag = os.getenv("USE_RAY_SERVE")
+        if env_flag is None:
+            return False
+        return env_flag.strip().lower() in {"true", "1", "yes", "on"}
 
 
-if __name__ == "__main__":  # pragma: no cover - manual execution
-    orchestrator = EvolutionOrchestrator()
-    orchestrator.trigger_encoder_training_pipeline()
+__all__ = ["EvolutionOrchestrator"]

--- a/modules/evolution_engine/self_training.py
+++ b/modules/evolution_engine/self_training.py
@@ -1,0 +1,117 @@
+"""Utilities bridging curated self-training datasets with the evolution engine."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+try:  # pragma: no cover - optional dependency at runtime
+    from datasets import Dataset  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - dataset library is optional
+    Dataset = None  # type: ignore[assignment]
+
+from models.datasets.catalog import DatasetCatalog
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CURATED_ROOT = Path("models/datasets/curated")
+
+
+def _iter_curated_records(path: Path) -> Iterable[dict[str, Any]]:
+    """Yield parsed curated records from a JSONL dataset file."""
+
+    if not path.exists():
+        logger.warning(
+            "curated.dataset.missing",
+            extra={"dataset_file": str(path)},
+        )
+        return
+
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    yield json.loads(stripped)
+                except json.JSONDecodeError:
+                    logger.debug(
+                        "curated.dataset.invalid_record",
+                        extra={"dataset_file": str(path)},
+                        exc_info=True,
+                    )
+    except OSError as exc:  # pragma: no cover - defensive IO guard
+        logger.error(
+            "curated.dataset.read_error",
+            extra={"dataset_file": str(path)},
+            exc_info=exc,
+        )
+    return
+
+
+def _extract_text(record: dict[str, Any]) -> str | None:
+    """Derive the textual training payload from a curated record."""
+
+    candidates: Sequence[str | None] = (
+        record.get("text"),
+        record.get("response"),
+        record.get("prompt"),
+        record.get("text_preview"),
+    )
+    for value in candidates:
+        if isinstance(value, str):
+            cleaned = value.strip()
+            if cleaned:
+                return cleaned
+    return None
+
+
+def collect_curated_data(
+    *,
+    dataset_root: str | Path | None = None,
+    limit: int | None = None,
+) -> Sequence[dict[str, Any]] | Any:
+    """Load the most recent curated dataset prepared by the self-training engine."""
+
+    root = Path(dataset_root) if dataset_root is not None else DEFAULT_CURATED_ROOT
+    catalog = DatasetCatalog(root)
+    latest = catalog.latest()
+    if latest is None:
+        logger.info("curated.dataset.unavailable", extra={"root": str(root)})
+        return []
+
+    records: list[dict[str, Any]] = []
+    for record in _iter_curated_records(latest.dataset_file):
+        text = _extract_text(record)
+        if not text:
+            continue
+        metadata = {
+            key: value
+            for key, value in record.items()
+            if key not in {"embedding", "vector", "tokens"}
+        }
+        cleaned = {"text": text, "metadata": metadata}
+        records.append(cleaned)
+        if limit is not None and len(records) >= limit:
+            break
+
+    if not records:
+        logger.info(
+            "curated.dataset.empty",
+            extra={"dataset_file": str(latest.dataset_file)},
+        )
+        return []
+
+    if Dataset is not None:  # pragma: no cover - exercised when datasets installed
+        try:
+            return Dataset.from_list(records)
+        except Exception:  # pragma: no cover - dataset creation failure
+            logger.exception("curated.dataset.hf_conversion_failed")
+
+    return records
+
+
+__all__ = ["collect_curated_data"]

--- a/modules/ray_service.py
+++ b/modules/ray_service.py
@@ -16,6 +16,8 @@ from monGARS.core.model_manager import LLMModelManager
 
 logger = logging.getLogger(__name__)
 
+_ALLOWED_RAY_UPDATE_KEYS = {"adapter_path", "version", "weights_path"}
+
 try:  # pragma: no cover - ray is optional in tests
     import ray
     from ray import serve
@@ -469,6 +471,35 @@ def deploy_ray_service(
     )
 
 
+def _normalise_ray_update_payload(user_config: Mapping[str, Any]) -> dict[str, Any]:
+    unexpected = set(user_config) - _ALLOWED_RAY_UPDATE_KEYS
+    if unexpected:
+        joined = ", ".join(sorted(unexpected))
+        raise RuntimeError(f"Unsupported Ray Serve user_config keys: {joined}")
+
+    payload: dict[str, Any] = {}
+    for key in _ALLOWED_RAY_UPDATE_KEYS:
+        if key not in user_config:
+            continue
+        value = user_config[key]
+        if value is None:
+            continue
+        if isinstance(value, os.PathLike):
+            payload[key] = os.fspath(value)
+        elif isinstance(value, (str, int, float, bool)):
+            payload[key] = value
+        else:
+            raise RuntimeError(
+                "Unsupported value type for Ray Serve payload key"
+                f" {key!r}: {type(value).__name__}"
+            )
+
+    if not payload:
+        raise RuntimeError("Ray Serve deployment update payload is empty")
+
+    return payload
+
+
 def update_ray_deployment(user_config: Mapping[str, Any]) -> None:
     """Update the active Ray Serve deployment with the provided adapter payload."""
 
@@ -483,9 +514,7 @@ def update_ray_deployment(user_config: Mapping[str, Any]) -> None:
     if deployment is None:  # pragma: no cover - deployment not registered
         raise RuntimeError("LLMServeDeployment is not registered")
 
-    payload = {
-        str(key): str(value) for key, value in user_config.items() if value is not None
-    }
+    payload = _normalise_ray_update_payload(user_config)
 
     try:
         deployment.update(user_config=payload)

--- a/modules/ray_service.py
+++ b/modules/ray_service.py
@@ -517,7 +517,7 @@ def update_ray_deployment(user_config: Mapping[str, Any]) -> None:
     payload = _normalise_ray_update_payload(user_config)
 
     try:
-        deployment.update(user_config=payload)
+        deployment.options(user_config=payload).deploy()
     except Exception as exc:  # pragma: no cover - Ray Serve API failure
         raise RuntimeError("Failed to update Ray Serve deployment") from exc
 

--- a/tests/test_evolution_engine.py
+++ b/tests/test_evolution_engine.py
@@ -99,32 +99,32 @@ def _mock_torch_vram(
     )
 
 
-def test_orchestrator_registers_interval_schedule(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    backend = DummyWorkflowBackend()
+ def test_orchestrator_registers_interval_schedule(
+     monkeypatch: pytest.MonkeyPatch,
+ ) -> None:
+     backend = DummyWorkflowBackend()
 
-    class _NoopTrainer:
-        def __init__(
-            self, training_config_path: str, output_dir: str
-        ) -> None:  # noqa: D401
-            self.training_config_path = training_config_path
-            self.output_dir = output_dir
+     class _NoopTrainer:
+         def __init__(
+             self, training_config_path: str, output_dir: str
+         ) -> None:  # noqa: D401
+             self.training_config_path = training_config_path
+             self.output_dir = output_dir
 
-        def fit(self, dataset: Any) -> dict[str, Any]:  # pragma: no cover - unused
-            return {}
+         def fit(self, dataset: Any) -> dict[str, Any]:  # pragma: no cover - unused
+             return {}
 
-    monkeypatch.setenv("USE_RAY_SERVE", "false")
-    orchestrator = EvolutionOrchestrator(
-        workflow_backend=backend,
-        trainer_cls=_NoopTrainer,
-        data_collector=lambda: [],
-        slot_manager_cls=None,
-    )
+     monkeypatch.setenv("USE_RAY_SERVE", "false")
+     orchestrator = EvolutionOrchestrator(
+         workflow_backend=backend,
+         trainer_cls=_NoopTrainer,
+         data_collector=lambda: [],
+         slot_manager_cls=None,
+     )
 
-    assert backend.schedule_parameters == {"force": False}
-    assert backend.flow is not None
-
+     assert backend.schedule_parameters == {"force": False}
+     assert backend.flow is not None
+    assert orchestrator.workflow_backend is backend
 
 def test_orchestrator_skips_training_when_busy(monkeypatch: pytest.MonkeyPatch) -> None:
     backend = DummyWorkflowBackend()

--- a/tests/test_ray_service.py
+++ b/tests/test_ray_service.py
@@ -382,8 +382,16 @@ def test_update_ray_deployment_validates_payload(monkeypatch):
     updates: dict[str, Any] = {}
 
     class FakeDeployment:
-        def update(self, *, user_config: dict[str, Any]) -> None:
-            updates.update(user_config)
+        def __init__(self) -> None:
+            self._user_config: dict[str, Any] | None = None
+
+        def options(self, *, user_config: dict[str, Any]) -> "FakeDeployment":
+            self._user_config = dict(user_config)
+            return self
+
+        def deploy(self) -> None:
+            if self._user_config is not None:
+                updates.update(self._user_config)
 
     class FakeServe:
         @staticmethod
@@ -412,7 +420,12 @@ def test_update_ray_deployment_rejects_unknown_keys(monkeypatch):
     from modules import ray_service
 
     class FakeDeployment:
-        def update(self, *, user_config: dict[str, Any]) -> None:  # pragma: no cover
+        def options(
+            self, *, user_config: dict[str, Any]
+        ) -> "FakeDeployment":  # pragma: no cover
+            return self
+
+        def deploy(self) -> None:  # pragma: no cover
             pass
 
     class FakeServe:
@@ -434,7 +447,12 @@ def test_update_ray_deployment_rejects_unsupported_types(monkeypatch):
     from modules import ray_service
 
     class FakeDeployment:
-        def update(self, *, user_config: dict[str, Any]) -> None:  # pragma: no cover
+        def options(
+            self, *, user_config: dict[str, Any]
+        ) -> "FakeDeployment":  # pragma: no cover
+            return self
+
+        def deploy(self) -> None:  # pragma: no cover
             pass
 
     class FakeServe:


### PR DESCRIPTION
### **User description**
## Summary
- add a background-scheduled evolution orchestrator that checks host idleness, limits VRAM pressure, and rolls out adapters via Ray when enabled
- expose curated self-training dataset collection helpers for orchestration
- extend Ray Serve utilities and add orchestrator-focused unit tests with scheduler and psutil mocks

## Testing
- pytest tests/test_evolution_engine.py -k orchestrator -q

------
https://chatgpt.com/codex/tasks/task_e_68e15a0355548333b33ca6199b76db21


___

### **PR Type**
Enhancement


___

### **Description**
- Add background scheduler for automated evolution training cycles

- Implement resource monitoring with CPU, memory, and VRAM safeguards

- Integrate Ray Serve deployment updates for adapter rollouts

- Add curated dataset collection utilities for self-training


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Background Scheduler"] --> B["Resource Check"]
  B --> C["Dataset Collection"]
  C --> D["MNTP Training"]
  D --> E["Manifest Update"]
  E --> F["Ray Deployment"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>orchestrator.py</strong><dd><code>Background scheduler with resource monitoring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/evolution_engine/orchestrator.py

<ul><li>Replace simple training pipeline with background scheduler <br>orchestrator<br> <li> Add system resource monitoring (CPU, memory, VRAM) before training<br> <li> Implement automatic Ray Serve deployment updates after training<br> <li> Add model slot management and comprehensive error handling</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/176/files#diff-02919c2f4bdf46f70eeb75b2b4e8a098d3b48a5bf214097fc78ba6961915b683">+263/-160</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>self_training.py</strong><dd><code>Curated dataset collection utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/evolution_engine/self_training.py

<ul><li>Add utilities for collecting curated self-training datasets<br> <li> Implement JSONL record parsing with text extraction<br> <li> Support HuggingFace Dataset conversion when available<br> <li> Include dataset catalog integration for latest dataset retrieval</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/176/files#diff-2babcb43d4c27b3ad16890b459f70d05f9e38261d16f555b911daa24cbf33340">+117/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ray_service.py</strong><dd><code>Ray deployment update functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/ray_service.py

<ul><li>Add <code>update_ray_deployment</code> function for runtime adapter updates<br> <li> Implement deployment configuration updates with user config payload<br> <li> Add comprehensive error handling for Ray Serve operations</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/176/files#diff-16cfff34ff44e2d5adf93dc2db3cfa9dab9e5c0af44e76e31299994b349e6b16">+34/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_evolution_engine.py</strong><dd><code>Orchestrator unit tests with mocking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_evolution_engine.py

<ul><li>Add comprehensive orchestrator tests with scheduler mocking<br> <li> Test resource monitoring behavior and training cycle execution<br> <li> Mock system utilities (psutil, torch) for isolated testing<br> <li> Verify Ray deployment rollout integration</ul>


</details>


  </td>
  <td><a href="https://github.com/ales27pm/monGARS/pull/176/files#diff-02ba0230ebb07b6b150cd8c7ffb6351583b618f95d3a1093b9c9343280de16eb">+189/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow-driven orchestration for training cycles with configurable scheduling, manual trigger, and graceful shutdown.
  * Resource-aware guards (CPU, memory, VRAM, optional CUDA) and slot coordination to prevent overload.
  * Automated curated data collection/validation, per-run directories, training summaries, artifact/manifest persistence, and optional guarded rollout to live serving.
  * Utilities to collect curated datasets and securely update live deployments with payload validation.

* **Tests**
  * Expanded coverage for scheduling, idle-guard behavior, VRAM scenarios, full training cycles, manifest rollouts, and deployment update validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->