### PR TITLE
Add governance guardrails for curated RAG datasets

### DIFF
--- a/docs/codebase_status_report.md
+++ b/docs/codebase_status_report.md
@@ -98,8 +98,8 @@ implementation details.
 - **Reinforcement Learning Integration** – the research loop is functional yet
   not wired into production automation, so observability and rollout policies
   need definition before declaring the phase complete.【F:modules/neurons/training/reinforcement_loop.py†L320-L520】
-- **RAG Governance** – dataset retention and export workflows still need
-  codified guardrails before expanding partner access.【F:docs/rag_context_enrichment.md†L60-L96】
+- ✅ **RAG Governance** – retention metadata, automated scrubbing, and documented
+  export flows keep curated artefacts compliant as partner integrations scale.【F:docs/rag_dataset_governance.md†L1-L160】
 
 ## Roadmap Phase Summary
 | Phase | Status | Evidence |
@@ -115,5 +115,5 @@ implementation details.
 ## Recommended Next Steps
 1. Define an integration plan for reinforcement-learning loops, including
    telemetry, rollback, and operator controls, before marking Phase 6 complete.【F:modules/neurons/training/reinforcement_loop.py†L320-L520】
-2. Finalise RAG retention governance so curated artefacts can be safely shared
-   with partners without leaking sensitive context.【F:docs/rag_context_enrichment.md†L60-L96】
+2. Deliver production-ready controls for the reinforcement-learning loop so it
+   can run alongside self-training without manual babysitting.【F:modules/neurons/training/reinforcement_loop.py†L320-L520】

--- a/docs/implementation_status.md
+++ b/docs/implementation_status.md
@@ -115,16 +115,16 @@ and reality.
   endpoint when no privileged accounts exist.
 - ✅ **SDK story**: Python and TypeScript SDKs ship with documented release
   tooling, allowing partners to integrate without scraping OpenAPI definitions.【F:sdks/python/README.md†L1-L120】【F:docs/sdk-release-guide.md†L1-L160】
-- **RAG governance**: document retention policies for curated datasets stored
-  under `models/datasets/curated/` and ensure operators scrub sensitive context
-  before exporting artefacts.
+- ✅ **RAG governance**: curated datasets carry retention metadata, automated
+  scrubbing checks, and operator playbooks covering exports and takedown flows.【F:docs/rag_dataset_governance.md†L1-L120】
 - **Advanced research loops**: wire the reinforcement-learning utilities into
   production workflows (telemetry, rollback, operator approval) before closing
   the milestone.
 
 ## Next Critical Implementation
 
-With SDK packaging complete, the next critical implementation is codifying RAG
-retention and export governance. Establishing automated scrubbing checks and
-operator playbooks keeps curated datasets compliant as partner access expands
-and unlocks the remaining controls in Phase 5.
+With governance in place for curated RAG datasets, the next critical
+implementation is productionising the reinforcement-learning research loop.
+This requires adding telemetry, rollout safeguards, and operator approvals so
+the experimentation tooling can graduate into the automated self-improvement
+pipeline.

--- a/docs/next_implementation_priority.md
+++ b/docs/next_implementation_priority.md
@@ -1,48 +1,58 @@
 # Next Implementation Priority
 
 ## Summary
-The SDK release closed the final open item for Phase 5, shifting the immediate
-focus to Retrieval-Augmented Generation (RAG) governance. We must codify dataset
-retention policies, automate scrubbing checks, and document operator workflows
-before expanding partner access to curated artefacts.
 
-## Supporting Signals from Existing Documentation
-- **Implementation Status Report** – Calls out RAG governance as the remaining
-  contradiction in Phase 5 now that SDK packaging is complete.【F:docs/implementation_status.md†L96-L140】
-- **Codebase Status Report** – Highlights dataset governance as a key risk and
-  recommends prioritising controls before scaling partner integrations.【F:docs/codebase_status_report.md†L40-L120】
-- **RAG Context Enrichment Guide** – Notes that curated datasets demand explicit
-  retention policies to protect sensitive context.【F:docs/rag_context_enrichment.md†L60-L96】
+With Retrieval-Augmented Generation governance complete, the immediate focus
+shifts to productionising the reinforcement-learning (RL) research loop. The
+loop exists in `modules/neurons/training/reinforcement_loop.py` but still lacks
+telemetry, rollout safeguards, and operator controls required for unattended
+operation.【F:docs/implementation_status.md†L96-L140】【F:modules/neurons/training/reinforcement_loop.py†L320-L520】
 
-## Rationale for Prioritising RAG Governance
-1. **Compliance Readiness** – Clearly documented retention windows and scrubbing
-   automation ensure the enrichment datasets align with privacy and contractual
-   requirements.
-2. **Operational Safety** – Guardrails around export workflows prevent the
-   accidental release of sensitive content as more teams rely on RAG-sourced
-   suggestions.
-3. **Ecosystem Trust** – Partners need assurance that enrichment data is curated
-   and auditable before embedding it into their own workflows.
+## Supporting Signals
+
+- **Implementation Status Report** – calls out RL automation as the remaining
+  contradiction after the governance milestone.【F:docs/implementation_status.md†L96-L140】
+- **Codebase Status Report** – recommends prioritising telemetry and operational
+  controls before graduating RL into production workflows.【F:docs/codebase_status_report.md†L96-L140】
+- **Evolution Engine Orchestrator** – already integrates curated datasets,
+  making it the natural landing spot once RL artefacts can be generated and
+  approved safely.【F:modules/evolution_engine/orchestrator.py†L1-L320】
+
+## Rationale for Prioritising RL Operationalisation
+
+1. **Experiment Velocity** – moving RL into the automated cycle reduces the
+   manual work currently required to evaluate policy improvements.
+2. **Safety & Observability** – explicit telemetry and guardrails prevent
+   regressions when exploring novel reward models.
+3. **Partner Readiness** – RL-backed suggestions unlock new product
+   capabilities, but only once the rollout and rollback story matches the rest
+   of the platform.
 
 ## Implementation Outline
-1. Catalogue existing datasets under `models/datasets/curated/` and define
-   metadata fields (provenance, expiry, sensitivity tags).
-2. Extend the enrichment service or background jobs to validate datasets against
-   the new policy (expiry checks, automated redaction, audit trails).
-3. Document operator procedures for onboarding new repositories, handling
-   takedown requests, and exporting artefacts safely.
-4. Integrate reporting into the telemetry pipeline so governance metrics surface
-   alongside existing peer and RAG monitoring.
+
+1. **Instrumentation** – emit structured metrics and events across the RL loop
+   (policy selection, reward aggregation, adapter export) tied into the existing
+   OpenTelemetry pipeline.【F:modules/neurons/training/reinforcement_loop.py†L320-L520】
+2. **Safeguards** – add approval hooks to the evolution orchestrator so RL
+   results require an operator sign-off before deployment, mirroring curated
+   dataset governance.【F:modules/evolution_engine/orchestrator.py†L320-L520】
+3. **Runbooks** – document the RL workflow alongside the new governance guide so
+   operators understand how to stage, review, and roll back experiments.【F:docs/rag_dataset_governance.md†L1-L160】
+4. **Testing** – extend the existing unit tests to cover RL edge cases and add a
+   targeted integration scenario verifying telemetry and approval gates.
 
 ## Success Criteria & Validation
-- Every curated dataset includes metadata covering provenance, expiry, and
-  review history.
-- Automated jobs flag or quarantine datasets that fall out of compliance, and
-  alerts surface through existing observability channels.
-- Updated runbooks enable operators and partners to follow the governance flow
-  without relying on ad-hoc institutional knowledge.
 
-## Follow-On Work Once Governance Lands
-- Resume reinforcement-learning integration workstreams for Phase 6.
-- Revisit SDK telemetry to capture partner usage patterns in line with the new
-  governance metrics.
+- RL training cycles emit metrics and logs that surface in the same dashboards
+  as self-training events.
+- Deployment of RL artefacts requires an explicit approval or automated policy
+  pass, with clear rollback instructions.
+- Updated documentation (including runbooks) enables on-call operators to triage
+  RL incidents without specialist knowledge.
+
+## Follow-On Work Once RL Is Operational
+
+- Resume energy-efficiency research outlined for the sustainability phase once
+  RL experiments can run safely in production.
+- Expand partner telemetry to correlate RL-driven responses with engagement and
+  satisfaction metrics.

--- a/docs/rag_context_enrichment.md
+++ b/docs/rag_context_enrichment.md
@@ -84,6 +84,5 @@ If RAG is disabled, the endpoint returns `{ "enabled": false, "focus_areas": [],
 
 - Keep repository indexing up to date to maintain high-quality results.
 - Curate `rag_repo_list` to balance context coverage against retrieval noise.
-- Document data-retention policies for the curated datasets stored in
-  `models/datasets/curated/` to ensure privacy expectations are met when RAG is
-  active.
+- Follow the curated dataset governance playbook to ensure retention policies
+  and export checks stay current as partner access scales.【F:docs/rag_dataset_governance.md†L1-L160】

--- a/docs/rag_dataset_governance.md
+++ b/docs/rag_dataset_governance.md
@@ -1,0 +1,82 @@
+# RAG Dataset Governance
+
+The curated datasets produced by `SelfTrainingEngine` now include structured
+governance metadata and automated scrubbing checks so that partner exports stay
+compliant. This document captures the retention policy, the validation pipeline,
+and the day-to-day operator procedures.
+
+## Metadata Contract
+
+Every dataset version registered in `models/datasets/curated/` now records the
+following fields:
+
+| Field | Description |
+| --- | --- |
+| `provenance` | Identifies which pipeline produced the dataset (`self-training` by default). |
+| `sensitivity` | Data classification tag surfaced to downstream consumers. |
+| `retention_days` | Maximum age before the dataset must be re-reviewed. |
+| `reviewed_by` / `reviewed_at` | Reviewer identity (defaults to automation) and timestamp. |
+| `export_window_days` / `export_window_ends_at` | Window during which exports are allowed before a re-review is required. |
+| `tags` | Extra governance tags applied to the dataset entry. |
+
+The metadata is built in `models/datasets/governance.py` and stored as part of
+the catalog entry returned by `DatasetCatalog.register`.【F:models/datasets/governance.py†L41-L132】【F:models/datasets/catalog.py†L17-L95】
+
+Configuration comes from new settings in `monGARS.config.Settings`, allowing
+operators to tune provenance labels, retention windows, and review identities
+without code changes.【F:monGARS/config.py†L198-L233】
+
+## Automated Scrubbing Checks
+
+When a curated batch is persisted, the governance layer re-scans every record
+before it is registered in the catalog. The checks currently include:
+
+1. **PII Detection** – reuses the sanitiser patterns to spot e-mail, phone,
+   payment, IP, and UUID fragments that should have been redacted. Any matches
+   mark the dataset as quarantined.【F:models/datasets/sanitizer.py†L11-L92】【F:models/datasets/governance.py†L134-L196】
+2. **Record Count Validation** – verifies the number of JSONL entries matches
+   what the pipeline recorded during batching.【F:models/datasets/governance.py†L171-L196】
+3. **Retention & Export Windows** – flags datasets whose expiry or export window
+   has elapsed so they can be re-reviewed before partner distribution.【F:models/datasets/governance.py†L96-L133】
+4. **Metadata Completeness** – fails fast if required reviewer information is
+   missing or malformed.【F:models/datasets/governance.py†L86-L109】
+
+Compliance results are persisted alongside the metadata and exposed through the
+training summaries so operators have visibility without digging into catalog
+files.【F:monGARS/core/self_training.py†L233-L272】
+
+## Operator Playbook
+
+### Onboarding a New Repository
+
+1. Configure provenance and tags for the partner via environment variables or
+   `.env` overrides (`RAG_CURATED_DEFAULT_PROVENANCE`,
+   `RAG_CURATED_DEFAULT_TAGS`).【F:monGARS/config.py†L198-L233】
+2. Trigger a self-training cycle or run `SelfTrainingEngine._run_training_cycle`
+   in a controlled environment to produce a curated batch.【F:monGARS/core/self_training.py†L65-L178】
+3. Confirm the resulting dataset shows `"status": "approved"` in its compliance
+   payload before enabling export to the partner workspace.【F:tests/self_training_test.py†L1-L200】
+
+### Handling Takedown or Expiry Requests
+
+1. Locate the dataset run ID in `models/datasets/curated/catalog.json` and
+   inspect the stored metadata to confirm expiry or export window details.【F:models/datasets/catalog.py†L39-L95】
+2. If the dataset is expired or quarantined, remove the directory and notify the
+   partner; the next training cycle will regenerate compliant batches.
+3. Update retention settings if contractual terms change, then rerun the next
+   training cycle so the new window is applied.
+
+### Export Procedure
+
+1. Prior to sharing, rerun the governance evaluation with
+   `DatasetGovernance.evaluate_dataset` to confirm the compliance status is
+   still `approved`.
+2. If violations are reported, address them (by re-sanitising data or updating
+   metadata) before distributing any artefacts. Export is blocked while the
+   dataset remains quarantined.
+
+## Observability
+
+Governance results are logged with structured metadata
+(`curated.dataset.governance_passed` / `.governance_failed`), enabling alerting
+or dashboards to track quarantine events over time.【F:models/datasets/governance.py†L198-L219】

--- a/models/datasets/__init__.py
+++ b/models/datasets/__init__.py
@@ -1,6 +1,16 @@
 """Dataset curation helpers."""
 
 from .catalog import DatasetCatalog, DatasetVersion
-from .sanitizer import sanitize_record, scrub_text
+from .governance import DatasetGovernance, GovernanceEvaluation, GovernanceViolation
+from .sanitizer import detect_pii, sanitize_record, scrub_text
 
-__all__ = ["DatasetCatalog", "DatasetVersion", "sanitize_record", "scrub_text"]
+__all__ = [
+    "DatasetCatalog",
+    "DatasetVersion",
+    "DatasetGovernance",
+    "GovernanceEvaluation",
+    "GovernanceViolation",
+    "sanitize_record",
+    "scrub_text",
+    "detect_pii",
+]

--- a/models/datasets/governance.py
+++ b/models/datasets/governance.py
@@ -1,0 +1,257 @@
+"""Governance helpers for curated Retrieval-Augmented Generation datasets."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Mapping
+
+from monGARS.config import Settings, get_settings
+
+from .sanitizer import detect_pii
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class GovernanceViolation:
+    """Represents a policy violation detected during dataset evaluation."""
+
+    code: str
+    message: str
+    details: Mapping[str, Any] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        payload = {"code": self.code, "message": self.message}
+        if self.details:
+            payload["details"] = dict(self.details)
+        return payload
+
+
+@dataclass(slots=True)
+class GovernanceEvaluation:
+    """Result of evaluating a curated dataset against governance policies."""
+
+    status: str
+    metadata: Mapping[str, Any]
+    checked_at: datetime
+    violations: list[GovernanceViolation]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "metadata": dict(self.metadata),
+            "checked_at": self.checked_at.replace(tzinfo=UTC).isoformat(),
+            "violations": [violation.as_dict() for violation in self.violations],
+        }
+
+
+class DatasetGovernance:
+    """Evaluate curated datasets for retention, export, and sanitisation."""
+
+    def __init__(self, *, settings: Settings | None = None) -> None:
+        self._settings = settings or get_settings()
+        self._retention_days = max(1, int(self._settings.rag_curated_retention_days))
+        self._export_window_days = max(
+            0, int(self._settings.rag_curated_export_window_days)
+        )
+        self._provenance = self._settings.rag_curated_default_provenance
+        self._sensitivity = self._settings.rag_curated_default_sensitivity
+        self._reviewer = self._settings.rag_curated_reviewer
+        self._default_tags: tuple[str, ...] = tuple(
+            self._settings.rag_curated_default_tags
+        )
+
+    def build_metadata(
+        self,
+        *,
+        run_id: str,
+        record_count: int,
+        created_at: datetime,
+    ) -> dict[str, Any]:
+        expires_at = created_at + timedelta(days=self._retention_days)
+        export_window_end = (
+            created_at + timedelta(days=self._export_window_days)
+            if self._export_window_days
+            else None
+        )
+        metadata: dict[str, Any] = {
+            "run_id": run_id,
+            "record_count": record_count,
+            "provenance": self._provenance,
+            "sensitivity": self._sensitivity,
+            "retention_days": self._retention_days,
+            "reviewed_by": self._reviewer,
+            "reviewed_at": created_at.replace(tzinfo=UTC).isoformat(),
+            "expires_at": expires_at.replace(tzinfo=UTC).isoformat(),
+            "export_window_days": self._export_window_days,
+            "tags": list(self._default_tags),
+        }
+        if export_window_end is not None:
+            metadata["export_window_ends_at"] = export_window_end.replace(
+                tzinfo=UTC
+            ).isoformat()
+        return metadata
+
+    def evaluate_dataset(
+        self,
+        dataset_file: Path,
+        *,
+        run_id: str,
+        record_count: int,
+        created_at: datetime | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> GovernanceEvaluation:
+        """Evaluate ``dataset_file`` and return governance metadata."""
+
+        evaluation_time = datetime.now(UTC)
+        created = created_at or evaluation_time
+        base_metadata = (
+            dict(metadata)
+            if metadata is not None
+            else self.build_metadata(
+                run_id=run_id, record_count=record_count, created_at=created
+            )
+        )
+        violations: list[GovernanceViolation] = []
+
+        if not base_metadata.get("reviewed_by"):
+            violations.append(
+                GovernanceViolation(
+                    code="missing_reviewer",
+                    message="Curated dataset metadata is missing an assigned reviewer.",
+                )
+            )
+
+        expires_at_raw = base_metadata.get("expires_at")
+        if expires_at_raw:
+            try:
+                expires_at = datetime.fromisoformat(str(expires_at_raw))
+                if expires_at <= evaluation_time:
+                    violations.append(
+                        GovernanceViolation(
+                            code="dataset_expired",
+                            message="Curated dataset has exceeded its retention window.",
+                            details={"expired_at": expires_at_raw},
+                        )
+                    )
+            except ValueError:
+                violations.append(
+                    GovernanceViolation(
+                        code="invalid_expiry",
+                        message="Curated dataset metadata contains an invalid expiry timestamp.",
+                        details={"expires_at": expires_at_raw},
+                    )
+                )
+
+        export_window_raw = base_metadata.get("export_window_ends_at")
+        if export_window_raw:
+            try:
+                export_deadline = datetime.fromisoformat(str(export_window_raw))
+                if export_deadline <= evaluation_time:
+                    violations.append(
+                        GovernanceViolation(
+                            code="export_window_elapsed",
+                            message=(
+                                "Export window elapsed; dataset must be re-reviewed "
+                                "before sharing externally."
+                            ),
+                            details={"export_window_ends_at": export_window_raw},
+                        )
+                    )
+            except ValueError:
+                violations.append(
+                    GovernanceViolation(
+                        code="invalid_export_window",
+                        message="Curated dataset metadata contains an invalid export window timestamp.",
+                        details={"export_window_ends_at": export_window_raw},
+                    )
+                )
+
+        if record_count <= 0:
+            violations.append(
+                GovernanceViolation(
+                    code="empty_dataset",
+                    message="Curated dataset does not contain any records.",
+                )
+            )
+
+        actual_count = 0
+        if not dataset_file.exists():
+            violations.append(
+                GovernanceViolation(
+                    code="dataset_missing",
+                    message="Curated dataset file is missing.",
+                    details={"path": str(dataset_file)},
+                )
+            )
+        else:
+            with dataset_file.open("r", encoding="utf-8") as handle:
+                for line_number, line in enumerate(handle, start=1):
+                    stripped = line.strip()
+                    if not stripped:
+                        continue
+                    actual_count += 1
+                    try:
+                        record = json.loads(stripped)
+                    except json.JSONDecodeError as exc:
+                        violations.append(
+                            GovernanceViolation(
+                                code="invalid_record",
+                                message="Dataset contains an invalid JSON record.",
+                                details={
+                                    "line": line_number,
+                                    "error": str(exc),
+                                },
+                            )
+                        )
+                        continue
+                    pii_hits = detect_pii(record)
+                    if pii_hits:
+                        violations.append(
+                            GovernanceViolation(
+                                code="pii_detected",
+                                message="Dataset record still contains identifiable information.",
+                                details={"line": line_number, "matches": pii_hits},
+                            )
+                        )
+            if actual_count and actual_count != record_count:
+                violations.append(
+                    GovernanceViolation(
+                        code="count_mismatch",
+                        message="Catalog record count does not match dataset contents.",
+                        details={"expected": record_count, "actual": actual_count},
+                    )
+                )
+
+        status = "approved" if not violations else "quarantined"
+        if status == "quarantined":
+            log.warning(
+                "curated.dataset.governance_failed",
+                extra={
+                    "run_id": run_id,
+                    "violations": [violation.code for violation in violations],
+                },
+            )
+        else:
+            log.info(
+                "curated.dataset.governance_passed",
+                extra={"run_id": run_id, "record_count": record_count},
+            )
+
+        return GovernanceEvaluation(
+            status=status,
+            metadata=base_metadata,
+            checked_at=evaluation_time,
+            violations=violations,
+        )
+
+
+__all__ = [
+    "DatasetGovernance",
+    "GovernanceEvaluation",
+    "GovernanceViolation",
+]

--- a/monGARS/config.py
+++ b/monGARS/config.py
@@ -211,6 +211,34 @@ class Settings(BaseSettings):
         default=None,
         description="Optional override for the RAG context enrichment service URL.",
     )
+    rag_curated_default_provenance: str = Field(
+        default="self-training",
+        description=(
+            "Label applied to curated datasets indicating their source pipeline."
+        ),
+    )
+    rag_curated_default_sensitivity: str = Field(
+        default="restricted",
+        description="Sensitivity classification applied to curated dataset exports.",
+    )
+    rag_curated_reviewer: str = Field(
+        default="self-training-automation",
+        description="Reviewer recorded against automatically curated datasets.",
+    )
+    rag_curated_default_tags: list[str] = Field(
+        default_factory=lambda: ["rag", "curated"],
+        description="Default governance tags applied to curated dataset versions.",
+    )
+    rag_curated_retention_days: int = Field(
+        default=30,
+        ge=1,
+        description="Number of days curated datasets remain valid before re-review.",
+    )
+    rag_curated_export_window_days: int = Field(
+        default=7,
+        ge=0,
+        description="Duration in days that curated datasets remain exportable post-review.",
+    )
     llm_adapter_registry_path: Path = Field(
         default=Path("models/encoders"),
         description="Directory storing adapter artifacts and manifest.",

--- a/tests/self_training_test.py
+++ b/tests/self_training_test.py
@@ -76,6 +76,10 @@ async def test_run_training_cycle_creates_version(
     assert Path(dataset_file).exists()
     assert trainer_stub.runs and trainer_stub.runs[0][0]["text_preview"] == "trainable"
     assert version["dataset"]["version"] == 1
+    assert version["dataset"]["quarantined"] is False
+    compliance = version["dataset"]["compliance"]
+    assert compliance["status"] == "approved"
+    assert "provenance" in compliance["metadata"]
 
 
 @pytest.mark.asyncio
@@ -208,11 +212,15 @@ async def test_dataset_catalog_and_pii_scrubbing(
     assert rows and "[REDACTED_EMAIL]" in rows[0]["text_preview"]
     assert trainer_stub.runs[0][0]["text_preview"].endswith("[REDACTED_EMAIL]")
     assert dataset_meta["version"] == 1
+    assert dataset_meta["compliance"]["status"] == "approved"
+    assert dataset_meta["governance"]["run_id"] == dataset_meta["run_id"]
+    assert dataset_meta["quarantined"] is False
 
     catalog_path = tmp_path / "datasets" / "catalog.json"
     catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
     assert catalog["latest_version"] == 1
     assert catalog["versions"][0]["run_id"] == dataset_meta["run_id"]
+    assert catalog["versions"][0]["quarantined"] is False
 
 
 def test_collect_internal_reasoning_records_handles_running_loop(

--- a/tests/test_dataset_governance.py
+++ b/tests/test_dataset_governance.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from models.datasets.governance import DatasetGovernance
+from monGARS.config import Settings
+
+
+def _build_settings(**overrides: object) -> Settings:
+    base = Settings(SECRET_KEY="unit-test-secret")
+    return base.model_copy(update=overrides)
+
+
+def test_dataset_governance_approves_clean_dataset(tmp_path: Path) -> None:
+    settings = _build_settings(
+        rag_curated_default_provenance="unit-test",
+        rag_curated_reviewer="compliance-bot",
+        rag_curated_default_tags=["rag", "unit-test"],
+    )
+    governance = DatasetGovernance(settings=settings)
+    dataset_file = tmp_path / "curated.jsonl"
+    dataset_file.write_text(
+        json.dumps({"text": "sanitised", "text_preview": "sanitised"}) + "\n",
+        encoding="utf-8",
+    )
+
+    evaluation = governance.evaluate_dataset(
+        dataset_file,
+        run_id="run-1",
+        record_count=1,
+        created_at=datetime.now(UTC) - timedelta(minutes=1),
+    )
+
+    assert evaluation.status == "approved"
+    assert not evaluation.violations
+    assert evaluation.metadata["provenance"] == "unit-test"
+    assert evaluation.metadata["reviewed_by"] == "compliance-bot"
+
+
+def test_dataset_governance_flags_pii(tmp_path: Path) -> None:
+    settings = _build_settings(
+        rag_curated_default_provenance="unit-test",
+        rag_curated_reviewer="qa",
+        rag_curated_retention_days=1,
+        rag_curated_export_window_days=1,
+    )
+    governance = DatasetGovernance(settings=settings)
+    dataset_file = tmp_path / "curated.jsonl"
+    dataset_file.write_text(
+        json.dumps({"text": "Contact me at test@example.com"}) + "\n",
+        encoding="utf-8",
+    )
+
+    evaluation = governance.evaluate_dataset(
+        dataset_file,
+        run_id="run-2",
+        record_count=1,
+        created_at=datetime.now(UTC) - timedelta(days=2),
+    )
+
+    assert evaluation.status == "quarantined"
+    assert any(v.code == "pii_detected" for v in evaluation.violations)
+    assert any(v.code == "dataset_expired" for v in evaluation.violations)
+    packed = evaluation.as_dict()
+    assert packed["status"] == "quarantined"
+    assert packed["metadata"]["run_id"] == "run-2"


### PR DESCRIPTION
## Summary
- add a dataset governance module that enforces retention metadata, scrubbing checks, and compliance status on curated batches
- integrate governance results into the self-training pipeline, dataset catalog, and configuration defaults while expanding unit coverage
- document the governance workflow and update roadmap reports to highlight reinforcement-learning as the next priority

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e44ad12d348333ad7cdbcd55e3461f

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/monGARS/202)
<!-- GitContextEnd -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces governance for curated datasets, including metadata, compliance evaluations, automated PII checks, quarantine status, and retention/export windows. Results are surfaced in the dataset catalog and self-training workflow.

- Documentation
  - Adds a dataset governance playbook and updates guidance to reflect new governance workflows.
  - Revises implementation status and next priorities toward operational controls for the reinforcement-learning loop, with updated cross-links.

- Tests
  - Adds tests covering approval/quarantine scenarios, PII detection, and catalog metadata propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->