### PR TITLE
Update LLM defaults to Dolphin 3.0

### DIFF
--- a/configs/llm_models.json
+++ b/configs/llm_models.json
@@ -3,24 +3,24 @@
     "default": {
       "models": {
         "general": {
-          "name": "dolphin-mistral:7b-v2.8-q4_K_M",
+          "name": "dolphin3",
           "provider": "ollama",
           "auto_download": true,
           "parameters": {
             "top_p": 0.9,
             "num_predict": 512
           },
-          "description": "Default bilingual conversation model shipped with the developer profile."
+          "description": "Dolphin 3.0 Llama 3.1 8B chat checkpoint."
         },
         "coding": {
-          "name": "qwen2.5-coder:7b-instruct-q6_K",
+          "name": "dolphin3-llm2vec",
           "provider": "ollama",
           "auto_download": true,
           "parameters": {
             "top_p": 0.9,
             "num_predict": 512
           },
-          "description": "Code-oriented model tuned for lightweight local inference."
+          "description": "LLM2Vec-wrapped Dolphin 3.0 build tuned for coding and embeddings."
         }
       }
     }

--- a/docs/model_management.md
+++ b/docs/model_management.md
@@ -12,7 +12,7 @@ optional description.
     "default": {
       "models": {
         "general": {
-          "name": "dolphin-mistral:7b-v2.8-q4_K_M",
+          "name": "dolphin3",
           "provider": "ollama",
           "auto_download": true,
           "parameters": {
@@ -20,7 +20,7 @@ optional description.
             "num_predict": 512
           }
         },
-        "coding": "qwen2.5-coder:7b-instruct-q6_K"
+        "coding": "dolphin3-llm2vec"
       }
     }
   }

--- a/monGARS/core/model_manager.py
+++ b/monGARS/core/model_manager.py
@@ -120,8 +120,16 @@ class ModelProvisionReport:
 
 
 _DEFAULT_MODELS: dict[str, ModelDefinition] = {
-    "general": ModelDefinition(role="general", name="dolphin-mistral:7b-v2.8-q4_K_M"),
-    "coding": ModelDefinition(role="coding", name="qwen2.5-coder:7b-instruct-q6_K"),
+    "general": ModelDefinition(
+        role="general",
+        name="dolphin3",
+        description="Dolphin 3.0 Llama 3.1 8B chat checkpoint",
+    ),
+    "coding": ModelDefinition(
+        role="coding",
+        name="dolphin3-llm2vec",
+        description="LLM2Vec-wrapped Dolphin 3.0 build for coding tasks",
+    ),
 }
 
 

--- a/tests/test_llm_adapter_refresh.py
+++ b/tests/test_llm_adapter_refresh.py
@@ -80,8 +80,8 @@ async def test_llm_integration_ignores_corrupt_manifest_without_ray(
         def __init__(self) -> None:
             self.calls: list[dict[str, object]] = []
             self._models = {
-                "dolphin-mistral:7b-v2.8-q4_K_M",
-                "qwen2.5-coder:7b-instruct-q6_K",
+                "dolphin3",
+                "dolphin3-llm2vec",
             }
 
         def chat(


### PR DESCRIPTION
## Summary
- point the default general and coding model definitions at the Dolphin 3.0 checkpoints
- refresh the llm model manifest and operator docs to describe the Dolphin-only profile
- align the adapter refresh test harness with the new Ollama inventory names

## Testing
- pytest -k llm_adapter_refresh

------
https://chatgpt.com/codex/tasks/task_e_68e3489e7418833388af9dcc13c5d269

## Summary by Sourcery

Point default general and coding LLM defaults at Dolphin 3.0, refresh related model manifest and documentation, and update tests to match the new model names.

Enhancements:
- Update default general and coding LLM model definitions to use Dolphin 3.0 checkpoints
- Refresh LLM model manifest to a Dolphin-only profile

Documentation:
- Update model management documentation to reference the new Dolphin 3.0 model names

Tests:
- Align the LLM adapter refresh test harness with the updated Dolphin 3.0 Ollama inventory names