### PR TITLE
Improve Docker Compose startup readiness handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ x-database-environment: &database-environment
   DB_USER: ${DB_USER:-mongars}
   DB_PASSWORD: ${DB_PASSWORD:-changeme}
   DB_NAME: ${DB_NAME:-mongars_db}
+  DB_STARTUP_TIMEOUT: ${DB_STARTUP_TIMEOUT:-120}
+  DB_STARTUP_RETRY_INTERVAL: ${DB_STARTUP_RETRY_INTERVAL:-3}
 
 x-app-environment: &app-environment
   <<: *database-environment
@@ -37,8 +39,7 @@ services:
     environment:
       <<: *app-environment
     depends_on:
-      postgres:
-        condition: service_healthy
+      - postgres
     networks:
       - mongars
 
@@ -48,13 +49,12 @@ services:
       context: .
       dockerfile: Dockerfile
       target: runtime
+    command: >-
+      bash -lc "python scripts/wait_for_database.py && uvicorn monGARS.api.web_api:app --host 0.0.0.0 --port 8000"
     depends_on:
-      migrations:
-        condition: service_completed_successfully
-      redis:
-        condition: service_healthy
-      postgres:
-        condition: service_healthy
+      - migrations
+      - redis
+      - postgres
     ports:
       - "${API_PORT:-8000}:8000"
     env_file:
@@ -80,13 +80,12 @@ services:
       context: .
       dockerfile: Dockerfile
       target: runtime
-    command: ["python", "webapp/manage.py", "migrate", "--noinput"]
+    command: >-
+      bash -lc "python scripts/wait_for_database.py && python webapp/manage.py migrate --noinput"
     restart: "no"
     depends_on:
-      postgres:
-        condition: service_healthy
-      migrations:
-        condition: service_completed_successfully
+      - postgres
+      - migrations
     env_file:
       - .env
     environment:
@@ -106,12 +105,10 @@ services:
       dockerfile: Dockerfile
       target: runtime
     command: >-
-      bash -lc "python webapp/manage.py runserver 0.0.0.0:8001"
+      bash -lc "python scripts/wait_for_database.py && python webapp/manage.py runserver 0.0.0.0:8001"
     depends_on:
-      api:
-        condition: service_started
-      webapp-migrations:
-        condition: service_completed_successfully
+      - api
+      - webapp-migrations
     ports:
       - "${WEBAPP_PORT:-8001}:8001"
     env_file:

--- a/scripts/wait_for_database.py
+++ b/scripts/wait_for_database.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""CLI helper to block until the PostgreSQL database is available."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from typing import Final
+
+from sqlalchemy.engine import URL
+
+from init_db import (
+    DEFAULT_DB_STARTUP_RETRY_INTERVAL,
+    DEFAULT_DB_STARTUP_TIMEOUT,
+    build_sync_url,
+    coerce_positive_float,
+    render_url,
+    wait_for_database,
+)
+
+LOGGER = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+DEFAULT_TIMEOUT_ENV: Final[str] = "DB_STARTUP_TIMEOUT"
+DEFAULT_INTERVAL_ENV: Final[str] = "DB_STARTUP_RETRY_INTERVAL"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Block until the configured PostgreSQL database is ready to accept connections.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=None,
+        help=(
+            "Maximum seconds to wait before failing. Defaults to the value in "
+            f"${DEFAULT_TIMEOUT_ENV} or {DEFAULT_DB_STARTUP_TIMEOUT}."
+        ),
+    )
+    parser.add_argument(
+        "--retry-interval",
+        type=float,
+        default=None,
+        help=(
+            "Seconds to sleep between attempts. Defaults to the value in "
+            f"${DEFAULT_INTERVAL_ENV} or {DEFAULT_DB_STARTUP_RETRY_INTERVAL}."
+        ),
+    )
+    return parser.parse_args()
+
+
+def resolve_timeout(raw: float | None, *, env_key: str, default: float) -> float:
+    if raw is not None and raw > 0:
+        return raw
+    return coerce_positive_float(os.getenv(env_key), default=default, minimum=0.0)
+
+
+def resolve_retry_interval(raw: float | None, *, env_key: str, default: float) -> float:
+    if raw is not None and raw > 0:
+        return raw
+    return coerce_positive_float(os.getenv(env_key), default=default, minimum=0.0)
+
+
+def main() -> int:
+    args = parse_args()
+    url: URL = build_sync_url()
+    timeout = resolve_timeout(
+        args.timeout,
+        env_key=DEFAULT_TIMEOUT_ENV,
+        default=DEFAULT_DB_STARTUP_TIMEOUT,
+    )
+    retry_interval = resolve_retry_interval(
+        args.retry_interval,
+        env_key=DEFAULT_INTERVAL_ENV,
+        default=DEFAULT_DB_STARTUP_RETRY_INTERVAL,
+    )
+
+    LOGGER.info("Waiting for PostgreSQL at %s", render_url(url, hide_password=True))
+    wait_for_database(url, timeout=timeout, retry_interval=retry_interval)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except TimeoutError as exc:  # pragma: no cover - CLI surface area
+        LOGGER.error("%s", exc)
+        sys.exit(1)
+    except Exception:  # pragma: no cover - defensive guard for CLI usage
+        LOGGER.exception("Unexpected failure while waiting for database")
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- ensure Docker services call a shared wait script before running by adding database startup timeout configuration and updated commands
- add retry-aware database availability checks reused by both the CLI helper and Alembic bootstrapper

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e3434d4a008333a9d2d23d93e99e67

## Summary by Sourcery

Implement retryable, timeout-based database readiness checks and integrate them into the initialization process and Docker Compose startup flow

New Features:
- Add coerce_positive_float and wait_for_database functions in init_db to validate and wait for database availability with configurable timeout and retry interval
- Introduce a standalone wait_for_database CLI script for blocking startup until the PostgreSQL database is ready

Enhancements:
- Expose DB_STARTUP_TIMEOUT and DB_STARTUP_RETRY_INTERVAL environment variables in Docker Compose with defaults
- Wrap service startup commands in Docker Compose with the wait_for_database script and simplify depends_on configuration by removing health condition blocks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Services now include a startup wait step that ensures the database is reachable before they run.
  - Added configurable database startup timing via environment variables (DB_STARTUP_TIMEOUT, DB_STARTUP_RETRY_INTERVAL).

- Bug Fixes
  - Reduced race conditions during container startup that caused intermittent failures.

- Chores
  - Simplified service dependency declarations and unified startup sequencing across services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->