### PR TITLE
Expand chat service end-to-end coverage

### DIFF
--- a/dolphin_llm2vec_pipeline.py
+++ b/dolphin_llm2vec_pipeline.py
@@ -10,7 +10,11 @@ from pathlib import Path
 from llm2vec import LLM2Vec
 
 from monGARS.mlops.dataset import prepare_instruction_dataset
-from monGARS.mlops.exporters import export_gguf, merge_lora_adapters, run_generation_smoke_test
+from monGARS.mlops.exporters import (
+    export_gguf,
+    merge_lora_adapters,
+    run_generation_smoke_test,
+)
 from monGARS.mlops.model import load_4bit_causal_lm, summarise_device_map
 from monGARS.mlops.training import (
     LoraHyperParams,
@@ -118,7 +122,9 @@ def main() -> None:
         "max_seq_len": MAX_SEQ_LEN,
         "notes": "Reload base in 4-bit, then load PEFT adapters and wrap with LLM2Vec.",
     }
-    (OUTPUT_DIR / "wrapper_config.json").write_text(json.dumps(wrapper_config, indent=2))
+    (OUTPUT_DIR / "wrapper_config.json").write_text(
+        json.dumps(wrapper_config, indent=2)
+    )
 
     if RUN_TINY_TESTS:
         prompt = (

--- a/monGARS/mlops/exporters.py
+++ b/monGARS/mlops/exporters.py
@@ -22,7 +22,9 @@ def merge_lora_adapters(
         from transformers import AutoModelForCausalLM, AutoTokenizer
     except Exception as exc:  # pragma: no cover - dependency missing
         logger.warning("Unable to import transformers/peft for merge", exc_info=True)
-        raise RuntimeError("transformers and peft are required to merge adapters") from exc
+        raise RuntimeError(
+            "transformers and peft are required to merge adapters"
+        ) from exc
 
     logger.info(
         "Merging adapters into base model",
@@ -57,11 +59,17 @@ def export_gguf(
 
     logger.info(
         "Exporting GGUF",
-        extra={"source_dir": str(source_dir), "gguf_dir": str(gguf_dir), "method": quantization_method},
+        extra={
+            "source_dir": str(source_dir),
+            "gguf_dir": str(gguf_dir),
+            "method": quantization_method,
+        },
     )
     gguf_dir.mkdir(parents=True, exist_ok=True)
     model, tokenizer = FastModel.from_pretrained(str(source_dir))
-    model.save_pretrained_gguf(str(gguf_dir), tokenizer=tokenizer, quantization_method=quantization_method)
+    model.save_pretrained_gguf(
+        str(gguf_dir), tokenizer=tokenizer, quantization_method=quantization_method
+    )
     logger.info("GGUF export complete", extra={"gguf_dir": str(gguf_dir)})
     return True
 

--- a/monGARS/mlops/model.py
+++ b/monGARS/mlops/model.py
@@ -31,7 +31,8 @@ def load_4bit_causal_lm(
         bnb_4bit_compute_dtype=torch.float16,
     )
     logger.info(
-        "Loading base model", extra={"model": model_id, "vram_budget_mb": vram_budget_mb}
+        "Loading base model",
+        extra={"model": model_id, "vram_budget_mb": vram_budget_mb},
     )
     model = AutoModelForCausalLM.from_pretrained(
         model_id,

--- a/monGARS/mlops/training.py
+++ b/monGARS/mlops/training.py
@@ -135,7 +135,9 @@ def disable_training_mode(model: Any) -> None:
         method()
 
 
-def run_embedding_smoke_test(encoder: Any, texts: Iterable[str]) -> tuple[int, int] | None:
+def run_embedding_smoke_test(
+    encoder: Any, texts: Iterable[str]
+) -> tuple[int, int] | None:
     """Execute a small embedding test returning the resulting tensor shape."""
 
     if not texts:

--- a/tests/test_webapp_chat_services.py
+++ b/tests/test_webapp_chat_services.py
@@ -1,7 +1,18 @@
 from __future__ import annotations
 
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Iterable
+
+import httpx
 import pytest
 
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("JWT_ALGORITHM", "HS256")
+
+from monGARS.api.dependencies import get_persistence_repository, hippocampus
+from monGARS.api.web_api import DEFAULT_USERS, app, get_conversational_module
 from webapp.chat import services
 
 
@@ -74,3 +85,144 @@ async def test_post_chat_message_error(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert "maintenance" in result["error"]
     assert recorder["url"] == "http://api/api/v1/conversation/chat"
+
+
+@dataclass
+class _StubUser:
+    username: str
+    password_hash: str
+    is_admin: bool = False
+
+
+class _InMemoryRepo:
+    def __init__(self) -> None:
+        self._users: dict[str, _StubUser] = {}
+
+    async def get_user_by_username(self, username: str) -> _StubUser | None:
+        return self._users.get(username)
+
+    async def create_user_atomic(
+        self,
+        username: str,
+        password_hash: str,
+        *,
+        is_admin: bool = False,
+        reserved_usernames: Iterable[str] | None = None,
+    ) -> _StubUser:
+        reserved = set(reserved_usernames or ())
+        if username in reserved or username in self._users:
+            raise ValueError("username already exists")
+        user = _StubUser(
+            username=username, password_hash=password_hash, is_admin=is_admin
+        )
+        self._users[username] = user
+        return user
+
+    async def create_user(
+        self, username: str, password_hash: str, *, is_admin: bool = False
+    ) -> _StubUser:
+        if username in self._users:
+            raise ValueError("username already exists")
+        user = _StubUser(
+            username=username, password_hash=password_hash, is_admin=is_admin
+        )
+        self._users[username] = user
+        return user
+
+
+class _StubConversationalModule:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def generate_response(
+        self,
+        user_id: str,
+        query: str,
+        session_id: str | None = None,
+        image_data: bytes | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "user_id": user_id,
+                "query": query,
+                "session_id": session_id,
+            }
+        )
+        await hippocampus.store(user_id, query, "stubbed-response")
+        speech_turn = {
+            "turn_id": "turn-1",
+            "text": "stubbed-response",
+            "created_at": datetime.now(UTC).isoformat(),
+            "segments": [],
+            "average_words_per_second": 2.0,
+            "tempo": 1.0,
+        }
+        return {
+            "text": "stubbed-response",
+            "confidence": 0.75,
+            "processing_time": 0.2,
+            "speech_turn": speech_turn,
+        }
+
+
+@pytest.mark.asyncio
+async def test_services_roundtrip_against_fastapi(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hippocampus._memory.clear()
+    hippocampus._locks.clear()
+    hippocampus._hydrated_users.clear()
+
+    repo = _InMemoryRepo()
+    defaults = DEFAULT_USERS["u1"]
+    repo._users["u1"] = _StubUser(
+        username="u1",
+        password_hash=defaults["password_hash"],
+        is_admin=defaults.get("is_admin", False),
+    )
+    convo = _StubConversationalModule()
+
+    app.dependency_overrides[get_persistence_repository] = lambda: repo
+    app.dependency_overrides[get_conversational_module] = lambda: convo
+
+    original_async_client = httpx.AsyncClient
+
+    def _async_client_factory(*args, **kwargs):
+        kwargs.setdefault("transport", httpx.ASGITransport(app=app))
+        kwargs.setdefault("base_url", "http://testserver")
+        return original_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(services.httpx, "AsyncClient", _async_client_factory)
+    monkeypatch.setattr(services, "FASTAPI_URL", "http://testserver")
+
+    try:
+        await app.router.startup()
+
+        token = await services.authenticate_user("u1", "x")
+        assert token
+
+        result = await services.post_chat_message(
+            "u1", token, "hi<script>alert(1)</script>"
+        )
+        assert result["response"] == "stubbed-response"
+        assert "error" not in result
+        assert result["confidence"] == pytest.approx(0.75)
+        assert result["processing_time"] == pytest.approx(0.2)
+
+        assert convo.calls == [
+            {"user_id": "u1", "query": "hialert(1)", "session_id": None}
+        ]
+
+        history = await services.fetch_history("u1", token)
+        assert isinstance(history, list)
+        assert history
+        latest = history[0]
+        assert latest["query"] == "hialert(1)"
+        assert latest["response"] == "stubbed-response"
+    finally:
+        await app.router.shutdown()
+        app.dependency_overrides.pop(get_persistence_repository, None)
+        app.dependency_overrides.pop(get_conversational_module, None)
+        hippocampus._memory.clear()
+        hippocampus._locks.clear()
+        hippocampus._hydrated_users.clear()


### PR DESCRIPTION
## Summary
- add in-memory repository and conversation stubs so chat service tests can exercise the FastAPI stack end-to-end
- cover token issuance, chat response propagation, and history persistence using httpx ASGI transport
- seed JWT configuration for the expanded tests

## Testing
- pytest tests/test_webapp_chat_services.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e325c8d28083339e2e2f65cda5df4b

## Summary by Sourcery

Expand end-to-end coverage of the chat service by adding in-memory stubs and running tests against the FastAPI stack using HTTPX ASGI transport.

Tests:
- Introduce _InMemoryRepo and _StubConversationalModule stubs to simulate persistence and conversational logic in tests
- Monkey-patch HTTPX AsyncClient and FastAPI dependencies to inject stub modules
- Add test_services_roundtrip_against_fastapi to verify authentication, chat message posting, response handling, and history persistence
- Reset in-memory hippocampus state before and after the end-to-end test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests for chat services: auth, sending messages, and retrieving history via a running app.
  * Introduced isolated setup/teardown, in-memory test components, and dependency injection to improve reliability and repeatability.
  * Verified request/response shapes, input sanitization, and end-to-end call flows.

* **Style / Refactor**
  * Minor formatting and signature layout changes across utility and ML-related code with no behavioral impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->