### PR TITLE
Add module entrypoint and script-mode imports for deep scan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,21 @@
-INPUT ?= .
-OUT ?= output
-
 .PHONY: install run dryrun test
 
+PY ?= python3
+OUT ?= output
+INPUT ?= .
+
+# Adjust MODULE if your package lives elsewhere
+MODULE ?= tools.monGARS_deep_scan
+REQFILE ?= tools/monGARS_deep_scan/requirements.txt
+
 install:
-	pip install -r tools/monGARS_deep_scan/requirements.txt
+$(PY) -m pip install -r $(REQFILE)
 
 run:
-	python -m tools.monGARS_deep_scan.deep_scan --input "$(INPUT)" --out "$(OUT)"
+PYTHONPATH=. $(PY) -m $(MODULE).deep_scan --input $(INPUT) --out $(OUT)
 
 dryrun:
-	python -m tools.monGARS_deep_scan.deep_scan --dry-run --input "$(INPUT)" --out "$(OUT)"
+PYTHONPATH=. $(PY) -m $(MODULE).deep_scan --input $(INPUT) --out $(OUT) --dry-run
 
 test:
-	pytest -q
+pytest -q

--- a/tools/monGARS_deep_scan/__main__.py
+++ b/tools/monGARS_deep_scan/__main__.py
@@ -1,0 +1,4 @@
+from .deep_scan import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- parameterize the Makefile deep scan targets with configurable Python interpreter and module paths
- add a package __main__ so `python -m tools.monGARS_deep_scan` dispatches to the scan CLI
- provide a script-mode import fallback in `deep_scan.py` to support direct execution

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e499b0b2e88333801129110107d845

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/monGARS/213)
<!-- GitContextEnd -->