### PR TITLE
Document roadmap status and refresh AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,21 +18,21 @@ highlights the non-negotiable guardrails and shared context.
 
 - **Security & Stability Hotlist**
   - ✅ Align JWT algorithm with deployed secrets (HS256 enforced until managed key storage is available).
-  - 🔒 Store runtime secrets in Vault/Sealed Secrets instead of raw `k8s/secrets.yaml`.
+  - ✅ Store runtime secrets in Vault/Sealed Secrets instead of raw `k8s/secrets.yaml`.
   - ✅ Update Dockerfiles to run as non-root and add a `.dockerignore` to exclude secrets and build artefacts.
-  - 👤 Replace demo users in `web_api.py` with the database-backed authentication flow and migrations.
+  - 🔄 Replace demo users in `web_api.py` with the database-backed authentication flow and migrations (default accounts still load at runtime and must be removed).
 - **Phase 3 – Hardware & Performance**
   - ✅ Worker auto-tuning for Pi/Jetson (`recommended_worker_count`).
   - ✅ Multi-architecture build scripts and cache metrics.
   - ✅ Hardened RBAC manifests.
   - ✅ Ray Serve HTTP integration with circuit breaking plus MNTP trainer support for LoRA and curated adapters.
-  - 🔄 Extend Alembic migrations for the newest SQLModel tables, including legacy tables created outside the current ORM layer.
+  - ✅ Extend Alembic migrations for the newest SQLModel tables, including legacy tables created outside the current ORM layer.
   - ✅ Expose Ray Serve success/failure counters via OpenTelemetry (`llm.ray.*` metrics emitted by `LLMIntegration`).
 - **Phase 5 – Web/API Refinement**
   - ✅ FastAPI chat/history/token endpoints with validation.
   - ✅ Django chat UI with progressive enhancement.
   - ✅ FastAPI WebSocket handler with ticket verification, history replay, and streaming guarded by `WS_ENABLE_EVENTS`.
-  - 🔄 Replace hard-coded credential stores with database-backed auth flows.
+  - 🔄 Replaced hard-coded credential stores with database-backed auth flows (the `DEFAULT_USERS` bootstrap in `monGARS/api/web_api.py` still provisions demo accounts until the cleanup lands).
   - 🚧 Publish polished SDKs and reference clients.
 
 ## Workflow Guardrails

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,10 +6,10 @@ required to reach production readiness.
 ## Immediate Priorities (Security & Stability)
 
 - ✅ Align JWT algorithm with deployed secrets (HS256 enforced until managed key storage is available).
-- 🔒 Store runtime secrets in Vault/Sealed Secrets instead of raw `k8s/secrets.yaml`.
+- ✅ Store runtime secrets in Vault/Sealed Secrets instead of raw `k8s/secrets.yaml`.
 - ✅ Update Dockerfiles to run as non-root and add a `.dockerignore` to exclude
   secrets and build artefacts.
-- 👤 Replace demo users in `web_api.py` with the database-backed authentication
+- 🔄 Replace demo users in `web_api.py` with the database-backed authentication
   flow and migrations (default accounts still load at runtime and must be
   removed).
 

--- a/configs/agents/agents_config.json
+++ b/configs/agents/agents_config.json
@@ -18,11 +18,11 @@
           "label": "Security & Stability Hotlist"
         },
         {
-          "phase": "Phase 3 – Hardware & Performance (🔄 In Progress, Target Q3 2025)",
+          "phase": "Phase 3 – Hardware & Performance (✅ Completed Q3 2025)",
           "label": "Phase 3 – Hardware & Performance"
         },
         {
-          "phase": "Phase 5 – Web Interface & API Refinement (🗓 Target Q1 2026)",
+          "phase": "Phase 5 – Web Interface & API Refinement (🔄 In Progress, Target Q1 2026)",
           "label": "Phase 5 – Web/API Refinement"
         }
       ],
@@ -61,11 +61,11 @@
       ],
       "roadmap_focus": [
         {
-          "phase": "Phase 3 – Hardware & Performance (🔄 In Progress, Target Q3 2025)",
+          "phase": "Phase 3 – Hardware & Performance (✅ Completed Q3 2025)",
           "label": "Runtime & Performance"
         },
         {
-          "phase": "Phase 4 – Collaborative Networking (🔄 In Progress, Target Q4 2025)",
+          "phase": "Phase 4 – Collaborative Networking (✅ Completed Q4 2025)",
           "label": "Networking & Collaboration"
         }
       ],
@@ -102,7 +102,7 @@
       ],
       "roadmap_focus": [
         {
-          "phase": "Phase 5 – Web Interface & API Refinement (🗓 Target Q1 2026)",
+          "phase": "Phase 5 – Web Interface & API Refinement (🔄 In Progress, Target Q1 2026)",
           "label": "API Refinement"
         }
       ],
@@ -138,7 +138,7 @@
       ],
       "roadmap_focus": [
         {
-          "phase": "Phase 3 – Hardware & Performance (🔄 In Progress, Target Q3 2025)",
+          "phase": "Phase 3 – Hardware & Performance (✅ Completed Q3 2025)",
           "label": "Performance & Resilience"
         },
         {
@@ -279,7 +279,7 @@
       ],
       "roadmap_focus": [
         {
-          "phase": "Phase 5 – Web Interface & API Refinement (🗓 Target Q1 2026)",
+          "phase": "Phase 5 – Web Interface & API Refinement (🔄 In Progress, Target Q1 2026)",
           "label": "Web Interface Goals"
         }
       ],
@@ -316,7 +316,7 @@
       ],
       "roadmap_focus": [
         {
-          "phase": "Phase 5 – Web Interface & API Refinement (🗓 Target Q1 2026)",
+          "phase": "Phase 5 – Web Interface & API Refinement (🔄 In Progress, Target Q1 2026)",
           "label": "Chat UX Alignment"
         }
       ],

--- a/docs/codebase_status_report.md
+++ b/docs/codebase_status_report.md
@@ -85,8 +85,9 @@ implementation details.
 
 ## Deployment & Operations
 - Docker, Compose, and multi-architecture build scripts sit alongside Kubernetes
-  manifests and a Vault-backed secret store so operators can run the stack on
-  laptops or clusters.【F:Dockerfile†L1-L200】【F:build_native.sh†L1-L160】【F:k8s/secrets.yaml†L1-L120】
+  manifests so operators can run the stack on laptops or clusters.【F:Dockerfile†L1-L200】【F:build_native.sh†L1-L160】
+- External secret orchestration pulls runtime credentials from Vault using an
+  `ExternalSecret`, eliminating raw `Secret` manifests in the repository.【F:k8s/secrets.yaml†L1-L52】
 - `scripts/deploy_docker.sh` automates profile selection, secret rotation, and
   container lifecycle management to streamline developer onboarding.【F:scripts/deploy_docker.sh†L1-L200】
 

--- a/docs/implementation_status.md
+++ b/docs/implementation_status.md
@@ -1,6 +1,6 @@
 # Implementation Status Overview
 
-Last updated: 2025-12-11
+Last updated: 2025-10-05
 
 This report reconciles the roadmap with the current codebase. Each phase notes
 what has shipped, what remains, and any discrepancies between historical plans
@@ -105,6 +105,8 @@ and reality.
 
 - ✅ **JWT alignment**: configuration and security manager now enforce HS256,
   deferring asymmetric keys until managed storage is available.
+- ✅ **Secret storage**: Kubernetes manifests source credentials from Vault via
+  an `ExternalSecret`, replacing inline Kubernetes `Secret` manifests.【F:k8s/secrets.yaml†L1-L52】
 - ✅ **Schema evolution**: Alembic migrations cover every ORM model and legacy
   table, allowing production rollouts without `init_db.py` fallbacks.
 - ✅ **Telemetry integration**: Ray Serve success, failure, and scaling counters

--- a/docs/incomplete_logic_audit.md
+++ b/docs/incomplete_logic_audit.md
@@ -1,6 +1,6 @@
 # Incomplete Logic Audit
 
-## Date: 2025-10-20
+## Date: 2025-10-05
 
 This follow-up audit re-runs and expands the repository-wide scan for patterns
 that typically signal unfinished implementations. The review covered the core

--- a/modules/AGENTS.md
+++ b/modules/AGENTS.md
@@ -15,7 +15,7 @@ Covers optional subsystems under `modules/`, including evolution and neuron trai
 - **Self-Improvement Focus**
   - ✅ Personality profiles persisted via SQLModel with live adapter updates.
   - ✅ Self-training cycles produce real adapter artefacts via `modules.neurons.training.mntp_trainer.MNTPTrainer` with deterministic fallbacks.
-  - 🚧 Explore reinforcement learning loops and advanced scaling strategies.
+  - 🔄 Reinforcement-learning research loops ship under `modules/neurons/training/reinforcement_loop.py`; integrate telemetry, rollout, and operator controls before calling the milestone complete.
   - 🔄 Expand tests for long-running MNTP jobs, multi-replica Ray Serve rollouts, and distributed workflows.
 
 ## Design Tenets

--- a/modules/evolution_engine/AGENTS.md
+++ b/modules/evolution_engine/AGENTS.md
@@ -16,7 +16,7 @@ Defines how retraining orchestration and self-healing pipelines behave under
 - **Self-Training Execution**
   - ✅ Personality profiles persisted via SQLModel with live adapter updates.
   - ✅ Self-training cycles produce real adapter artefacts via `modules.neurons.training.mntp_trainer.MNTPTrainer` with deterministic fallbacks.
-  - 🚧 Explore reinforcement learning loops and advanced scaling strategies.
+  - 🔄 Reinforcement-learning research loops ship under `modules/neurons/training/reinforcement_loop.py`; integrate telemetry, rollout, and operator controls before calling the milestone complete.
   - 🔄 Expand tests for long-running MNTP jobs, multi-replica Ray Serve rollouts, and distributed workflows.
 
 ## Pipeline Discipline

--- a/modules/neurons/AGENTS.md
+++ b/modules/neurons/AGENTS.md
@@ -15,7 +15,7 @@ Applies to neuron trainers and utilities under `modules/neurons/`.
 - **Training Cadence**
   - ✅ Personality profiles persisted via SQLModel with live adapter updates.
   - ✅ Self-training cycles produce real adapter artefacts via `modules.neurons.training.mntp_trainer.MNTPTrainer` with deterministic fallbacks.
-  - 🚧 Explore reinforcement learning loops and advanced scaling strategies.
+  - 🔄 Reinforcement-learning research loops ship under `modules/neurons/training/reinforcement_loop.py`; integrate telemetry, rollout, and operator controls before calling the milestone complete.
   - 🔄 Expand tests for long-running MNTP jobs, multi-replica Ray Serve rollouts, and distributed workflows.
 
 ## Runtime Expectations

--- a/monGARS/AGENTS.md
+++ b/monGARS/AGENTS.md
@@ -17,12 +17,12 @@ Covers the primary FastAPI app, cognition services, persistence layer, and share
   - ✅ Multi-architecture build scripts and cache metrics.
   - ✅ Hardened RBAC manifests.
   - ✅ Ray Serve HTTP integration with circuit breaking plus MNTP trainer support for LoRA and curated adapters.
-  - 🔄 Extend Alembic migrations for the newest SQLModel tables, including legacy tables created outside the current ORM layer.
+  - ✅ Extend Alembic migrations for the newest SQLModel tables, including legacy tables created outside the current ORM layer.
   - ✅ Expose Ray Serve success/failure counters via OpenTelemetry (`llm.ray.*` metrics emitted by `LLMIntegration`).
 - **Networking & Collaboration**
   - ✅ Encrypted peer registry, admin-guarded endpoints, and distributed scheduler.
   - ✅ Sommeil Paradoxal idle-time optimisation and safe apply pipeline.
-  - 🔄 Implement load-aware scheduling strategies and share optimisation telemetry across nodes.
+  - ✅ Implemented load-aware scheduling strategies and shared optimisation telemetry across nodes.
 
 ## Dependency & Configuration Discipline
 

--- a/monGARS/api/AGENTS.md
+++ b/monGARS/api/AGENTS.md
@@ -16,7 +16,7 @@ Applies to routers, schemas, WebSocket helpers, and auth utilities under `monGAR
   - ✅ FastAPI chat/history/token endpoints with validation.
   - ✅ Django chat UI with progressive enhancement.
   - ✅ FastAPI WebSocket handler with ticket verification, history replay, and streaming guarded by `WS_ENABLE_EVENTS`.
-  - 🔄 Replace hard-coded credential stores with database-backed auth flows.
+  - 🔄 Replaced hard-coded credential stores with database-backed auth flows (the `DEFAULT_USERS` bootstrap in `monGARS/api/web_api.py` still provisions demo accounts until the cleanup lands).
   - 🚧 Publish polished SDKs and reference clients.
 
 ## Endpoint Design

--- a/monGARS/core/AGENTS.md
+++ b/monGARS/core/AGENTS.md
@@ -17,12 +17,12 @@ Guides orchestrators, schedulers, and memory abstractions under `monGARS/core/`.
   - ✅ Multi-architecture build scripts and cache metrics.
   - ✅ Hardened RBAC manifests.
   - ✅ Ray Serve HTTP integration with circuit breaking plus MNTP trainer support for LoRA and curated adapters.
-  - 🔄 Extend Alembic migrations for the newest SQLModel tables, including legacy tables created outside the current ORM layer.
+  - ✅ Extend Alembic migrations for the newest SQLModel tables, including legacy tables created outside the current ORM layer.
   - ✅ Expose Ray Serve success/failure counters via OpenTelemetry (`llm.ray.*` metrics emitted by `LLMIntegration`).
 - **Self-Improvement**
   - ✅ Personality profiles persisted via SQLModel with live adapter updates.
   - ✅ Self-training cycles produce real adapter artefacts via `modules.neurons.training.mntp_trainer.MNTPTrainer` with deterministic fallbacks.
-  - 🚧 Explore reinforcement learning loops and advanced scaling strategies.
+  - 🔄 Reinforcement-learning research loops ship under `modules/neurons/training/reinforcement_loop.py`; integrate telemetry, rollout, and operator controls before calling the milestone complete.
   - 🔄 Expand tests for long-running MNTP jobs, multi-replica Ray Serve rollouts, and distributed workflows.
 
 ## Architectural Principles

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -15,13 +15,13 @@ suites.
 
 - **Stability Assurance**
   - ✅ Align JWT algorithm with deployed secrets (HS256 enforced until managed key storage is available).
-  - 🔒 Store runtime secrets in Vault/Sealed Secrets instead of raw `k8s/secrets.yaml`.
+  - ✅ Store runtime secrets in Vault/Sealed Secrets instead of raw `k8s/secrets.yaml`.
   - ✅ Update Dockerfiles to run as non-root and add a `.dockerignore` to exclude secrets and build artefacts.
-  - 👤 Replace demo users in `web_api.py` with the database-backed authentication flow and migrations.
+  - 🔄 Replace demo users in `web_api.py` with the database-backed authentication flow and migrations (default accounts still load at runtime and must be removed).
 - **Research Coverage**
   - ✅ Personality profiles persisted via SQLModel with live adapter updates.
   - ✅ Self-training cycles produce real adapter artefacts via `modules.neurons.training.mntp_trainer.MNTPTrainer` with deterministic fallbacks.
-  - 🚧 Explore reinforcement learning loops and advanced scaling strategies.
+  - 🔄 Reinforcement-learning research loops ship under `modules/neurons/training/reinforcement_loop.py`; integrate telemetry, rollout, and operator controls before calling the milestone complete.
   - 🔄 Expand tests for long-running MNTP jobs, multi-replica Ray Serve rollouts, and distributed workflows.
 
 ## Structure & Conventions

--- a/webapp/AGENTS.md
+++ b/webapp/AGENTS.md
@@ -17,7 +17,7 @@ middleware.
   - ✅ FastAPI chat/history/token endpoints with validation.
   - ✅ Django chat UI with progressive enhancement.
   - ✅ FastAPI WebSocket handler with ticket verification, history replay, and streaming guarded by `WS_ENABLE_EVENTS`.
-  - 🔄 Replace hard-coded credential stores with database-backed auth flows.
+  - 🔄 Replaced hard-coded credential stores with database-backed auth flows (the `DEFAULT_USERS` bootstrap in `monGARS/api/web_api.py` still provisions demo accounts until the cleanup lands).
   - 🚧 Publish polished SDKs and reference clients.
 
 ## Views & Services

--- a/webapp/chat/AGENTS.md
+++ b/webapp/chat/AGENTS.md
@@ -16,7 +16,7 @@ Covers views, services, forms, and templates for `webapp/chat/`.
   - ✅ FastAPI chat/history/token endpoints with validation.
   - ✅ Django chat UI with progressive enhancement.
   - ✅ FastAPI WebSocket handler with ticket verification, history replay, and streaming guarded by `WS_ENABLE_EVENTS`.
-  - 🔄 Replace hard-coded credential stores with database-backed auth flows.
+  - 🔄 Replaced hard-coded credential stores with database-backed auth flows (the `DEFAULT_USERS` bootstrap in `monGARS/api/web_api.py` still provisions demo accounts until the cleanup lands).
   - 🚧 Publish polished SDKs and reference clients.
 
 ## Architecture


### PR DESCRIPTION
## Summary
- mark the roadmap and implementation status report with Vault-backed secret storage while calling out the remaining demo-user cleanup
- refresh every AGENTS.md via the manager script so the roadmap bullets match the new phase statuses
- capture Vault ExternalSecret usage in the codebase status report and refresh the incomplete logic audit date

## Testing
- pytest tests/test_api_chat.py tests/test_distributed_scheduler.py tests/test_incomplete_logic_guardrails.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e2a2f502f483338703c1586920b9de

## Summary by Sourcery

Refresh documentation status markers and roadmap to reflect completed Vault-backed secret storage, ExternalSecret integration, and updated phase completions, while highlighting remaining demo-user cleanup and updating audit timestamps.

Enhancements:
- Mark Vault-backed secret storage uses ExternalSecrets in deployment docs and codebase status.
- Refresh completion statuses in all AGENTS.md files to match current implementation phases.
- Update roadmap and implementation_status reports with new phase markers and current timestamps.
- Call out remaining demo-user cleanup and update incomplete logic audit date.