### PR TITLE
Fix CPU fallback for QLoRA trainer

### DIFF
--- a/monGARS/mlops/training.py
+++ b/monGARS/mlops/training.py
@@ -222,8 +222,11 @@ def _build_training_arguments(
         else:
             dtype_args = {"bf16": False, "fp16": False}
 
-    if not use_cuda and "no_cuda" not in base_args:
-        dtype_args["no_cuda"] = True
+    if not use_cuda:
+        if "no_cuda" not in base_args:
+            dtype_args["no_cuda"] = True
+        if "use_cpu" not in base_args:
+            dtype_args["use_cpu"] = True
 
     return TrainingArguments(
         output_dir=str(cfg.output_dir),

--- a/tests/test_mlops_training.py
+++ b/tests/test_mlops_training.py
@@ -201,6 +201,7 @@ def test_train_qlora_falls_back_to_cpu_when_oom_persists(monkeypatch, trainer_co
     assert len(DummyTrainer.instances) == 2
     cpu_args = DummyTrainer.instances[-1].args
     assert cpu_args.no_cuda is True
+    assert cpu_args.use_cpu is True
     assert cpu_args.fp16 is False
     assert cpu_args.bf16 is False
     assert cpu_args.optim == "adamw_torch"


### PR DESCRIPTION
## Summary
- ensure the training argument builder marks CPU runs with both `no_cuda` and `use_cpu` when CUDA is unavailable or disabled
- extend the QLoRA fallback test to assert the new CPU configuration

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4534ceda483338c4d13dbdacd3a39

## Summary by Sourcery

Mark CPU fallback runs with both no_cuda and use_cpu flags when CUDA is unavailable or disabled and update the QLoRA fallback test to assert the new use_cpu flag.

Bug Fixes:
- Add use_cpu argument to the CPU fallback configuration in the training argument builder.

Tests:
- Extend the QLoRA CPU fallback test to assert that use_cpu is set to True.