### PR TITLE
Remove demo auth bootstrap and refresh docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ modules so contributors can experiment end-to-end without bespoke tooling.
 
 ## Project Health
 - **Phase 5 – Web/API Refinement**: REST, WebSocket, and Django operator flows
-  are production-ready, but default bootstrap accounts remain (`DEFAULT_USERS`)
-  and the SDK publishing milestone is still open.【F:monGARS/api/web_api.py†L41-L84】【F:docs/codebase_status_report.md†L76-L108】
+  are production-ready, credential bootstrap now relies solely on persisted
+  accounts, and the SDK publishing milestone remains open.【F:monGARS/api/web_api.py†L43-L84】【F:docs/codebase_status_report.md†L76-L108】
 - **Phase 6 – Self-Improvement & Research**: Automated MNTP self-training and
   reinforcement-learning loops exist, yet integration with operational rollout
   controls and long-haul observability keeps the milestone in progress.【F:monGARS/core/self_training.py†L1-L160】【F:modules/neurons/training/reinforcement_loop.py†L320-L520】【F:docs/codebase_status_report.md†L109-L144】
-- **Open Risks**: Prioritise removing bootstrap credentials, packaging the
-  Python/TypeScript SDKs, and defining reinforcement-learning rollout guardrails
-  before closing the remaining roadmap items.【F:docs/codebase_status_report.md†L145-L188】
+- **Open Risks**: Prioritise packaging the Python/TypeScript SDKs and defining
+  reinforcement-learning rollout guardrails before closing the remaining
+  roadmap items.【F:docs/codebase_status_report.md†L145-L188】
 
 See [docs/codebase_status_report.md](docs/codebase_status_report.md) for the full
 audit of runtime modules, tests, and deployment assets.【F:docs/codebase_status_report.md†L1-L188】

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,9 +50,8 @@ required to reach production readiness.
 - ✅ Django chat UI with progressive enhancement.
 - ✅ FastAPI WebSocket handler with ticket verification, history replay, and
   streaming guarded by `WS_ENABLE_EVENTS`.
-- 🔄 Replaced hard-coded credential stores with database-backed auth flows (the
-  `DEFAULT_USERS` bootstrap in `monGARS/api/web_api.py` still provisions demo
-  accounts until the cleanup lands).
+- ✅ Replaced hard-coded credential stores with database-backed auth flows;
+  FastAPI no longer seeds demo credentials at startup.
 - 🚧 Publish polished SDKs and reference clients.
 
 ## Phase 6 – Self-Improvement & Research (🗓 Target Q2 2026)

--- a/docs/codebase_status_report.md
+++ b/docs/codebase_status_report.md
@@ -10,9 +10,9 @@ implementation details.
 - **FastAPI application** – `monGARS/api/web_api.py` exposes authentication,
   chat, conversation history, and peer-management endpoints with typed
   responses and dependency-injected services.【F:monGARS/api/web_api.py†L63-L200】【F:monGARS/api/web_api.py†L203-L331】
-- **Bootstrap users** – demo credentials are still seeded at startup via
-  `DEFAULT_USERS`, which keeps the credential-hardening milestone open until the
-  bootstrap flow is replaced with persisted accounts only.【F:monGARS/api/web_api.py†L41-L62】
+- **Bootstrap users** – demo credentials were removed; the FastAPI lifespan now
+  validates overrides without seeding default accounts so deployments rely on
+  persisted records exclusively.【F:monGARS/api/web_api.py†L41-L88】
 - **WebSocket streaming** – `monGARS/api/ws_manager.py` enforces ticket
   verification, manages per-user rate limiting, and fans out UI events through
   a token-bucket protected broadcaster.【F:monGARS/api/ws_manager.py†L1-L144】【F:monGARS/api/ws_manager.py†L145-L250】
@@ -92,8 +92,9 @@ implementation details.
   container lifecycle management to streamline developer onboarding.【F:scripts/deploy_docker.sh†L1-L200】
 
 ## Known Gaps & Risks
-- **Credential Hardening** – remove the bootstrap accounts and migrate existing
-  installs to database-backed credentials only.【F:monGARS/api/web_api.py†L41-L84】
+- **Credential Hardening** – legacy bootstrap accounts were removed from FastAPI;
+  audit existing deployments to ensure no environments still rely on the retired
+  defaults before rotating secrets.【F:monGARS/api/web_api.py†L41-L88】
 - **SDK Publication** – Python and TypeScript SDKs exist under `sdks/`, but they
   have not been packaged or distributed, leaving the roadmap milestone open.【F:sdks/python/README.md†L1-L160】【F:sdks/typescript/README.md†L1-L160】
 - **Reinforcement Learning Integration** – the research loop is functional yet
@@ -107,14 +108,12 @@ implementation details.
 | 2 – Functional Expansion | ✅ Complete | Adaptive response, mimicry, curiosity, and captioning modules run end-to-end.【F:monGARS/core/conversation.py†L1-L122】【F:monGARS/core/mimicry.py†L1-L200】 |
 | 3 – Hardware & Performance | ✅ Complete | Scheduler metrics, worker tuning, and Ray Serve integration are implemented.【F:monGARS/utils/hardware.py†L1-L120】【F:monGARS/core/distributed_scheduler.py†L1-L200】【F:monGARS/core/llm_integration.py†L1-L200】 |
 | 4 – Collaborative Networking | ✅ Complete | Peer telemetry, load-aware scheduling, and Sommeil optimisation loops are shipping.【F:monGARS/core/peer.py†L1-L200】【F:monGARS/core/sommeil.py†L1-L160】 |
-| 5 – Web/API Refinement | 🔄 In Progress | Core endpoints and WebSocket handling are live, but demo credential bootstrap persists and SDKs remain unpublished.【F:monGARS/api/web_api.py†L41-L84】【F:monGARS/api/ws_manager.py†L1-L144】【F:sdks/python/README.md†L1-L160】 |
+| 5 – Web/API Refinement | 🔄 In Progress | Core endpoints and WebSocket handling are live, credential bootstrap now relies on persisted accounts, and SDKs remain unpublished.【F:monGARS/api/web_api.py†L41-L88】【F:monGARS/api/ws_manager.py†L1-L144】【F:sdks/python/README.md†L1-L160】 |
 | 6 – Self-Improvement & Research | 🔄 In Progress | Self-training and RL tooling exist, yet reinforcement runs are not integrated and long-haul tests are pending.【F:monGARS/core/self_training.py†L1-L200】【F:modules/neurons/training/reinforcement_loop.py†L320-L520】 |
 | 7 – Sustainability & Longevity | 🌱 Planned | Evolution engine and energy tracking are present, but cross-node artefact sharing and energy dashboards remain design items.【F:modules/evolution_engine/orchestrator.py†L1-L160】【F:modules/evolution_engine/energy.py†L1-L160】 |
 
 ## Recommended Next Steps
-1. Retire `DEFAULT_USERS` and migrate existing deployments to persisted
-   credentials, closing the last security loophole in Phase 5.【F:monGARS/api/web_api.py†L41-L84】
-2. Package and publish the Python/TypeScript SDKs with automated CI builds so
+1. Package and publish the Python/TypeScript SDKs with automated CI builds so
    partner teams can integrate against a supported client surface.【F:sdks/python/pyproject.toml†L1-L80】【F:sdks/typescript/package.json†L1-L120】
-3. Define an integration plan for reinforcement-learning loops, including
+2. Define an integration plan for reinforcement-learning loops, including
    telemetry, rollback, and operator controls, before marking Phase 6 complete.【F:modules/neurons/training/reinforcement_loop.py†L320-L520】

--- a/docs/implementation_status.md
+++ b/docs/implementation_status.md
@@ -70,12 +70,9 @@ and reality.
   `/api/v1/auth/ws/ticket`, replays history, and streams responses when
   `WS_ENABLE_EVENTS` is true.
 - Database-backed authentication is the default: `PersistenceRepository`
-  persists user records, and login bootstrap flows promote hashed defaults into
-  durable accounts on first use. **Open issue:** the legacy `DEFAULT_USERS`
-  mapping in `monGARS/api/web_api.py` still seeds demo credentials, so the
-  milestone remains partially complete until those accounts are removed. Until
-  that bootstrap path is excised, anyone aware of the defaults can still mint
-  tokens without provisioning a real account.
+  persists user records, and login bootstrap flows now rely exclusively on
+  persisted accounts after retiring the legacy demo credential mapping in
+  `monGARS/api/web_api.py`.
 - Planned work: consolidate validation rules and publish polished client SDKs.
 
 ## Phase 6 – Self-Improvement & Research (Target Q2 2026)

--- a/docs/next_implementation_priority.md
+++ b/docs/next_implementation_priority.md
@@ -1,18 +1,19 @@
 # Next Implementation Priority
 
 ## Summary
-Now that schema evolution and telemetry upgrades are complete, the next
-high-impact milestone is publishing first-party SDKs and reference clients while
-credential hardening work wraps up.
+Now that schema evolution, telemetry upgrades, and credential hardening are
+complete, the next high-impact milestone is publishing first-party SDKs and
+reference clients.
 Operators and partner teams currently rely on OpenAPI scraping or ad-hoc scripts;
 packaged SDKs will harden integrations and shrink the support surface area as
 the project moves into long-term maintenance.
 
 ## Supporting Signals from Existing Documentation
 - **Roadmap**: Phase 5 keeps SDKs and reference clients as the final deliverable
-  but still flags the presence of demo credential defaults that must be removed.
+  and now records that demo credential defaults have been removed from FastAPI
+  startup flows.
 - **Implementation Status Report**: Highlights SDK packaging as the new
-  contradiction to resolve, notes the outstanding credential cleanup, and calls
+  contradiction to resolve, confirms the credential cleanup, and calls
   out the need for clear RAG governance to accompany client distribution.
 - **Roadmap Charter (AGENTS.md)**: Security & Stability items are satisfied,
   shifting attention to sustainable integration stories for external teams.
@@ -30,9 +31,8 @@ the project moves into long-term maintenance.
 
 ## Implementation Outline
 1. **Define API Surfaces** – Lock the minimal stable routes (chat, history,
-   review, peer management) and document any feature flags they depend on. Fold
-   the credential cleanup into this pass by removing the `DEFAULT_USERS`
-   bootstrap so SDK consumers cannot rely on demo logins.
+   review, peer management) and document any feature flags they depend on now
+   that credential bootstrap relies solely on persisted accounts.
 2. **Generate Typed Clients** – Use `openapi-python-client` and `openapi-typescript`
    (or equivalent) to scaffold SDKs, layering ergonomic helpers for
    authentication flows, ticket refresh, and streaming responses.

--- a/monGARS/api/web_api.py
+++ b/monGARS/api/web_api.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 import logging
 from contextlib import asynccontextmanager
 from datetime import datetime
@@ -18,7 +17,6 @@ from fastapi.security import OAuth2PasswordRequestForm
 
 from monGARS.api.authentication import (
     authenticate_user,
-    ensure_bootstrap_users,
     get_current_admin_user,
     get_current_user,
 )
@@ -57,36 +55,16 @@ from . import ws_manager
 
 _ws_manager = ws_manager.ws_manager
 sec_manager = SecurityManager()
-DEFAULT_USERS: dict[str, dict[str, Any]] = {
-    "u1": {
-        "password_hash": sec_manager.get_password_hash("x"),
-        "is_admin": True,
-    },
-    "u2": {
-        "password_hash": sec_manager.get_password_hash("y"),
-        "is_admin": False,
-    },
-}
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Seed demo users when the application starts."""
+    """Validate dependency overrides and prepare application state."""
 
     override = app.dependency_overrides.get(get_persistence_repository)
-    if override is not None:
-        if not callable(override):
-            logger.error("lifespan.invalid_override", extra={"override": override})
-            raise TypeError("Dependency override must be callable")
-        candidate = override()
-        repo = await candidate if inspect.isawaitable(candidate) else candidate
-    else:
-        repo = get_persistence_repository()
-    try:
-        await ensure_bootstrap_users(repo, DEFAULT_USERS)
-    except Exception as exc:  # pragma: no cover - defensive logging
-        logger.exception("lifespan.bootstrap_failed")
-        raise RuntimeError("Failed to bootstrap default users") from exc
+    if override is not None and not callable(override):
+        logger.error("lifespan.invalid_override", extra={"override": override})
+        raise TypeError("Dependency override must be callable")
     yield
 
 
@@ -158,7 +136,6 @@ async def register_user(
         await repo.create_user_atomic(
             reg.username,
             sec_manager.get_password_hash(reg.password),
-            reserved_usernames=DEFAULT_USERS.keys(),
         )
     except ValueError as exc:
         logger.debug(

--- a/tests/api/test_contract.py
+++ b/tests/api/test_contract.py
@@ -129,6 +129,17 @@ def contract_client() -> Iterable[Tuple[TestClient, _FakePersistenceRepository]]
     communicator = _FakePeerCommunicator()
     conversation = _FakeConversationModule()
 
+    repo._users["u1"] = _FakeAccount(
+        username="u1",
+        password_hash=sec_manager.get_password_hash("x"),
+        is_admin=True,
+    )
+    repo._users["u2"] = _FakeAccount(
+        username="u2",
+        password_hash=sec_manager.get_password_hash("y"),
+        is_admin=False,
+    )
+
     app.dependency_overrides[get_persistence_repository] = lambda: repo
     app.dependency_overrides[get_hippocampus] = lambda: hippocampus
     app.dependency_overrides[get_peer_communicator] = lambda: communicator

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,3 +8,30 @@ import os
 # test suite always overrides CI-provided connection strings.
 os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./mongars_test.db"
 os.environ["SECRET_KEY"] = "test-secret-key"
+
+import pytest_asyncio
+
+from monGARS.api.dependencies import get_persistence_repository
+from monGARS.core.security import SecurityManager
+
+
+@pytest_asyncio.fixture
+async def ensure_test_users() -> None:
+    """Provision standard test users expected by API contract suites."""
+
+    repo = get_persistence_repository()
+    sec_manager = SecurityManager()
+    defaults = (
+        ("u1", "x", True),
+        ("u2", "y", False),
+    )
+    for username, password, is_admin in defaults:
+        try:
+            await repo.create_user_atomic(
+                username,
+                sec_manager.get_password_hash(password),
+                is_admin=is_admin,
+            )
+        except ValueError:
+            continue
+    yield

--- a/tests/test_api_chat.py
+++ b/tests/test_api_chat.py
@@ -14,6 +14,8 @@ from monGARS.api.web_api import app
 from monGARS.core.conversation import ConversationalModule
 from monGARS.core.security import SecurityManager
 
+pytestmark = pytest.mark.usefixtures("ensure_test_users")
+
 
 def _speech_turn_payload(text: str) -> dict:
     return {

--- a/tests/test_api_history.py
+++ b/tests/test_api_history.py
@@ -10,6 +10,9 @@ from monGARS.api.dependencies import hippocampus
 from monGARS.api.web_api import app
 
 
+pytestmark = pytest.mark.usefixtures("ensure_test_users")
+
+
 @pytest.fixture
 def client() -> TestClient:
     """Return a test client with isolated hippocampus state."""

--- a/tests/test_api_model_management.py
+++ b/tests/test_api_model_management.py
@@ -21,6 +21,9 @@ os.environ.setdefault("JWT_ALGORITHM", "HS256")
 os.environ.setdefault("SECRET_KEY", "test-secret")
 
 
+pytestmark = pytest.mark.usefixtures("ensure_test_users")
+
+
 class FakeModelManager:
     def __init__(self) -> None:
         self._profile = ModelProfile(

--- a/tests/test_api_rag.py
+++ b/tests/test_api_rag.py
@@ -19,6 +19,9 @@ from monGARS.core.rag import (
 )
 
 
+pytestmark = pytest.mark.usefixtures("ensure_test_users")
+
+
 class DummyRagEnricher:
     def __init__(self) -> None:
         self.last_call: dict | None = None

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -7,7 +7,7 @@ from httpx import ASGITransport, AsyncClient
 
 from monGARS.api.authentication import authenticate_user, ensure_bootstrap_users
 from monGARS.api.dependencies import get_peer_communicator, get_persistence_repository
-from monGARS.api.web_api import DEFAULT_USERS, app, sec_manager
+from monGARS.api.web_api import app, sec_manager
 from monGARS.init_db import reset_database
 
 
@@ -253,10 +253,8 @@ async def test_bootstrap_users_create_demo_accounts() -> None:
 
 
 @pytest.mark.asyncio
-async def test_startup_bootstraps_default_users(client: AsyncClient) -> None:
+async def test_startup_does_not_create_demo_accounts(client: AsyncClient) -> None:
     ready = await client.get("/ready")
     assert ready.status_code == status.HTTP_200_OK
     repo = get_persistence_repository()
-    user = await repo.get_user_by_username("u1")
-    assert user is not None
-    assert user.is_admin == DEFAULT_USERS["u1"]["is_admin"]
+    assert await repo.get_user_by_username("u1") is None

--- a/tests/test_webapp_chat_services.py
+++ b/tests/test_webapp_chat_services.py
@@ -12,7 +12,8 @@ os.environ.setdefault("SECRET_KEY", "test")
 os.environ.setdefault("JWT_ALGORITHM", "HS256")
 
 from monGARS.api.dependencies import get_persistence_repository, hippocampus
-from monGARS.api.web_api import DEFAULT_USERS, app, get_conversational_module
+from monGARS.api.web_api import app, get_conversational_module
+from monGARS.core.security import SecurityManager
 from webapp.chat import services
 
 
@@ -174,11 +175,11 @@ async def test_services_roundtrip_against_fastapi(
     hippocampus._hydrated_users.clear()
 
     repo = _InMemoryRepo()
-    defaults = DEFAULT_USERS["u1"]
+    sec_manager = SecurityManager()
     repo._users["u1"] = _StubUser(
         username="u1",
-        password_hash=defaults["password_hash"],
-        is_admin=defaults.get("is_admin", False),
+        password_hash=sec_manager.get_password_hash("x"),
+        is_admin=True,
     )
     convo = _StubConversationalModule()
 

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -19,6 +19,9 @@ from monGARS.core.conversation import ConversationalModule
 from monGARS.core.ui_events import make_event
 
 
+pytestmark = pytest.mark.usefixtures("ensure_test_users")
+
+
 @pytest_asyncio.fixture
 async def client(monkeypatch):
     hippocampus._memory.clear()


### PR DESCRIPTION
## Summary
- remove the legacy DEFAULT_USERS bootstrap from the FastAPI lifespan and rely entirely on persisted accounts
- seed standard users inside the test harness and update contract fixtures that previously referenced demo credentials
- refresh documentation to note the credential cleanup and adjust follow-on priorities

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e42f4cfbf883339a42adcb7a753af4