### PR TITLE
Fix 4-bit loader compatibility with new transformers

### DIFF
--- a/monGARS/mlops/model.py
+++ b/monGARS/mlops/model.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import inspect
 import logging
 from pathlib import Path
 from typing import Any, Iterable
@@ -25,19 +24,18 @@ def load_4bit_causal_lm(
     offload_path = Path(offload_dir)
     offload_path.mkdir(parents=True, exist_ok=True)
 
-    bnb_kwargs: dict[str, Any] = {
+    bnb_common: dict[str, Any] = {
         "load_in_4bit": True,
         "bnb_4bit_use_double_quant": True,
         "bnb_4bit_quant_type": "nf4",
         "bnb_4bit_compute_dtype": torch.float16,
     }
-    if (
-        "llm_int8_enable_fp32_cpu_offload"
-        in inspect.signature(BitsAndBytesConfig.__init__).parameters
-    ):
-        bnb_kwargs["llm_int8_enable_fp32_cpu_offload"] = True
-
-    bnb_cfg = BitsAndBytesConfig(**bnb_kwargs)
+    try:
+        bnb_cfg = BitsAndBytesConfig(
+            **bnb_common, llm_int8_enable_fp32_cpu_offload=True
+        )
+    except TypeError:
+        bnb_cfg = BitsAndBytesConfig(**bnb_common)
 
     device_map = {
         "model.embed_tokens": 0,
@@ -63,14 +61,15 @@ def load_4bit_causal_lm(
         "quantization_config": bnb_cfg,
         "low_cpu_mem_usage": True,
         "trust_remote_code": trust_remote_code,
-        "dtype": torch.float16,
     }
-
-    from_pretrained_signature = inspect.signature(AutoModelForCausalLM.from_pretrained)
-    if "dtype" not in from_pretrained_signature.parameters:
-        model_kwargs["torch_dtype"] = model_kwargs.pop("dtype")
-
-    model = AutoModelForCausalLM.from_pretrained(model_id, **model_kwargs)
+    try:
+        model = AutoModelForCausalLM.from_pretrained(
+            model_id, **model_kwargs, torch_dtype=torch.float16
+        )
+    except TypeError:
+        model = AutoModelForCausalLM.from_pretrained(
+            model_id, **model_kwargs, dtype=torch.float16
+        )
 
     tokenizer = AutoTokenizer.from_pretrained(model_id, use_fast=True)
     if tokenizer.pad_token_id is None and tokenizer.eos_token_id is not None:

--- a/tests/mlops/test_model.py
+++ b/tests/mlops/test_model.py
@@ -56,55 +56,12 @@ def _patch_bitsandbytes(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(model_module, "BitsAndBytesConfig", _FakeBitsAndBytesConfig)
 
 
-def test_load_4bit_causal_lm_uses_dtype_kwarg(
+def test_load_4bit_causal_lm_prefers_torch_dtype_kwarg(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ):
     recorded_kwargs: dict[str, Any] = {}
 
     def _fake_from_pretrained(
-        model_id: str,
-        *,
-        device_map: dict[str, Any],
-        max_memory: dict[Any, str],
-        offload_folder: str,
-        quantization_config: Any,
-        low_cpu_mem_usage: bool,
-        trust_remote_code: bool,
-        dtype,
-    ) -> Any:  # noqa: ARG001
-        recorded_kwargs.update(
-            {
-                "device_map": device_map,
-                "max_memory": max_memory,
-                "offload_folder": offload_folder,
-                "quantization_config": quantization_config,
-                "low_cpu_mem_usage": low_cpu_mem_usage,
-                "trust_remote_code": trust_remote_code,
-                "dtype": dtype,
-            }
-        )
-        return _DummyModel()
-
-    monkeypatch.setattr(
-        model_module.AutoModelForCausalLM, "from_pretrained", _fake_from_pretrained
-    )
-
-    model, tokenizer = model_module.load_4bit_causal_lm(
-        "meta-llama/Llama-2-7b-hf", offload_dir=tmp_path
-    )
-
-    assert isinstance(model, _DummyModel)
-    assert isinstance(tokenizer, _DummyTokenizer)
-    assert recorded_kwargs["dtype"] is model_module.torch.float16
-    assert "llm_int8_enable_fp32_cpu_offload" not in recorded_kwargs
-
-
-def test_load_4bit_causal_lm_falls_back_to_torch_dtype(
-    monkeypatch: pytest.MonkeyPatch, tmp_path
-):
-    recorded_kwargs: dict[str, Any] = {}
-
-    def _legacy_from_pretrained(
         model_id: str,
         *,
         device_map: dict[str, Any],
@@ -129,11 +86,103 @@ def test_load_4bit_causal_lm_falls_back_to_torch_dtype(
         return _DummyModel()
 
     monkeypatch.setattr(
+        model_module.AutoModelForCausalLM, "from_pretrained", _fake_from_pretrained
+    )
+
+    model, tokenizer = model_module.load_4bit_causal_lm(
+        "meta-llama/Llama-2-7b-hf", offload_dir=tmp_path
+    )
+
+    assert isinstance(model, _DummyModel)
+    assert isinstance(tokenizer, _DummyTokenizer)
+    assert recorded_kwargs["torch_dtype"] is model_module.torch.float16
+    assert recorded_kwargs["quantization_config"].llm_int8_enable_fp32_cpu_offload is True
+
+
+def test_load_4bit_causal_lm_falls_back_to_dtype_kwarg(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    calls: list[dict[str, Any]] = []
+
+    def _legacy_from_pretrained(
+        model_id: str,
+        *,
+        device_map: dict[str, Any],
+        max_memory: dict[Any, str],
+        offload_folder: str,
+        quantization_config: Any,
+        low_cpu_mem_usage: bool,
+        trust_remote_code: bool,
+        **kwargs,
+    ) -> Any:  # noqa: ARG001
+        calls.append(kwargs)
+        if "torch_dtype" in kwargs:
+            raise TypeError("unexpected keyword argument 'torch_dtype'")
+        return _DummyModel()
+
+    monkeypatch.setattr(
         model_module.AutoModelForCausalLM, "from_pretrained", _legacy_from_pretrained
     )
 
     model_module.load_4bit_causal_lm("meta-llama/Llama-2-7b-hf", offload_dir=tmp_path)
 
-    assert "torch_dtype" in recorded_kwargs
-    assert "dtype" not in recorded_kwargs
-    assert recorded_kwargs["torch_dtype"] is model_module.torch.float16
+    assert len(calls) == 2
+    assert calls[0]["torch_dtype"] is model_module.torch.float16
+    assert calls[1]["dtype"] is model_module.torch.float16
+
+
+def test_load_4bit_causal_lm_handles_legacy_bitsandbytes_kwargs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    quant_configs: list[Any] = []
+
+    class _LegacyBitsAndBytesConfig:
+        def __init__(
+            self,
+            *,
+            load_in_4bit: bool,
+            bnb_4bit_use_double_quant: bool,
+            bnb_4bit_quant_type: str,
+            bnb_4bit_compute_dtype,
+            **kwargs,
+        ) -> None:
+            if "llm_int8_enable_fp32_cpu_offload" in kwargs:
+                raise TypeError("unexpected keyword argument")
+            self.load_in_4bit = load_in_4bit
+            self.bnb_4bit_use_double_quant = bnb_4bit_use_double_quant
+            self.bnb_4bit_quant_type = bnb_4bit_quant_type
+            self.bnb_4bit_compute_dtype = bnb_4bit_compute_dtype
+
+    monkeypatch.setattr(model_module, "BitsAndBytesConfig", _LegacyBitsAndBytesConfig)
+
+    def _fake_from_pretrained(
+        *_, quantization_config: Any, **__
+    ) -> Any:  # noqa: ANN002
+        quant_configs.append(quantization_config)
+        return _DummyModel()
+
+    monkeypatch.setattr(
+        model_module.AutoModelForCausalLM, "from_pretrained", _fake_from_pretrained
+    )
+
+    model_module.load_4bit_causal_lm("meta-llama/Llama-2-7b-hf", offload_dir=tmp_path)
+
+    assert len(quant_configs) == 1
+    cfg = quant_configs[0]
+    assert not hasattr(cfg, "llm_int8_enable_fp32_cpu_offload")
+
+
+def test_load_4bit_causal_lm_sets_tokenizer_pad_token(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setattr(
+        model_module.AutoModelForCausalLM,
+        "from_pretrained",
+        lambda *_, **__: _DummyModel(),
+    )
+
+    _, tokenizer = model_module.load_4bit_causal_lm(
+        "meta-llama/Llama-2-7b-hf", offload_dir=tmp_path
+    )
+
+    assert tokenizer.pad_token == tokenizer.eos_token


### PR DESCRIPTION
## Summary
- guard 4-bit loader against deprecated kwargs when constructing the HF model
- add unit coverage to ensure dtype selection works across transformers releases

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e3521794d48333a1b134d86b1f92ed

## Summary by Sourcery

Ensure 4-bit model loader remains compatible with both legacy and new Transformers APIs by dynamically selecting appropriate keyword arguments based on function signatures, and add tests to verify dtype and offload flag handling.

Bug Fixes:
- Guard against deprecated llm_int8_enable_fp32_cpu_offload argument in BitsAndBytesConfig when unavailable
- Detect and adapt to new from_pretrained signature by using 'dtype' instead of 'torch_dtype' when appropriate

Enhancements:
- Refactor load_4bit_causal_lm to assemble configuration and model loading kwargs dynamically via inspect.signature

Tests:
- Add unit tests to verify dtype selection and offload flag inclusion for both legacy and new transformer signatures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Seamless loading of 4-bit quantized language models across different library versions by auto-adapting dtype handling.
- Bug Fixes
  - Prevents unintended CPU offload options from being applied during model load in certain environments.
  - Improves robustness of model initialization by dynamically adapting to available parameters.
- Refactor
  - Streamlined configuration and model-loading argument handling for better compatibility and maintainability.
- Tests
  - Added comprehensive tests covering 4-bit load paths, dtype fallback behavior, and argument forwarding to ensure backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->