### PR TITLE
Reserve VRAM headroom for QLoRA training

### DIFF
--- a/build_and_wrap.py
+++ b/build_and_wrap.py
@@ -43,6 +43,11 @@ LR = float(os.environ.get("LR", "2e-4"))
 EPOCHS = float(os.environ.get("EPOCHS", "1.0"))
 MAX_STEPS = int(os.environ.get("MAX_STEPS", "-1"))
 VRAM_BUDGET_MB = int(os.environ.get("VRAM_BUDGET_MB", "7300"))
+ACTIVATION_BUFFER_MB = int(
+    os.environ.get(
+        "ACTIVATION_BUFFER_MB", os.environ.get("VRAM_ACTIVATION_BUFFER_MB", "1024")
+    )
+)
 OFFLOAD_DIR = Path(os.environ.get("OFFLOAD_DIR", "./offload"))
 OUTPUT_DIR = Path(os.environ.get("OUTPUT_DIR", "./out"))
 EXPORT_MERGED_FP16 = os.environ.get("EXPORT_MERGED_FP16", "0") == "1"
@@ -111,6 +116,7 @@ def _assemble_training_summary(
             "epochs": EPOCHS,
             "max_steps": MAX_STEPS,
             "vram_budget_mb": VRAM_BUDGET_MB,
+            "activation_buffer_mb": ACTIVATION_BUFFER_MB,
             "quantization_method": "bnb-4bit-nf4",
         },
     )
@@ -153,6 +159,7 @@ def main() -> None:
     model, tokenizer = load_4bit_causal_lm(
         MODEL_ID,
         vram_budget_mb=VRAM_BUDGET_MB,
+        activation_buffer_mb=ACTIVATION_BUFFER_MB,
         offload_dir=OFFLOAD_DIR,
     )
     summarise_device_map(model)
@@ -200,6 +207,7 @@ def main() -> None:
         max_seq_len=MAX_SEQ_LEN,
         vram_budget_mb=VRAM_BUDGET_MB,
         offload_dir=OFFLOAD_DIR.resolve(),
+        activation_buffer_mb=ACTIVATION_BUFFER_MB,
     )
     write_wrapper_bundle(bundle_config, wrapper_dir)
 

--- a/dolphin_llm2vec_pipeline.py
+++ b/dolphin_llm2vec_pipeline.py
@@ -37,6 +37,11 @@ DATASET_ID = os.environ.get("DATASET_ID", "yahma/alpaca-cleaned")
 OUTPUT_DIR = Path(os.environ.get("OUTPUT_DIR", "outputs_dolphin8b"))
 OFFLOAD_DIR = Path(os.environ.get("OFFLOAD_DIR", "./offload"))
 VRAM_BUDGET_MB = int(os.environ.get("VRAM_BUDGET_MB", "7300"))
+ACTIVATION_BUFFER_MB = int(
+    os.environ.get(
+        "ACTIVATION_BUFFER_MB", os.environ.get("VRAM_ACTIVATION_BUFFER_MB", "1024")
+    )
+)
 MAX_SEQ_LEN = int(os.environ.get("MAX_SEQ_LEN", "1024"))
 BATCH_SIZE = int(os.environ.get("BATCH_SIZE", "1"))
 GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "8"))
@@ -75,6 +80,7 @@ def main() -> None:
     model, tokenizer = load_4bit_causal_lm(
         MODEL_ID,
         vram_budget_mb=VRAM_BUDGET_MB,
+        activation_buffer_mb=ACTIVATION_BUFFER_MB,
         offload_dir=OFFLOAD_DIR,
     )
     summarise_device_map(model)
@@ -120,6 +126,7 @@ def main() -> None:
         "adapters_dir": str(OUTPUT_DIR),
         "quantization": "bnb-4bit nf4 double-quant fp16 compute",
         "max_seq_len": MAX_SEQ_LEN,
+        "activation_buffer_mb": ACTIVATION_BUFFER_MB,
         "notes": "Reload base in 4-bit, then load PEFT adapters and wrap with LLM2Vec.",
     }
     (OUTPUT_DIR / "wrapper_config.json").write_text(

--- a/modules/neurons/training/mntp_trainer.py
+++ b/modules/neurons/training/mntp_trainer.py
@@ -1170,9 +1170,9 @@ class MNTPTrainer:
     def _resolve_model_name(self) -> str:
         model_name = self.config["model_name_or_path"].strip()
         lower_name = model_name.lower()
-        if lower_name.startswith("cognitivecomputations/dolphin3.0") or lower_name.startswith(
-            "dphn/dolphin3.0"
-        ):
+        if lower_name.startswith(
+            "cognitivecomputations/dolphin3.0"
+        ) or lower_name.startswith("dphn/dolphin3.0"):
             logger.warning(
                 "Large model specified; defaulting to lightweight reference model",
                 extra={"requested_model": model_name},
@@ -1602,6 +1602,16 @@ class MNTPTrainer:
             vram_budget = int(self.config.get("wrapper_vram_budget_mb", 7168))
         except (TypeError, ValueError) as exc:
             raise ValueError("wrapper_vram_budget_mb must be an integer") from exc
+        if vram_budget <= 0:
+            raise ValueError("wrapper_vram_budget_mb must be positive")
+        try:
+            activation_buffer = int(
+                self.config.get("wrapper_activation_buffer_mb", 1024)
+            )
+        except (TypeError, ValueError) as exc:
+            raise ValueError("wrapper_activation_buffer_mb must be an integer") from exc
+        if activation_buffer < 0:
+            raise ValueError("wrapper_activation_buffer_mb must be non-negative")
         try:
             max_seq_len = int(self.config.get("max_seq_length", 512))
         except (TypeError, ValueError) as exc:
@@ -1633,6 +1643,7 @@ class MNTPTrainer:
             max_seq_len=max_seq_len,
             vram_budget_mb=vram_budget,
             offload_dir=offload_path,
+            activation_buffer_mb=activation_buffer,
             quantized_4bit=quantized_flag,
         )
 

--- a/monGARS/mlops/wrapper_loader.py
+++ b/monGARS/mlops/wrapper_loader.py
@@ -87,6 +87,10 @@ def _load_config(config_path: Path) -> WrapperConfig:
         vram_budget = int(vram_budget_raw)
         if vram_budget <= 0:
             raise ValueError
+        activation_buffer_raw = data.get("activation_buffer_mb", 1024)
+        activation_buffer = int(activation_buffer_raw)
+        if activation_buffer < 0:
+            raise ValueError
         offload_dir = Path(data["offload_dir"])
     except KeyError as exc:
         raise WrapperBundleError(f"Wrapper config missing key: {exc.args[0]}") from exc
@@ -108,6 +112,7 @@ def _load_config(config_path: Path) -> WrapperConfig:
         max_seq_len=max_seq_len,
         vram_budget_mb=vram_budget,
         offload_dir=offload_dir,
+        activation_buffer_mb=activation_buffer,
         quantized_4bit=quantized,
     )
 

--- a/tests/test_mlops_artifacts.py
+++ b/tests/test_mlops_artifacts.py
@@ -24,6 +24,7 @@ def sample_config(tmp_path: Path) -> WrapperConfig:
         max_seq_len=1024,
         vram_budget_mb=7300,
         offload_dir=(tmp_path / "offload").resolve(),
+        activation_buffer_mb=768,
     )
 
 
@@ -50,7 +51,9 @@ def test_write_wrapper_bundle_writes_all_files(
     assert "ChatAndEmbed" in module_text
     assert config_json["base_model_id"] == sample_config.base_model_id
     assert config_json["vram_budget_mb"] == sample_config.vram_budget_mb
+    assert config_json["activation_buffer_mb"] == sample_config.activation_buffer_mb
     assert "Wrapper Integration" in readme_text
+    assert "ACTIVATION_BUFFER_MB" in module_text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add an activation buffer option to the QLoRA build scripts and dolphin pipeline so the loader reserves GPU headroom
- compute an adjusted weight budget in the 4-bit model loader and propagate the setting through wrapper configs and loaders
- extend artifacts and model tests to cover the new configuration fields and VRAM budgeting behaviour

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e355905d6c833388feee06f24c8ea8

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/monGARS/190)
<!-- GitContextEnd -->