### PR TITLE
Handle CUDA OOM retries in QLoRA trainer

### DIFF
--- a/monGARS/mlops/training.py
+++ b/monGARS/mlops/training.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable, Type
+from typing import Any, Callable, Iterable, Type
 
 import torch
 from transformers import Trainer, TrainingArguments, default_data_collator
@@ -121,14 +121,29 @@ class TrainerConfig:
     max_steps: int
 
 
+@dataclass(slots=True)
+class OOMRetryEvent:
+    """Structured payload describing a CUDA OOM retry decision."""
+
+    exception: BaseException
+    attempt: int
+    remaining_retries: int
+    batch_size: int
+    grad_accum: int
+    next_batch_size: int
+    next_grad_accum: int
+    will_retry: bool
+
+
+OOMEventHook = Callable[[OOMRetryEvent], None]
+
+
 def _is_cuda_oom(exc: BaseException) -> bool:
     """Return ``True`` when ``exc`` represents a CUDA out-of-memory error."""
 
     if isinstance(exc, torch.cuda.OutOfMemoryError):
         return True
-    if isinstance(exc, RuntimeError) and "out of memory" in str(exc).lower():
-        return True
-    return False
+    return isinstance(exc, RuntimeError) and "out of memory" in str(exc).lower()
 
 
 def _maybe_empty_cuda_cache() -> None:
@@ -140,6 +155,176 @@ def _maybe_empty_cuda_cache() -> None:
             empty_cache()
         except Exception:  # pragma: no cover - defensive guard
             logger.debug("Unable to empty CUDA cache", exc_info=True)
+
+
+def _reset_cuda_peak_memory_stats() -> None:
+    """Reset CUDA peak memory statistics when the API is available."""
+
+    reset_stats = getattr(torch.cuda, "reset_peak_memory_stats", None)
+    if callable(reset_stats):  # pragma: no branch - attribute lookup guard
+        try:
+            reset_stats()
+        except Exception:  # pragma: no cover - defensive guard
+            logger.debug("Unable to reset CUDA peak memory stats", exc_info=True)
+
+
+def _zero_trainer_optimizer(trainer: Any) -> None:
+    """Clear gradients held by the trainer optimizer, if present."""
+
+    optimizer = getattr(trainer, "optimizer", None)
+    if optimizer is None:  # pragma: no cover - accessor guard
+        return
+
+    try:
+        optimizer.zero_grad(set_to_none=True)
+    except TypeError:
+        optimizer.zero_grad()
+    except Exception:  # pragma: no cover - defensive guard
+        logger.debug("Unable to zero trainer optimizer", exc_info=True)
+
+
+def _dispatch_oom_hooks(hooks: Iterable[OOMEventHook], event: OOMRetryEvent) -> None:
+    """Call registered OOM hooks, swallowing their exceptions."""
+
+    for hook in hooks:
+        try:
+            hook(event)
+        except Exception:  # pragma: no cover - hooks are best effort
+            logger.debug("OOM event hook raised", exc_info=True)
+
+
+def _apply_backoff(value: int, factor: float) -> int:
+    """Reduce ``value`` using ``factor`` while ensuring progress."""
+
+    if value <= 1:
+        return 1
+
+    reduced = max(1, int(value * factor))
+    if reduced == value:
+        reduced = max(1, value - 1)
+    return reduced
+
+
+def _build_training_arguments(
+    cfg: TrainerConfig,
+    base_args: dict[str, Any],
+    batch_size: int,
+    grad_accum: int,
+    bf16_ok: bool,
+) -> TrainingArguments:
+    """Create ``TrainingArguments`` with shared defaults."""
+
+    return TrainingArguments(
+        output_dir=str(cfg.output_dir),
+        per_device_train_batch_size=batch_size,
+        gradient_accumulation_steps=grad_accum,
+        learning_rate=cfg.learning_rate,
+        num_train_epochs=cfg.epochs,
+        max_steps=cfg.max_steps if cfg.max_steps > 0 else -1,
+        bf16=bf16_ok,
+        fp16=not bf16_ok,
+        gradient_checkpointing=True,
+        **base_args,
+    )
+
+
+def _coerce_oom_hooks(raw_hooks: Any) -> tuple[OOMEventHook, ...]:
+    """Normalise hook configuration into an immutable tuple."""
+
+    if raw_hooks is None:
+        return ()
+    if callable(raw_hooks):
+        return (raw_hooks,)
+    if isinstance(raw_hooks, Iterable) and not isinstance(raw_hooks, (str, bytes)):
+        hooks: list[OOMEventHook] = []
+        for hook in raw_hooks:
+            if hook is None:
+                continue
+            if not callable(hook):
+                raise TypeError("OOM event hooks must be callables")
+            hooks.append(hook)
+        return tuple(hooks)
+    raise TypeError("OOM event hooks must be a callable or iterable of callables")
+
+
+def _sanitize_backoff_factor(raw_factor: Any) -> float:
+    """Validate and return a usable OOM backoff factor."""
+
+    try:
+        factor = float(raw_factor)
+    except (TypeError, ValueError):  # pragma: no cover - defensive guard
+        logger.warning("Invalid OOM backoff factor %r; falling back to 0.5", raw_factor)
+        return 0.5
+
+    if not 0 < factor < 1:
+        logger.warning("OOM backoff factor %.3f is outside (0, 1); defaulting to 0.5", factor)
+        return 0.5
+    return factor
+
+
+def _handle_cuda_oom(
+    *,
+    trainer: Any,
+    exc: BaseException,
+    attempt: int,
+    max_retries: int,
+    batch_size: int,
+    grad_accum: int,
+    backoff_factor: float,
+    hooks: Iterable[OOMEventHook],
+) -> tuple[bool, int, int]:
+    """Process a CUDA OOM exception and decide whether to retry."""
+
+    _maybe_empty_cuda_cache()
+    _reset_cuda_peak_memory_stats()
+    _zero_trainer_optimizer(trainer)
+
+    next_batch = batch_size
+    next_grad = grad_accum
+
+    if batch_size > 1:
+        next_batch = _apply_backoff(batch_size, backoff_factor)
+    if next_batch == batch_size and grad_accum > 1:
+        next_grad = _apply_backoff(grad_accum, backoff_factor)
+
+    maxed_attempts = attempt >= max_retries
+    can_reduce = (next_batch < batch_size) or (next_grad < grad_accum)
+    exhausted = batch_size == 1 and grad_accum == 1
+    will_retry = not (maxed_attempts or exhausted) and can_reduce
+
+    log_payload = {
+        "attempt": attempt + 1,
+        "batch_size": batch_size,
+        "grad_accum": grad_accum,
+        "next_batch_size": next_batch,
+        "next_grad_accum": next_grad,
+        "remaining_retries": max(0, max_retries - attempt),
+    }
+
+    if will_retry:
+        logger.warning(
+            "CUDA OOM encountered during training; retrying with reduced settings",
+            extra=log_payload,
+        )
+    else:
+        logger.error("Training failed due to CUDA OOM", extra=log_payload)
+
+    event = OOMRetryEvent(
+        exception=exc,
+        attempt=attempt + 1,
+        remaining_retries=max(0, max_retries - attempt),
+        batch_size=batch_size,
+        grad_accum=grad_accum,
+        next_batch_size=next_batch,
+        next_grad_accum=next_grad,
+        will_retry=will_retry,
+    )
+    _dispatch_oom_hooks(hooks, event)
+
+    if not will_retry:
+        return False, batch_size, grad_accum
+
+    return True, next_batch, next_grad
 
 
 def train_qlora(
@@ -160,37 +345,27 @@ def train_qlora(
 
     extra_args = dict(extra_args or {})
     bf16_ok = getattr(torch.cuda, "is_bf16_supported", lambda: False)()
-    logging_steps = extra_args.pop("logging_steps", 25)
-    save_steps = extra_args.pop("save_steps", 250)
-    save_total_limit = extra_args.pop("save_total_limit", 1)
-    report_to = extra_args.pop("report_to", [])
-    optim = extra_args.pop("optim", "adamw_bnb_8bit")
-    torch_empty_cache_steps = extra_args.pop("torch_empty_cache_steps", 50)
+
     oom_retries = int(extra_args.pop("oom_retries", 2))
+    backoff_factor = _sanitize_backoff_factor(extra_args.pop("oom_backoff_factor", 0.5))
+    oom_hooks = _coerce_oom_hooks(extra_args.pop("oom_event_hooks", ()))
+
+    base_args = {
+        "logging_steps": extra_args.pop("logging_steps", 25),
+        "save_steps": extra_args.pop("save_steps", 250),
+        "save_total_limit": extra_args.pop("save_total_limit", 1),
+        "report_to": extra_args.pop("report_to", []),
+        "optim": extra_args.pop("optim", "adamw_bnb_8bit"),
+        "torch_empty_cache_steps": extra_args.pop("torch_empty_cache_steps", 50),
+    }
+    base_args.update(extra_args)
 
     batch_size = max(1, config.batch_size)
     grad_accum = max(1, config.grad_accum)
     attempt = 0
 
     while True:
-        args = TrainingArguments(
-            output_dir=str(config.output_dir),
-            per_device_train_batch_size=batch_size,
-            gradient_accumulation_steps=grad_accum,
-            learning_rate=config.learning_rate,
-            num_train_epochs=config.epochs,
-            max_steps=config.max_steps if config.max_steps > 0 else -1,
-            logging_steps=logging_steps,
-            save_steps=save_steps,
-            save_total_limit=save_total_limit,
-            report_to=report_to,
-            bf16=bf16_ok,
-            fp16=not bf16_ok,
-            gradient_checkpointing=True,
-            optim=optim,
-            torch_empty_cache_steps=torch_empty_cache_steps,
-            **extra_args,
-        )
+        args = _build_training_arguments(config, base_args, batch_size, grad_accum, bf16_ok)
         trainer = trainer_cls(
             model=model,
             args=args,
@@ -213,40 +388,23 @@ def train_qlora(
             if not _is_cuda_oom(exc):
                 raise
 
-            _maybe_empty_cuda_cache()
-
-            if attempt >= oom_retries or (batch_size == 1 and grad_accum == 1):
-                logger.error(
-                    "Training failed due to CUDA OOM",
-                    extra={
-                        "attempt": attempt + 1,
-                        "batch_size": batch_size,
-                        "grad_accum": grad_accum,
-                    },
-                )
-                raise
-
-            previous_batch_size = batch_size
-            previous_grad_accum = grad_accum
-
-            if batch_size > 1:
-                batch_size = max(1, batch_size // 2)
-            elif grad_accum > 1:
-                grad_accum = max(1, grad_accum // 2)
-
-            attempt += 1
-
-            logger.warning(
-                "CUDA OOM encountered during training; retrying with reduced settings",
-                extra={
-                    "attempt": attempt + 1,
-                    "prev_batch_size": previous_batch_size,
-                    "prev_grad_accum": previous_grad_accum,
-                    "batch_size": batch_size,
-                    "grad_accum": grad_accum,
-                },
+            should_retry, next_batch, next_grad = _handle_cuda_oom(
+                trainer=trainer,
+                exc=exc,
+                attempt=attempt,
+                max_retries=oom_retries,
+                batch_size=batch_size,
+                grad_accum=grad_accum,
+                backoff_factor=backoff_factor,
+                hooks=oom_hooks,
             )
 
+            if not should_retry:
+                raise
+
+            batch_size = next_batch
+            grad_accum = next_grad
+            attempt += 1
             del trainer
             continue
 

--- a/monGARS/mlops/training.py
+++ b/monGARS/mlops/training.py
@@ -384,7 +384,7 @@ def train_qlora(
 
         try:
             trainer.train()
-        except BaseException as exc:  # pragma: no cover - covered via unit tests
+        except Exception as exc:  # pragma: no cover - covered via unit tests
             if not _is_cuda_oom(exc):
                 raise
 

--- a/tests/test_mlops_training.py
+++ b/tests/test_mlops_training.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from monGARS.mlops.training import TrainerConfig, train_qlora
+
+
+class DummyTrainer:
+    """Test double that mimics ``transformers.Trainer``."""
+
+    failures_remaining = 0
+    instances: list["DummyTrainer"] = []
+
+    def __init__(
+        self, *, model, args, train_dataset, data_collator
+    ):  # noqa: D401 - signature mirrors Trainer
+        self.model = model
+        self.args = args
+        self.train_dataset = train_dataset
+        self.data_collator = data_collator
+        self.train_calls = 0
+        DummyTrainer.instances.append(self)
+
+    def train(self) -> None:
+        self.train_calls += 1
+        if DummyTrainer.failures_remaining > 0:
+            DummyTrainer.failures_remaining -= 1
+            raise torch.cuda.OutOfMemoryError("mock OOM")
+
+
+@pytest.fixture(autouse=True)
+def _reset_dummy_trainer():
+    DummyTrainer.failures_remaining = 0
+    DummyTrainer.instances.clear()
+    yield
+    DummyTrainer.failures_remaining = 0
+    DummyTrainer.instances.clear()
+
+
+@pytest.fixture
+def trainer_config(tmp_path):
+    return TrainerConfig(
+        output_dir=tmp_path,
+        batch_size=4,
+        grad_accum=2,
+        learning_rate=2e-4,
+        epochs=1.0,
+        max_steps=-1,
+    )
+
+
+def test_train_qlora_success(trainer_config):
+    trainer = train_qlora(
+        object(),
+        dataset=[{"input_ids": [1, 2]}],
+        config=trainer_config,
+        trainer_cls=DummyTrainer,
+    )
+
+    assert isinstance(trainer, DummyTrainer)
+    assert trainer.args.per_device_train_batch_size == 4
+    assert trainer.args.gradient_accumulation_steps == 2
+    assert trainer.train_calls == 1
+
+
+def test_train_qlora_retries_with_smaller_batch(trainer_config):
+    DummyTrainer.failures_remaining = 1
+    trainer = train_qlora(
+        object(),
+        dataset=[{"input_ids": [1, 2]}],
+        config=trainer_config,
+        trainer_cls=DummyTrainer,
+    )
+
+    # Two trainer instances are created: the initial attempt and the retry
+    assert len(DummyTrainer.instances) == 2
+    assert DummyTrainer.instances[0].args.per_device_train_batch_size == 4
+    assert DummyTrainer.instances[1].args.per_device_train_batch_size == 2
+    assert trainer.args.per_device_train_batch_size == 2
+
+
+def test_train_qlora_reduces_gradient_accumulation_when_batch_is_one(trainer_config):
+    DummyTrainer.failures_remaining = 1
+    trainer_config.batch_size = 1
+    trainer_config.grad_accum = 8
+
+    trainer = train_qlora(
+        object(),
+        dataset=[{"input_ids": [1]}],
+        config=trainer_config,
+        trainer_cls=DummyTrainer,
+    )
+
+    assert len(DummyTrainer.instances) == 2
+    assert DummyTrainer.instances[0].args.gradient_accumulation_steps == 8
+    assert DummyTrainer.instances[1].args.gradient_accumulation_steps == 4
+    assert trainer.args.gradient_accumulation_steps == 4
+
+
+def test_train_qlora_raises_after_exhausting_retries(trainer_config):
+    DummyTrainer.failures_remaining = 2
+
+    with pytest.raises(torch.cuda.OutOfMemoryError):
+        train_qlora(
+            object(),
+            dataset=[{"input_ids": [1]}],
+            config=trainer_config,
+            extra_args={"oom_retries": 0},
+            trainer_cls=DummyTrainer,
+        )
+
+    assert len(DummyTrainer.instances) == 1


### PR DESCRIPTION
## Summary
- add CUDA OOM detection with automatic batch/gradient fallback in `train_qlora`
- expose trainer class injection to support testing and improve logging during retries
- cover the new behaviour with unit tests that simulate OOM recovery scenarios

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e3586d348883338b32ca66e746ab02

## Summary by Sourcery

Implement automatic CUDA OOM detection and retry logic in the QLoRA training helper, enabling resilient fine-tuning by reducing batch size or gradient accumulation upon OOM and supporting custom Trainer injection.

New Features:
- Add automatic detection of CUDA out-of-memory errors in train_qlora with retries and fallback to smaller batch sizes or gradient accumulation
- Expose a trainer_cls parameter in train_qlora to allow custom Trainer class injection for better testability and logging

Enhancements:
- Introduce helper functions to identify CUDA OOM exceptions and clear the CUDA cache before retries
- Enhance logging to include attempt count, batch size, and gradient accumulation details during retries

Tests:
- Add unit tests using a DummyTrainer to simulate OOM scenarios and verify retry behavior and final failure after exhausting retries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic recovery from GPU out-of-memory during training with retries, cache clearing, and progressive reduction of batch size and/or gradient accumulation.
  - Configurable retry limit and support for injecting a custom trainer class.
  - More flexible handling of additional training arguments.
- Documentation
  - Updated training docs to describe OOM retry behavior and configuration.
- Tests
  - Added comprehensive tests covering successful runs, OOM-triggered retries, gradient accumulation reduction when batch size is minimal, and failure after exhausting retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->