### PR TITLE
Handle multi-generation vLLM outputs and harden tests

### DIFF
--- a/Dockerfile.rayserve
+++ b/Dockerfile.rayserve
@@ -36,6 +36,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         "llm2vec>=0.2.3" \
         "peft>=0.13.2" \
         "sentencepiece>=0.2.0" \
+        "vllm>=0.4.2" \
         "transformers>=4.44.2"
 
 # Return to the default ray user for runtime safety.

--- a/modules/ray_service.py
+++ b/modules/ray_service.py
@@ -26,9 +26,10 @@ except ImportError:  # pragma: no cover - fallback when ray not installed
     serve = None  # type: ignore[assignment]
 
 try:  # pragma: no cover - optional dependency for inference
-    import ollama
-except ImportError:  # pragma: no cover - Ray deployment can still start without Ollama
-    ollama = None
+    from vllm import LLM, SamplingParams
+except ImportError:  # pragma: no cover - Ray deployment can still start without vLLM
+    LLM = None  # type: ignore[assignment]
+    SamplingParams = None  # type: ignore[assignment]
 
 if serve:  # pragma: no cover - executed only when ray is installed
     try:
@@ -97,6 +98,12 @@ class RayLLMDeployment:
         coding_definition = self._model_manager.get_model_definition("coding")
         self.general_model = os.getenv("RAY_GENERAL_MODEL", general_definition.name)
         self.coding_model = os.getenv("RAY_CODING_MODEL", coding_definition.name)
+        if LLM is None or SamplingParams is None:
+            raise RuntimeError(
+                "vLLM is not available; install the vllm package in the Ray Serve image."
+            )
+        self._llm_engines: dict[str, LLM] = {}
+        self._initialise_llm_engines()
         resolved_temperature = self._model_manager.resolve_parameter(
             "general", "temperature", settings.AI_MODEL_TEMPERATURE
         )
@@ -142,6 +149,26 @@ class RayLLMDeployment:
             llm2vec_options={"device_map": DEFAULT_DEVICE_MAP},
             wrapper_dir=default_wrapper,
         )
+
+    def _initialise_llm_engines(self) -> None:
+        models = {self.general_model, self.coding_model}
+        for model_name in models:
+            if model_name in self._llm_engines:
+                continue
+            try:
+                self._llm_engines[model_name] = LLM(model=model_name)
+            except Exception as exc:  # pragma: no cover - backend-specific failures
+                logger.exception(
+                    "llm.ray.vllm_initialisation_failed",
+                    extra={"model": model_name},
+                )
+                raise RuntimeError(
+                    f"Failed to initialise vLLM engine for model {model_name!r}"
+                ) from exc
+            logger.info(
+                "llm.ray.vllm_initialised",
+                extra={"model": model_name},
+            )
 
     def _stat_manifest(self) -> float | None:
         try:
@@ -369,51 +396,71 @@ class RayLLMDeployment:
         self, prompt: str, task_type: str
     ) -> tuple[str, dict[str, Any]]:
         model = self._select_model(task_type)
-        if not ollama:
-            raise RayServeException("Ollama client is not available on the Ray replica")
+        engine = self._llm_engines.get(model)
+        if engine is None:
+            raise RayServeException(f"Model {model!r} is not loaded on this replica")
 
+        sampling_params = self._build_sampling_params()
         try:
-            response = await asyncio.to_thread(
-                ollama.chat,
-                model=model,
-                messages=[{"role": "user", "content": prompt}],
-                options={
-                    "temperature": float(self.temperature),
-                    "top_p": float(self.top_p),
-                    "num_predict": int(self.max_tokens),
-                    "stream": False,
-                },
+            responses = await asyncio.to_thread(
+                engine.generate,
+                [prompt],
+                sampling_params=sampling_params,
             )
         except Exception as exc:  # pragma: no cover - backend-specific failures
             logger.exception(
-                "llm.ray.ollama_failure",
+                "llm.ray.vllm_failure",
                 extra={"model": model},
             )
             raise RayServeException("Text generation failed") from exc
 
-        message = response.get("message") if isinstance(response, dict) else None
-        text: Any
-        if isinstance(message, dict):
-            text = message.get("content")
-        else:
-            text = None
-        if not isinstance(text, str):
-            text = response.get("content") if isinstance(response, dict) else None
-        if not isinstance(text, str):
+        if not responses:
+            raise RayServeException("vLLM returned no generations")
+
+        first = responses[0]
+        outputs = getattr(first, "outputs", None)
+        if not outputs:
+            raise RayServeException("vLLM response did not include any outputs")
+
+        texts: list[str] = []
+        completion_tokens = 0
+        completion_breakdown: list[int] = []
+        for candidate in outputs:
+            candidate_text = getattr(candidate, "text", None)
+            if isinstance(candidate_text, str) and candidate_text:
+                texts.append(candidate_text)
+
+            token_ids = getattr(candidate, "token_ids", None)
+            if token_ids is not None:
+                try:
+                    token_length = len(token_ids)
+                except TypeError:
+                    token_length = 0
+                else:
+                    completion_tokens += token_length
+                    completion_breakdown.append(token_length)
+
+        if not texts:
             raise RayServeException("LLM response did not include textual content")
 
-        usage_raw = response.get("usage") if isinstance(response, dict) else None
-        usage: dict[str, Any]
-        if isinstance(usage_raw, dict):
-            usage = {
-                key: value
-                for key, value in usage_raw.items()
-                if isinstance(key, str) and isinstance(value, (int, float))
-            }
-        else:
-            usage = {}
+        prompt_token_source = getattr(first, "prompt_token_ids", []) or []
+        prompt_tokens = len(prompt_token_source)
+        text = "\n\n".join(texts)
+        usage: dict[str, Any] = {
+            "model": model,
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+            "generations": len(texts),
+        }
+        if completion_breakdown:
+            usage["completion_tokens_per_generation"] = completion_breakdown
+        metrics = getattr(first, "metrics", None)
+        if isinstance(metrics, Mapping):
+            for key, value in metrics.items():
+                if isinstance(key, str) and isinstance(value, (int, float)):
+                    usage.setdefault(key, value)
 
-        usage.setdefault("model", model)
         return text, usage
 
     def _summarise_embedding(
@@ -429,6 +476,13 @@ class RayLLMDeployment:
             "norm": magnitude,
             "mean": mean_activation,
         }
+
+    def _build_sampling_params(self) -> SamplingParams:
+        return SamplingParams(
+            temperature=float(self.temperature),
+            top_p=float(self.top_p),
+            max_tokens=int(self.max_tokens),
+        )
 
     def _select_model(self, task_type: str) -> str:
         if task_type.lower() in {"code", "coding", "developer"}:

--- a/tests/test_ray_service.py
+++ b/tests/test_ray_service.py
@@ -115,25 +115,87 @@ def _run_orchestrator_pipeline(registry_path: Path, trainer_cls: type) -> Path:
     return Path(orchestrator.trigger_encoder_training_pipeline())
 
 
+@pytest.fixture
+def fake_vllm(monkeypatch: pytest.MonkeyPatch):
+    from modules import ray_service
+
+    class FakeSamplingParams:
+        def __init__(self, *_, **kwargs) -> None:
+            self.kwargs = kwargs
+            self.temperature = kwargs.get("temperature")
+            self.top_p = kwargs.get("top_p")
+            self.max_tokens = kwargs.get("max_tokens")
+
+    class FakeSequenceOutput:
+        def __init__(self, text: str | None, token_count: int = 3) -> None:
+            self.text = text
+            self.token_ids = list(range(token_count))
+
+    class FakeRequestOutput:
+        def __init__(
+            self,
+            *,
+            texts: list[str | None],
+            prompt_tokens: int = 2,
+            metrics: dict[str, float] | None = None,
+            token_counts: list[int] | None = None,
+        ) -> None:
+            counts = token_counts or [3] * len(texts)
+            self.outputs = [
+                FakeSequenceOutput(text, counts[idx] if idx < len(counts) else 3)
+                for idx, text in enumerate(texts)
+            ]
+            self.prompt_token_ids = list(range(prompt_tokens))
+            self.metrics = metrics if metrics is not None else {"latency_ms": 1.5}
+
+    class FakeLLM:
+        instances: list["FakeLLM"] = []
+        requests: list[tuple[str, list[str], FakeSamplingParams]] = []
+        next_generate: list[FakeRequestOutput] | None = None
+        generate_exception: Exception | None = None
+        initialisation_error: Exception | None = None
+
+        def __init__(self, *, model: str) -> None:
+            if FakeLLM.initialisation_error is not None:
+                raise FakeLLM.initialisation_error
+            self.model = model
+            FakeLLM.instances.append(self)
+
+        def generate(
+            self, prompts: list[str], sampling_params: FakeSamplingParams
+        ) -> list[FakeRequestOutput]:
+            FakeLLM.requests.append((self.model, prompts, sampling_params))
+            if FakeLLM.generate_exception is not None:
+                exc = FakeLLM.generate_exception
+                FakeLLM.generate_exception = None
+                raise exc
+            if FakeLLM.next_generate is not None:
+                result = FakeLLM.next_generate
+                FakeLLM.next_generate = None
+                return result
+            return [FakeRequestOutput(texts=[f"response-for-{self.model}"])]
+
+        @classmethod
+        def reset(cls) -> None:
+            cls.instances.clear()
+            cls.requests.clear()
+            cls.next_generate = None
+            cls.generate_exception = None
+            cls.initialisation_error = None
+
+    monkeypatch.setattr(ray_service, "SamplingParams", FakeSamplingParams)
+    monkeypatch.setattr(ray_service, "LLM", FakeLLM)
+    FakeLLM.RequestOutput = FakeRequestOutput
+    FakeLLM.SequenceOutput = FakeSequenceOutput
+    FakeLLM.reset()
+    return FakeLLM
+
+
 @pytest.mark.asyncio
-async def test_ray_service_render_response_uses_ollama(monkeypatch):
+async def test_ray_service_render_response_uses_vllm(fake_vllm):
     from modules import ray_service
 
     deployment = ray_service.RayLLMDeployment(base_model_path="base")
-
-    called = {}
-
-    class FakeOllama:
-        @staticmethod
-        def chat(
-            *, model: str, messages: list[dict[str, str]], options: dict[str, float]
-        ):
-            called["model"] = model
-            called["messages"] = messages
-            called["options"] = options
-            return {"message": {"content": "ok"}, "usage": {"eval_count": 1}}
-
-    monkeypatch.setattr(ray_service, "ollama", FakeOllama())
 
     result = await deployment._render_response(
         "prompt",
@@ -142,13 +204,114 @@ async def test_ray_service_render_response_uses_ollama(monkeypatch):
         "general",
     )
 
-    assert result["content"] == "ok"
-    assert result["message"]["content"] == "ok"
-    assert result["usage"]["model"] == deployment.general_model
-    assert called["messages"][0]["content"] == "prompt"
+    assert result["content"] == f"response-for-{deployment.general_model}"
+    assert result["message"]["content"] == result["content"]
+    usage = result["usage"]
+    assert usage["model"] == deployment.general_model
+    assert usage["prompt_tokens"] == 2
+    assert usage["completion_tokens"] == 3
+    assert usage["total_tokens"] == 5
+    assert usage["generations"] == 1
+    assert usage["completion_tokens_per_generation"] == [3]
+    assert usage["latency_ms"] == pytest.approx(1.5)
+
+    model, prompts, sampling_params = fake_vllm.requests[-1]
+    assert model == deployment.general_model
+    assert prompts == ["prompt"]
+    assert sampling_params.temperature == pytest.approx(deployment.temperature)
+    assert sampling_params.top_p == pytest.approx(deployment.top_p)
+    assert sampling_params.max_tokens == deployment.max_tokens
 
 
-def test_ray_service_encode_prompt_error(monkeypatch):
+@pytest.mark.asyncio
+async def test_ray_service_render_response_handles_multiple_generations(fake_vllm):
+    from modules import ray_service
+
+    fake_vllm.reset()
+    fake_vllm.next_generate = [
+        fake_vllm.RequestOutput(
+            texts=["first", "second"],
+            prompt_tokens=4,
+            metrics={"latency_ms": 2.5, "time_to_first_token_ms": 0.7},
+            token_counts=[2, 4],
+        )
+    ]
+
+    deployment = ray_service.RayLLMDeployment(base_model_path="base")
+    result = await deployment._render_response(
+        "prompt", [[0.1, 0.2, 0.3]], None, "general"
+    )
+
+    assert result["content"] == "first\n\nsecond"
+    usage = result["usage"]
+    assert usage["prompt_tokens"] == 4
+    assert usage["completion_tokens"] == 6
+    assert usage["total_tokens"] == 10
+    assert usage["generations"] == 2
+    assert usage["completion_tokens_per_generation"] == [2, 4]
+    assert usage["latency_ms"] == pytest.approx(2.5)
+    assert usage["time_to_first_token_ms"] == pytest.approx(0.7)
+
+
+@pytest.mark.asyncio
+async def test_ray_service_generate_raises_on_empty_generations(fake_vllm):
+    from modules import ray_service
+
+    fake_vllm.reset()
+    fake_vllm.next_generate = []
+
+    deployment = ray_service.RayLLMDeployment(base_model_path="base")
+
+    with pytest.raises(ray_service.RayServeException) as excinfo:
+        await deployment._render_response("prompt", [[0.1]], None, "general")
+
+    assert "returned no generations" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_ray_service_generate_raises_on_missing_outputs(fake_vllm):
+    from modules import ray_service
+
+    fake_vllm.reset()
+    fake_vllm.next_generate = [fake_vllm.RequestOutput(texts=[])]
+
+    deployment = ray_service.RayLLMDeployment(base_model_path="base")
+
+    with pytest.raises(ray_service.RayServeException) as excinfo:
+        await deployment._render_response("prompt", [[0.1]], None, "general")
+
+    assert "did not include any outputs" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_ray_service_generate_raises_on_missing_text(fake_vllm):
+    from modules import ray_service
+
+    fake_vllm.reset()
+    fake_vllm.next_generate = [fake_vllm.RequestOutput(texts=[None])]
+
+    deployment = ray_service.RayLLMDeployment(base_model_path="base")
+
+    with pytest.raises(ray_service.RayServeException) as excinfo:
+        await deployment._render_response("prompt", [[0.1]], None, "general")
+
+    assert "did not include textual content" in str(excinfo.value)
+
+
+def test_ray_service_initialisation_failure_is_reported(fake_vllm):
+    from modules import ray_service
+
+    fake_vllm.reset()
+    fake_vllm.initialisation_error = RuntimeError("initialisation failed")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        ray_service.RayLLMDeployment(base_model_path="base")
+
+    assert "Failed to initialise vLLM engine" in str(excinfo.value)
+    fake_vllm.reset()
+
+
+def test_ray_service_encode_prompt_error(fake_vllm, monkeypatch):
     from modules import ray_service
 
     deployment = ray_service.RayLLMDeployment(base_model_path="base")
@@ -255,7 +418,7 @@ def test_llm_integration_invalid_backoff_falls_back_to_defaults(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_ray_deployment_refreshes_after_training_pipeline(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake_vllm
 ) -> None:
     from modules import ray_service
 
@@ -305,7 +468,7 @@ async def test_ray_deployment_refreshes_after_training_pipeline(
 
 @pytest.mark.asyncio
 async def test_ray_deployment_rejects_invalid_adapter_payload(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake_vllm
 ) -> None:
     from modules import ray_service
 
@@ -346,7 +509,7 @@ async def test_ray_deployment_rejects_invalid_adapter_payload(
 
 @pytest.mark.asyncio
 async def test_ray_deployment_accepts_multi_replica_payload_once(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake_vllm
 ) -> None:
     from modules import ray_service
 


### PR DESCRIPTION
## Summary
- replace the Ollama-backed Ray Serve deployment with a vLLM engine that loads once per replica, aggregates multiple generations, and tracks rich usage metrics via SamplingParams-based generation
- add Docker dependency on vLLM and extend the fake vLLM-based unit suite to cover success metrics plus empty/malformed generation and initialization failures

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4bc7d0d048333bc57b4aafdc91eca