### PR TITLE
Add CLI defaults for custom dataset builder

### DIFF
--- a/.github/workflows/custom-dataset.yml
+++ b/.github/workflows/custom-dataset.yml
@@ -1,8 +1,8 @@
-name: Build Custom Québec-French Dataset (repo-only)
+name: Build Custom Québec-French Dataset
 
 on:
   push:
-    branches: ['**']         # run on any branch commit
+    branches: ['**']
   workflow_dispatch:
     inputs:
       ratios:
@@ -27,19 +27,26 @@ permissions:
 
 env:
   PYTHON_VERSION: "3.12"
+  SCAN_OUTPUT_DIR: data/deep_scan
+  FINAL_OUTPUT_DIR: data/final
+  DATASET_RATIOS: ${{ github.event.inputs.ratios || 'frca:0.50,agent:0.40,repo:0.10' }}
+  DATASET_VAL_PCT: ${{ github.event.inputs.val_pct || 0.06 }}
+  DATASET_STRICT_QC: ${{ github.event.inputs.strict_qc || 'true' }}
+  DATASET_RETENTION_DAYS: ${{ github.event.inputs.retention_days || 14 }}
 
 concurrency:
   group: custom-dataset-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  scan_and_build:
+  curate:
+    name: Curate Québec-French dataset
     runs-on: ubuntu-latest
-    env:
-      CONFIRM_SCAN: "YES"
-      CONFIRM_DATA_FETCH: "NO"
+    defaults:
+      run:
+        shell: bash
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -49,264 +56,58 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install OS deps (graphviz for PNG graph)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y graphviz
+      - name: Cache pip downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ env.PYTHON_VERSION }}-${{ hashFiles('tools/monGARS_deep_scan/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ env.PYTHON_VERSION }}-
+            ${{ runner.os }}-pip-
 
-      - name: Create analyzer script (no heredoc)
-        run: |
-          set -euo pipefail
-          mkdir -p scripts
-          : > scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '#!/usr/bin/env python3' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'import os, re, json, csv, hashlib, subprocess, sys' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'from pathlib import Path' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'OUT = Path("data/ultimate"); RAW = OUT/"raw_texts"; PROC = OUT/"processed_repo"' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'for d in (RAW, PROC): d.mkdir(parents=True, exist_ok=True)' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'SFT = PROC/"sft_repo.jsonl"; AGT = PROC/"agent_instruct_repo.jsonl"; EMB = PROC/"embeddings_repo.jsonl"' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'PROV = PROC/"provenance.csv"; DOT = OUT/"interaction_graph.dot"; PNG = OUT/"interaction_graph.png"' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'if os.environ.get("CONFIRM_SCAN","") != "YES":' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    print("ABORT: set CONFIRM_SCAN=YES"); sys.exit(2)' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'EXTS = {"md","rst","txt","json","yml","yaml","py","sh","cfg","ini","toml","sql","js","ts"}' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'def is_text(p):' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    try:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '        with p.open("rb") as f: return b"\\x00" not in f.read(4096)' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    except: return False' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'root = Path(".").resolve(); files=[]' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'if (root/".git").exists():' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    try:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '        out = subprocess.check_output(["git","ls-files"], text=True)' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '        for rel in out.splitlines():' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '            p=root/rel' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '            if p.suffix.lstrip(".") in EXTS and p.exists() and is_text(p):' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '                dst=RAW/p.relative_to(root); dst.parent.mkdir(parents=True, exist_ok=True)' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '                dst.write_bytes(p.read_bytes()); files.append(dst)' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    except: pass' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'if not files:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    for p in root.rglob("*"):' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '        if p.is_file() and p.suffix.lstrip(".") in EXTS and is_text(p) and ".git" not in p.parts:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '            dst=RAW/p.relative_to(root); dst.parent.mkdir(parents=True, exist_ok=True)' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '            dst.write_bytes(p.read_bytes()); files.append(dst)' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'DIALOG=re.compile(r'^\\s*(User|Utilisateur|Client|Moi|Tu|Vous|Assistant|System|Bot|Agent)\\s*[:\\-—]\\s*(.+)', re.I)' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'PIPE=re.compile(r'(workflow|pipeline|job|stage|steps|run:|script:|entrypoint|commands?)', re.I)' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'JSONL=re.compile(r'^\\s*[\\{\\[]\\s*\".*')' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'def sha(s): import hashlib; return hashlib.sha1(s.encode("utf-8")).hexdigest()[:12]' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'sft_rows=[]; ag_rows=[]; emb_rows=[]; prov=[]' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'for f in files:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    try: text=f.read_text(encoding="utf-8", errors="ignore")' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    except: continue' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    lines=text.splitlines()' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    cur=[]' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    for i,ln in enumerate(lines):' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '        if DIALOG.match(ln): cur.append((i+1, ln.strip()))' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '        else:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '            if cur:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '                instr=None; outs=[]' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '                for _,l in cur:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '                    m=DIALOG.match(l); who=m.group(1).lower(); content=m.group(2).strip()' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '                    if instr is None and re.match(r'(user|utilisateur|client|moi|tu|vous)', who, re.I): instr=content' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '                    else: outs.append(content)' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '                if instr and outs:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '                    rec={"instruction":instr,"input":"","output":" ".join(outs)}' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '                    sft_rows.append(rec); prov.append([sha(json.dumps(rec,ensure_ascii=False)), str(f.relative_to(RAW)), cur[0][0], cur[-1][0], "sft_dialog","auto"])' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '                cur=[]' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    if cur:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '        instr=None; outs=[]' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '        for _,l in cur:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '            m=DIALOG.match(l); who=m.group(1).lower(); content=m.group(2).strip()' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '            if instr is None and re.match(r'(user|utilisateur|client|moi|tu|vous)', who, re.I): instr=content' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '            else: outs.append(content)' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '        if instr and outs:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '            rec={"instruction":instr,"input":"","output":" ".join(outs)}' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '            sft_rows.append(rec); prov.append([sha(json.dumps(rec,ensure_ascii=False)), str(f.relative_to(RAW)), cur[0][0], cur[-1][0], "sft_dialog","auto"])' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    curp=[]' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    for i,ln in enumerate(lines):' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '        if PIPE.search(ln) or JSONL.match(ln) or ln.strip().startswith(("steps:", "- run:", "script:")):' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '            curp.append((i+1, ln))' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '        else:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '            if curp:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '                block="\\n".join(l for _,l in curp)' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '                rec={"instruction":"Interpret this pipeline fragment and return structured steps as JSON. Preserve tool names and env vars.","input":block,"output":{"steps":[],"notes":"AUTO"}}' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '                ag_rows.append(rec); prov.append([sha(json.dumps(rec,ensure_ascii=False)), str(f.relative_to(RAW)), curp[0][0], curp[-1][0], "agent_pipeline","auto"])' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '                curp=[]' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    if curp:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '        block="\\n".join(l for _,l in curp)' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '        rec={"instruction":"Interpret this pipeline fragment and return structured steps as JSON. Preserve tool names and env vars.","input":block,"output":{"steps":[],"notes":"AUTO"}}' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '        ag_rows.append(rec); prov.append([sha(json.dumps(rec,ensure_ascii=False)), str(f.relative_to(RAW)), curp[0][0], curp[-1][0], "agent_pipeline","auto"])' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    para=[]; start=1' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    for i,ln in enumerate(lines):' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '        if ln.strip()=="":' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '            if para:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '                t="\\n".join(para).strip()' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '                if len(t)>=40:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '                    emb_rows.append({"text":t,"source":str(f.relative_to(RAW))})' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '                    prov.append([sha(t), str(f.relative_to(RAW)), start, i, "embedding_paragraph","auto"])' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '                para=[]; start=i+2' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '        else:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '            para.append(ln)' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    if para:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '        t="\\n".join(para).strip()' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '        if len(t)>=40:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '            emb_rows.append({"text":t,"source":str(f.relative_to(RAW))})' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '            prov.append([sha(t), str(f.relative_to(RAW)), start, len(lines), "embedding_paragraph","auto"])' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'def write_jsonl(p, rows):' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    p.parent.mkdir(parents=True, exist_ok=True)' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    with p.open("w", encoding="utf-8") as f:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '        for r in rows: f.write(json.dumps(r, ensure_ascii=False)+"\\n")' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'write_jsonl(SFT, sft_rows); write_jsonl(AGT, ag_rows); write_jsonl(EMB, emb_rows)' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'with PROV.open("w", encoding="utf-8", newline="") as f:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    w=csv.writer(f); w.writerow(["record_id","source_file","start_line","end_line","type","note"]); w.writerows(prov)' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'with DOT.open("w", encoding="utf-8") as f:' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    f.write("digraph interactions {\\n  \\"repo\\" [label=\\"repo\\"];\\n")' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    for i in range(min(20, len(sft_rows))): f.write(f' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' "        '  \"repo\" -> \"sft_' + str(i) + '\";\\n')" >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' '    f.write("}\\n")' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'try: subprocess.run(["dot","-Tpng", str(DOT), "-o", str(PNG)], check=True)' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'except: pass' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'print(f"OK: SFT={len(sft_rows)} AGENT={len(ag_rows)} EMB={len(emb_rows)}")' >> scripts/ultimate_repo_analyzer.py
-          printf '%s\n' 'print("OUT:", SFT, AGT, EMB, PROV, DOT, PNG if PNG.exists() else "(no PNG)")' >> scripts/ultimate_repo_analyzer.py
-          chmod +x scripts/ultimate_repo_analyzer.py
-
-      - name: Create dataset builder (no heredoc)
-        run: |
-          set -euo pipefail
-          mkdir -p scripts
-          : > scripts/prepare_dataset.py
-          printf '%s\n' '#!/usr/bin/env python3' >> scripts/prepare_dataset.py
-          printf '%s\n' 'import json, random, argparse, hashlib' >> scripts/prepare_dataset.py
-          printf '%s\n' 'from pathlib import Path' >> scripts/prepare_dataset.py
-          printf '%s\n' 'QC_TERMS=["dépanneur","poutine","cégep","tuque","magasiner","char","chum","blonde","icitte","ben là","patente","tabarnak"]' >> scripts/prepare_dataset.py
-          printf '%s\n' 'MIN_LEN=12; MAX_OUT_CHARS=3000' >> scripts/prepare_dataset.py
-          printf '%s\n' 'def sha(s): import hashlib; return hashlib.sha1(s.encode("utf-8")).hexdigest()' >> scripts/prepare_dataset.py
-          printf '%s\n' 'def is_qc(t): t=t.lower(); return any(w in t for w in QC_TERMS)' >> scripts/prepare_dataset.py
-          printf '%s\n' 'def clamp(s,n): s=s.strip(); return s if len(s)<=n else s[:n].rsplit(" ",1)[0]+" …"' >> scripts/prepare_dataset.py
-          printf '%s\n' 'def load_jsonl(p):' >> scripts/prepare_dataset.py
-          printf '%s\n' '    p=Path(p);' >> scripts/prepare_dataset.py
-          printf '%s\n' '    if not p.exists(): return []' >> scripts/prepare_dataset.py
-          printf '%s\n' '    with p.open("r",encoding="utf-8") as f:' >> scripts/prepare_dataset.py
-          printf '%s\n' '        for line in f:' >> scripts/prepare_dataset.py
-          printf '%s\n' '            line=line.strip()' >> scripts/prepare_dataset.py
-          printf '%s\n' '            if line: yield json.loads(line)' >> scripts/prepare_dataset.py
-          printf '%s\n' 'def norm_sft(j):' >> scripts/prepare_dataset.py
-          printf '%s\n' '    if not isinstance(j,dict) or "instruction" not in j or "output" not in j: return None' >> scripts/prepare_dataset.py
-          printf '%s\n' '    instr=(j.get("instruction") or "").strip(); inp=(j.get("input") or "").strip(); out=j.get("output")' >> scripts/prepare_dataset.py
-          printf '%s\n' '    if not isinstance(out,str): out=json.dumps(out,ensure_ascii=False,separators=(",",":"))' >> scripts/prepare_dataset.py
-          printf '%s\n' '    out=clamp(out,MAX_OUT_CHARS)' >> scripts/prepare_dataset.py
-          printf '%s\n' '    if len(instr)<MIN_LEN or len(out)<MIN_LEN: return None' >> scripts/prepare_dataset.py
-          printf '%s\n' '    return {"instruction":instr,"input":inp,"output":out}' >> scripts/prepare_dataset.py
-          printf '%s\n' 'def dedupe(xs,key=lambda x:x):' >> scripts/prepare_dataset.py
-          printf '%s\n' '    s=set(); o=[]' >> scripts/prepare_dataset.py
-          printf '%s\n' '    for it in xs:' >> scripts/prepare_dataset.py
-          printf '%s\n' '        k=key(it)' >> scripts/prepare_dataset.py
-          printf '%s\n' '        if k in s: continue' >> scripts/prepare_dataset.py
-          printf '%s\n' '        s.add(k); o.append(it)' >> scripts/prepare_dataset.py
-          printf '%s\n' '    return o' >> scripts/prepare_dataset.py
-          printf '%s\n' 'def main():' >> scripts/prepare_dataset.py
-          printf '%s\n' '    ap=argparse.ArgumentParser()' >> scripts/prepare_dataset.py
-          printf '%s\n' '    ap.add_argument("--frca", default="data/raw/repo_sft.jsonl")' >> scripts/prepare_dataset.py
-          printf '%s\n' '    ap.add_argument("--agent", default="data/raw/agent_handoff.jsonl")' >> scripts/prepare_dataset.py
-          printf '%s\n' '    ap.add_argument("--repo", default="data/raw/repo_sft.jsonl")' >> scripts/prepare_dataset.py
-          printf '%s\n' '    ap.add_argument("--outdir", default="data/final")' >> scripts/prepare_dataset.py
-          printf '%s\n' '    ap.add_argument("--seed", type=int, default=42)' >> scripts/prepare_dataset.py
-          printf '%s\n' '    ap.add_argument("--ratio", default="frca:0.50,agent:0.40,repo:0.10")' >> scripts/prepare_dataset.py
-          printf '%s\n' '    ap.add_argument("--val_pct", type=float, default=0.06)' >> scripts/prepare_dataset.py
-          printf '%s\n' '    ap.add_argument("--strict_qc", action="store_true")' >> scripts/prepare_dataset.py
-          printf '%s\n' '    a=ap.parse_args(); random.seed(a.seed)' >> scripts/prepare_dataset.py
-          printf '%s\n' '    ratios={};' >> scripts/prepare_dataset.py
-          printf '%s\n' '    for part in a.ratio.split(","):' >> scripts/prepare_dataset.py
-          printf '%s\n' '        k,v=part.split(":"); ratios[k.strip()]=float(v)' >> scripts/prepare_dataset.py
-          printf '%s\n' '    sources={"frca":a.frca,"agent":a.agent,"repo":a.repo}' >> scripts/prepare_dataset.py
-          printf '%s\n' '    buckets={}' >> scripts/prepare_dataset.py
-          printf '%s\n' '    for name,path in sources.items():' >> scripts/prepare_dataset.py
-          printf '%s\n' '        rows=[]' >> scripts/prepare_dataset.py
-          printf '%s\n' '        for j in load_jsonl(path):' >> scripts/prepare_dataset.py
-          printf '%s\n' '            s=norm_sft(j)' >> scripts/prepare_dataset.py
-          printf '%s\n' '            if not s: continue' >> scripts/prepare_dataset.py
-          printf '%s\n' '            if a.strict_qc and name!="agent":' >> scripts/prepare_dataset.py
-          printf '%s\n' '                if not is_qc(s["instruction"]+" "+s["output"]): continue' >> scripts/prepare_dataset.py
-          printf '%s\n' '            rows.append(s)' >> scripts/prepare_dataset.py
-          printf '%s\n' '        rows=dedupe(rows, key=lambda x: sha((x["instruction"]+"|"+x["input"]).lower()))' >> scripts/prepare_dataset.py
-          printf '%s\n' '        buckets[name]=rows' >> scripts/prepare_dataset.py
-          printf '%s\n' '        print(f"[LOAD] {name}: {len(rows)}")' >> scripts/prepare_dataset.py
-          printf '%s\n' '    total=sum(len(v) for v in buckets.values())' >> scripts/prepare_dataset.py
-          printf '%s\n' '    if total==0: raise SystemExit("No data")' >> scripts/prepare_dataset.py
-          printf '%s\n' '    targets={k:int(ratios.get(k,0)*total) for k in buckets}' >> scripts/prepare_dataset.py
-          printf '%s\n' '    mixed=[]' >> scripts/prepare_dataset.py
-          printf '%s\n' '    for k, arr in buckets.items():' >> scripts/prepare_dataset.py
-          printf '%s\n' '        random.shuffle(arr); take=min(len(arr), max(0, targets.get(k,0)))' >> scripts/prepare_dataset.py
-          printf '%s\n' '        mixed.extend(arr[:take])' >> scripts/prepare_dataset.py
-          printf '%s\n' '    if len(mixed)<total:' >> scripts/prepare_dataset.py
-          printf '%s\n' '        pool=[x for xs in buckets.values() for x in xs]; random.shuffle(pool)' >> scripts/prepare_dataset.py
-          printf '%s\n' '        for x in pool:' >> scripts/prepare_dataset.py
-          printf '%s\n' '            if len(mixed)>=total: break' >> scripts/prepare_dataset.py
-          printf '%s\n' '            mixed.append(x)' >> scripts/prepare_dataset.py
-          printf '%s\n' '    random.shuffle(mixed)' >> scripts/prepare_dataset.py
-          printf '%s\n' '    n_val=int(len(mixed)*a.val_pct); val=mixed[:n_val]; train=mixed[n_val:]' >> scripts/prepare_dataset.py
-          printf '%s\n' '    out=Path(a.outdir); out.mkdir(parents=True,exist_ok=True)' >> scripts/prepare_dataset.py
-          printf '%s\n' '    with (out/"train.jsonl").open("w",encoding="utf-8") as f:' >> scripts/prepare_dataset.py
-          printf '%s\n' '        for r in train: f.write(json.dumps(r,ensure_ascii=False)+"\\n")' >> scripts/prepare_dataset.py
-          printf '%s\n' '    with (out/"val.jsonl").open("w",encoding="utf-8") as f:' >> scripts/prepare_dataset.py
-          printf '%s\n' '        for r in val: f.write(json.dumps(r,ensure_ascii=False)+"\\n")' >> scripts/prepare_dataset.py
-          printf '%s\n' '    print(f"[DONE] train={len(train)} val={len(val)} strict_qc={a.strict_qc}")' >> scripts/prepare_dataset.py
-          printf '%s\n' 'if __name__=="__main__": main()' >> scripts/prepare_dataset.py
-          chmod +x scripts/prepare_dataset.py
-
-      - name: Install minimal Python deps
+      - name: Install dataset tooling
         run: |
           python -m pip install --upgrade pip
-          pip install networkx || true
+          pip install -r tools/monGARS_deep_scan/requirements.txt
 
-      - name: Run analyzer
+      - name: Execute deep scan pipeline
+        env:
+          PYTHONPATH: .
         run: |
           set -euxo pipefail
-          python scripts/ultimate_repo_analyzer.py
-          echo "== Output tree =="; find data/ultimate -maxdepth 3 -type f | sort || true
+          python -m tools.monGARS_deep_scan.deep_scan \
+            --input . \
+            --out "${SCAN_OUTPUT_DIR}" \
+            --exclude-dir "${SCAN_OUTPUT_DIR},${FINAL_OUTPUT_DIR},.git" \
+            --jobs 4
+          ls "${SCAN_OUTPUT_DIR}"
 
-      - name: Assemble inputs for dataset builder
+      - name: Build train/validation splits
+        env:
+          PYTHONPATH: .
         run: |
-          set -euxo pipefail
-          mkdir -p data/raw
-          cp data/ultimate/processed_repo/sft_repo.jsonl            data/raw/repo_sft.jsonl
-          cp data/ultimate/processed_repo/agent_instruct_repo.jsonl data/raw/agent_handoff.jsonl
-          cp data/ultimate/processed_repo/sft_repo.jsonl            data/raw/frca_repo.jsonl
+          python -m tools.monGARS_deep_scan.build_dataset
 
-      - name: Build final dataset (train/val)
+      - name: Publish dataset summary
+        env:
+          PYTHONPATH: .
         run: |
-          set -euxo pipefail
-          python scripts/prepare_dataset.py \
-            --frca data/raw/frca_repo.jsonl \
-            --agent data/raw/agent_handoff.jsonl \
-            --repo data/raw/repo_sft.jsonl \
-            --outdir data/final \
-            --ratio "${{ inputs.ratios || 'frca:0.50,agent:0.40,repo:0.10' }}" \
-            --val_pct ${{ inputs.val_pct || 0.06 }} \
-            $([ "${{ inputs.strict_qc || true }}" = "true" ] && echo "--strict_qc" || true)
-          echo "== Final counts =="; wc -l data/final/train.jsonl || true; wc -l data/final/val.jsonl || true
+          python -m tools.monGARS_deep_scan.publish_summary --final-dir "${FINAL_OUTPUT_DIR}" --output summary.md
+          cat summary.md >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload artifacts
+      - name: Upload dataset artefacts
         uses: actions/upload-artifact@v4
         with:
-          name: final-custom-dataset
+          name: custom-quebec-french-dataset
           path: |
-            data/ultimate/processed_repo/sft_repo.jsonl
-            data/ultimate/processed_repo/agent_instruct_repo.jsonl
-            data/ultimate/processed_repo/embeddings_repo.jsonl
-            data/ultimate/processed_repo/provenance.csv
-            data/ultimate/interaction_graph.dot
-            data/ultimate/interaction_graph.png
-            data/final/train.jsonl
-            data/final/val.jsonl
-          retention-days: ${{ inputs.retention_days || 14 }}
+            ${SCAN_OUTPUT_DIR}/sft_dataset.jsonl
+            ${SCAN_OUTPUT_DIR}/agent_handoff_dataset.jsonl
+            ${SCAN_OUTPUT_DIR}/embeddings_corpus.jsonl
+            ${SCAN_OUTPUT_DIR}/provenance.csv
+            ${SCAN_OUTPUT_DIR}/report.md
+            ${SCAN_OUTPUT_DIR}/logs/**
+            ${FINAL_OUTPUT_DIR}/train.jsonl
+            ${FINAL_OUTPUT_DIR}/val.jsonl
+            ${FINAL_OUTPUT_DIR}/dataset_summary.json
+          retention-days: ${{ env.DATASET_RETENTION_DAYS }}
           if-no-files-found: error

--- a/tools/monGARS_deep_scan/build_dataset.py
+++ b/tools/monGARS_deep_scan/build_dataset.py
@@ -1,0 +1,314 @@
+"""Assemble curated train/validation splits for the custom dataset workflow."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import random
+import sys
+from pathlib import Path
+from typing import Iterable
+
+from tools.monGARS_deep_scan.utils.hashing import stable_hash
+
+MIN_TEXT = 12
+MAX_OUTPUT_CHARS = 3000
+
+
+def _load_jsonl(path: Path) -> Iterable[dict]:
+    with path.open("r", encoding="utf-8") as handle:
+        for line_no, line in enumerate(handle, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError as exc:
+                print(
+                    f"::warning::Skipping invalid JSON in {path} line {line_no}: {exc}",
+                    file=sys.stderr,
+                )
+
+
+def _normalise(record: dict) -> dict | None:
+    instruction = (record.get("instruction") or "").strip()
+    input_text = (record.get("input") or "").strip()
+    output = record.get("output")
+
+    if isinstance(output, (dict, list)):
+        output = json.dumps(output, ensure_ascii=False, separators=(",", ":"))
+    elif output is None:
+        output = ""
+    else:
+        output = str(output).strip()
+
+    if len(instruction) < MIN_TEXT or len(output) < MIN_TEXT:
+        return None
+    if len(output) > MAX_OUTPUT_CHARS:
+        output = output[:MAX_OUTPUT_CHARS].rsplit(" ", 1)[0] + " …"
+
+    return {"instruction": instruction, "input": input_text, "output": output}
+
+
+def _parse_ratios(raw: str) -> dict[str, float]:
+    ratios: dict[str, float] = {}
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if ":" not in part:
+            print(
+                f"::warning::Ignoring malformed ratio entry '{part}'", file=sys.stderr
+            )
+            continue
+        key, value = part.split(":", 1)
+        try:
+            ratios[key.strip()] = float(value)
+        except ValueError:
+            print(
+                f"::warning::Invalid ratio value '{value}' for key '{key.strip()}'",
+                file=sys.stderr,
+            )
+
+    if not ratios:
+        ratios = {"frca": 0.5, "agent": 0.4, "repo": 0.1}
+
+    total = sum(ratios.values())
+    if total > 0:
+        ratios = {key: value / total for key, value in ratios.items()}
+
+    for bucket in ("frca", "agent", "repo"):
+        ratios.setdefault(bucket, 0.0)
+
+    return ratios
+
+
+def _hash_row(row: dict) -> str:
+    return stable_hash(
+        [row.get("instruction", ""), row.get("input", ""), row.get("output", "")]
+    )
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return str(value).strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scan-dir",
+        default=os.environ.get("SCAN_OUTPUT_DIR", "data/deep_scan"),
+        help="Directory containing deep scan outputs",
+    )
+    parser.add_argument(
+        "--final-dir",
+        default=os.environ.get("FINAL_OUTPUT_DIR", "data/final"),
+        help="Directory that will receive train/val splits",
+    )
+    parser.add_argument(
+        "--ratios",
+        default=os.environ.get("DATASET_RATIOS", "frca:0.50,agent:0.40,repo:0.10"),
+        help="Comma-delimited sampling ratios, e.g. frca:0.5,agent:0.4,repo:0.1",
+    )
+    parser.add_argument(
+        "--val-pct",
+        type=float,
+        default=float(os.environ.get("DATASET_VAL_PCT", 0.06)),
+        help="Validation split fraction expressed as a decimal",
+    )
+    parser.add_argument(
+        "--strict-qc",
+        action=argparse.BooleanOptionalAction,
+        default=_env_bool("DATASET_STRICT_QC", True),
+        help="Require fr-CA QC flag for inclusion in repo/frca buckets",
+    )
+    parser.add_argument(
+        "--seed",
+        default=(
+            os.environ.get("DATASET_SEED")
+            or os.environ.get("GITHUB_RUN_ID")
+            or os.environ.get("GITHUB_SHA")
+            or "42"
+        ),
+        help="Random seed for deterministic sampling",
+    )
+    return parser.parse_args(argv)
+
+
+def assemble_dataset(
+    scan_dir: Path,
+    final_dir: Path,
+    *,
+    ratios_raw: str,
+    val_pct: float,
+    strict_qc: bool,
+    seed_value: str | int,
+) -> dict:
+    try:
+        random.seed(int(seed_value))
+    except ValueError:
+        random.seed(seed_value)
+
+    if not scan_dir.exists():
+        raise SystemExit(f"Scan directory {scan_dir} not found")
+    final_dir.mkdir(parents=True, exist_ok=True)
+
+    ratios = _parse_ratios(ratios_raw)
+
+    if val_pct < 0:
+        val_pct = 0.0
+    elif val_pct > 1:
+        val_pct = 1.0
+
+    sft_path = scan_dir / "sft_dataset.jsonl"
+    agent_path = scan_dir / "agent_handoff_dataset.jsonl"
+    if not sft_path.exists() or not agent_path.exists():
+        raise SystemExit("Deep scan outputs missing required dataset files")
+
+    sft_records: list[tuple[dict, bool]] = []
+    for record in _load_jsonl(sft_path):
+        parsed = _normalise(record)
+        if not parsed:
+            continue
+        qc_flag = bool(record.get("_meta", {}).get("qc_fr_ca", False))
+        sft_records.append((parsed, qc_flag))
+
+    buckets: dict[str, list[dict]] = {"frca": [], "agent": [], "repo": []}
+    for parsed, qc_flag in sft_records:
+        if qc_flag or not strict_qc:
+            buckets["frca"].append(parsed)
+        if qc_flag or not strict_qc:
+            buckets["repo"].append(parsed)
+
+    for record in _load_jsonl(agent_path):
+        parsed = _normalise(record)
+        if not parsed:
+            continue
+        buckets["agent"].append(parsed)
+
+    record_sources: dict[str, set[str]] = {}
+    all_records: list[dict] = []
+
+    for bucket_name, records in buckets.items():
+        deduped: list[dict] = []
+        seen: set[str] = set()
+        for row in records:
+            row_hash = _hash_row(row)
+            if row_hash in seen:
+                continue
+            seen.add(row_hash)
+            deduped.append(row)
+            record_sources.setdefault(row_hash, set()).add(bucket_name)
+        buckets[bucket_name] = deduped
+        all_records.extend(deduped)
+
+    if not all_records:
+        raise SystemExit("No qualifying records available for dataset assembly")
+
+    unique_total = len({_hash_row(row) for row in all_records})
+    source_counts = {key: len(value) for key, value in buckets.items()}
+    requested_total = max(unique_total, 1)
+
+    mixed: list[dict] = []
+    selected_ids: set[str] = set()
+    selected_breakdown: dict[str, int] = {"frca": 0, "agent": 0, "repo": 0}
+
+    for key in ("frca", "agent", "repo"):
+        records = buckets.get(key, [])
+        if not records:
+            continue
+        random.shuffle(records)
+        target = int(round(ratios.get(key, 0.0) * requested_total))
+        if ratios.get(key, 0.0) > 0 and target == 0:
+            target = 1
+        target = min(target, len(records))
+
+        taken = 0
+        for row in records:
+            row_hash = _hash_row(row)
+            if row_hash in selected_ids:
+                continue
+            mixed.append(row)
+            selected_ids.add(row_hash)
+            selected_breakdown[key] = selected_breakdown.get(key, 0) + 1
+            taken += 1
+            if taken >= target:
+                break
+
+    min_required = min(unique_total, requested_total)
+    if len(mixed) < min_required:
+        pool = all_records.copy()
+        random.shuffle(pool)
+        for row in pool:
+            if len(mixed) >= min_required:
+                break
+            row_hash = _hash_row(row)
+            if row_hash in selected_ids:
+                continue
+            mixed.append(row)
+            selected_ids.add(row_hash)
+            origins = sorted(record_sources.get(row_hash, {"repo"}))
+            origin = origins[0] if origins else "repo"
+            selected_breakdown[origin] = selected_breakdown.get(origin, 0) + 1
+
+    random.shuffle(mixed)
+
+    val_count = int(len(mixed) * val_pct)
+    validation = mixed[:val_count]
+    training = mixed[val_count:]
+
+    datasets = {
+        final_dir / "train.jsonl": training,
+        final_dir / "val.jsonl": validation,
+    }
+
+    for path, records in datasets.items():
+        with path.open("w", encoding="utf-8") as handle:
+            for row in records:
+                handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    generated_at = dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
+    summary = {
+        "generated_at": generated_at.replace("+00:00", "Z"),
+        "commit": os.environ.get("GITHUB_SHA"),
+        "requested_ratios": ratios,
+        "strict_qc": strict_qc,
+        "validation_fraction": val_pct,
+        "train_records": len(training),
+        "validation_records": len(validation),
+        "total_records": len(mixed),
+        "source_counts": source_counts,
+        "selected_counts": selected_breakdown,
+        "actual_ratios": {
+            key: (selected_breakdown.get(key, 0) / len(mixed) if mixed else 0.0)
+            for key in sorted(selected_breakdown)
+        },
+    }
+
+    summary_path = final_dir / "dataset_summary.json"
+    summary_path.write_text(
+        json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    return summary
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    args = _parse_args(argv)
+    summary = assemble_dataset(
+        Path(args.scan_dir).resolve(),
+        Path(args.final_dir).resolve(),
+        ratios_raw=args.ratios,
+        val_pct=args.val_pct,
+        strict_qc=args.strict_qc,
+        seed_value=args.seed,
+    )
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/monGARS_deep_scan/publish_summary.py
+++ b/tools/monGARS_deep_scan/publish_summary.py
@@ -1,0 +1,71 @@
+"""Render the dataset summary markdown for the GitHub Actions job summary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+
+def build_markdown(summary: dict) -> str:
+    lines = [
+        "# Québec-French dataset build",
+        "",
+        f"* Total records: {summary['total_records']}",
+        f"* Train records: {summary['train_records']}",
+        f"* Validation records: {summary['validation_records']}",
+        f"* Strict QC: {summary['strict_qc']}",
+        "",
+        "## Source buckets",
+    ]
+
+    for key, value in summary.get("source_counts", {}).items():
+        lines.append(f"- {key}: {value}")
+
+    lines.append("")
+    lines.append("## Requested ratios")
+    for key, value in summary.get("requested_ratios", {}).items():
+        lines.append(f"- {key}: {value}")
+
+    lines.append("")
+    lines.append("## Selected counts")
+    for key, value in summary.get("selected_counts", {}).items():
+        lines.append(f"- {key}: {value}")
+
+    lines.append("")
+    lines.append("## Actual ratios")
+    for key, value in summary.get("actual_ratios", {}).items():
+        lines.append(f"- {key}: {value:.4f}")
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--final-dir",
+        default=os.environ.get("FINAL_OUTPUT_DIR", "data/final"),
+        help="Directory containing dataset_summary.json",
+    )
+    parser.add_argument(
+        "--output",
+        default="summary.md",
+        help="Path for the rendered markdown summary",
+    )
+    args = parser.parse_args()
+
+    final_dir = Path(args.final_dir)
+    summary_path = final_dir / "dataset_summary.json"
+    if not summary_path.exists():
+        raise SystemExit(f"Dataset summary not found at {summary_path}")
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    markdown = build_markdown(summary)
+    output_path = Path(args.output)
+    output_path.write_text(markdown, encoding="utf-8")
+    print(markdown)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add argparse-powered CLI to `build_dataset.py` so scan directories, ratios, and QC flags fall back to sensible defaults when environment variables are absent
- expose an `assemble_dataset` helper that clamps validation fractions, seeds deterministically, and returns the summary payload used for job reporting

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4c40571a4833388dc53443a15089d