### PR TITLE
Document next critical implementation in status report

### DIFF
--- a/docs/implementation_status.md
+++ b/docs/implementation_status.md
@@ -120,3 +120,12 @@ and reality.
 - **Advanced research loops**: wire the reinforcement-learning utilities into
   production workflows (telemetry, rollback, operator approval) before closing
   the milestone.
+
+## Next Critical Implementation
+
+Publishing the polished SDKs and reference clients called out in Phase 5
+remains the most urgent deliverable. Until those packages are produced and
+documented, partners must continue reverse-engineering the OpenAPI schema to
+integrate with monGARS. Prioritising the SDK release unblocks external
+consumers, aligns with the roadmap's outstanding "SDK story" action item, and
+brings the Web Interface & API Refinement phase to completion.


### PR DESCRIPTION
## Summary
- add a "Next Critical Implementation" section to the implementation status report
- highlight that publishing the polished SDKs and reference clients is the primary outstanding deliverable for Phase 5

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e43a4ef4a883338d809343fcd22b6f