### PR TITLE
Add runtime VRAM buffer controls to QLoRA pipeline

### DIFF
--- a/build_and_wrap.py
+++ b/build_and_wrap.py
@@ -48,6 +48,11 @@ ACTIVATION_BUFFER_MB = int(
         "ACTIVATION_BUFFER_MB", os.environ.get("VRAM_ACTIVATION_BUFFER_MB", "1024")
     )
 )
+RUNTIME_BUFFER_MB = int(
+    os.environ.get(
+        "RUNTIME_BUFFER_MB", os.environ.get("VRAM_RUNTIME_BUFFER_MB", "768")
+    )
+)
 OFFLOAD_DIR = Path(os.environ.get("OFFLOAD_DIR", "./offload"))
 OUTPUT_DIR = Path(os.environ.get("OUTPUT_DIR", "./out"))
 EXPORT_MERGED_FP16 = os.environ.get("EXPORT_MERGED_FP16", "0") == "1"
@@ -117,6 +122,7 @@ def _assemble_training_summary(
             "max_steps": MAX_STEPS,
             "vram_budget_mb": VRAM_BUDGET_MB,
             "activation_buffer_mb": ACTIVATION_BUFFER_MB,
+            "runtime_buffer_mb": RUNTIME_BUFFER_MB,
             "quantization_method": "bnb-4bit-nf4",
         },
     )
@@ -160,6 +166,7 @@ def main() -> None:
         MODEL_ID,
         vram_budget_mb=VRAM_BUDGET_MB,
         activation_buffer_mb=ACTIVATION_BUFFER_MB,
+        runtime_buffer_mb=RUNTIME_BUFFER_MB,
         offload_dir=OFFLOAD_DIR,
     )
     summarise_device_map(model)

--- a/tests/mlops/test_model.py
+++ b/tests/mlops/test_model.py
@@ -99,7 +99,7 @@ def test_load_4bit_causal_lm_prefers_torch_dtype_kwarg(
     assert (
         recorded_kwargs["quantization_config"].llm_int8_enable_fp32_cpu_offload is True
     )
-    assert recorded_kwargs["max_memory"][0] == "6076MiB"
+    assert recorded_kwargs["max_memory"][0] == "5308MiB"
 
 
 def test_load_4bit_causal_lm_falls_back_to_dtype_kwarg(
@@ -172,7 +172,7 @@ def test_load_4bit_causal_lm_reserves_activation_buffer(
         offload_dir=tmp_path,
     )
 
-    assert recorded["max_memory"][0] == "3500MiB"
+    assert recorded["max_memory"][0] == "2732MiB"
 
 
 def test_load_4bit_causal_lm_handles_legacy_bitsandbytes_kwargs(


### PR DESCRIPTION
## Summary
- add a runtime VRAM buffer parameter to the 4-bit loader so we always reserve headroom during training retries
- surface the runtime buffer env var in the fine-tuning entrypoint and training summary metadata
- update the model loader unit tests for the new default weight budget calculations

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e360e5549c8333b41e3c8ec4da9b2f

## Summary by Sourcery

Add configurable runtime VRAM buffer to the QLoRA pipeline and update budget calculations and tests accordingly

New Features:
- Introduce runtime_buffer_mb parameter in load_4bit_causal_lm and training entrypoint
- Add RUNTIME_BUFFER_MB environment variable (or VRAM_RUNTIME_BUFFER_MB) for fine-tuning

Enhancements:
- Adjust _compute_weight_budget to subtract runtime buffer and update logging to include its value
- Surface runtime_buffer_mb in metadata summaries and device map logging

Tests:
- Update unit tests for load_4bit_causal_lm to reflect new default weight budget calculations