### PR TITLE
Fix CPU offload config for 4-bit loader

### DIFF
--- a/monGARS/mlops/model.py
+++ b/monGARS/mlops/model.py
@@ -38,7 +38,7 @@ def load_4bit_causal_lm(
         "model.norm": 0,
         "lm_head": "cpu",
     }
-    max_memory = {0: f"{int(vram_budget_mb)}MiB", "cpu": "64GiB"}
+    max_memory = {0: f"{vram_budget_mb}MiB", "cpu": "64GiB"}
 
     logger.info(
         "Loading base model",


### PR DESCRIPTION
## Summary
- keep the 4-bit `lm_head` on CPU while enabling HF CPU offload to avoid VRAM spikes during model load, now setting the offload flag on the quantization config and using the new `dtype` kwarg so quantized loads succeed on CPU/GPU splits
- introduce a light LoRA preparation helper that skips `prepare_model_for_kbit_training` and exposes it through the mlops package
- update training entry points to consume the new helper defaults for safer 8GB execution

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e334368cf48333882972531a0c13cd

## Summary by Sourcery

Improve memory management and training preparation for 4-bit and k-bit models by refining CPU offload settings, preventing VRAM spikes, and introducing a lightweight LoRA preparation helper.

New Features:
- Add prepare_lora_model_light helper to attach LoRA adapters without upcasting lm_head to FP32

Enhancements:
- Keep 4-bit lm_head on CPU with explicit device_map, updated BitsAndBytesConfig flags, and dtype to avoid VRAM spikes during model loading
- Reduce default LoRA rank and alpha to 16
- Introduce internal _enable_input_require_grads to ensure input embeddings require gradients
- Provide backward-compatible prepare_lora_model wrapper around the new light helper
- Configure loaded models with disabled cache and eager attention where supported

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved low-VRAM model loading by enabling selective CPU offload, reducing GPU memory pressure and enhancing load reliability and responsiveness.

* **Bug Fixes**
  * Addressed out-of-memory errors during 4-bit model initialization on devices with limited VRAM, improving stability during startup and inference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->