### PR TITLE
Add multi-module dataset and training toolchain

### DIFF
--- a/.github/workflows/custom-dataset.yml
+++ b/.github/workflows/custom-dataset.yml
@@ -1,8 +1,8 @@
-name: Build Custom Québec-French Dataset
+name: Build Custom Québec-French Dataset (repo-only)
 
 on:
   push:
-    branches: ['**']
+    branches: ['**']         # run on any branch commit
   workflow_dispatch:
     inputs:
       ratios:
@@ -26,27 +26,20 @@ permissions:
   contents: read
 
 env:
-  PYTHON_VERSION: "3.11"
-  SCAN_OUTPUT_DIR: data/deep_scan
-  FINAL_OUTPUT_DIR: data/final
-  DATASET_RATIOS: ${{ github.event.inputs.ratios || 'frca:0.50,agent:0.40,repo:0.10' }}
-  DATASET_VAL_PCT: ${{ github.event.inputs.val_pct || 0.06 }}
-  DATASET_STRICT_QC: ${{ github.event.inputs.strict_qc || 'true' }}
-  DATASET_RETENTION_DAYS: ${{ github.event.inputs.retention_days || 14 }}
+  PYTHON_VERSION: "3.12"
 
 concurrency:
   group: custom-dataset-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  curate:
-    name: Curate Québec-French dataset
+  scan_and_build:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
+    env:
+      CONFIRM_SCAN: "YES"
+      CONFIRM_DATA_FETCH: "NO"
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -56,58 +49,58 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Cache pip downloads
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ env.PYTHON_VERSION }}-${{ hashFiles('tools/monGARS_deep_scan/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ env.PYTHON_VERSION }}-
-            ${{ runner.os }}-pip-
+      - name: Install OS deps (graphviz for PNG graph)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz
 
-      - name: Install dataset tooling
+      - name: Install minimal Python deps
         run: |
           python -m pip install --upgrade pip
-          pip install -r tools/monGARS_deep_scan/requirements.txt
+          pip install networkx || true
 
-      - name: Execute deep scan pipeline
-        env:
-          PYTHONPATH: .
+      - name: Verify required scripts exist
+        run: |
+          test -f scripts/ultimate_repo_analyzer.py || (echo "Missing scripts/ultimate_repo_analyzer.py" && exit 1)
+          test -f scripts/prepare_dataset.py        || (echo "Missing scripts/prepare_dataset.py" && exit 1)
+
+      - name: Run analyzer (scan repo → mined artifacts)
         run: |
           set -euxo pipefail
-          python -m tools.monGARS_deep_scan.deep_scan \
-            --input . \
-            --out "${SCAN_OUTPUT_DIR}" \
-            --exclude-dir "${SCAN_OUTPUT_DIR},${FINAL_OUTPUT_DIR},.git" \
-            --jobs 4
-          ls "${SCAN_OUTPUT_DIR}"
+          python scripts/ultimate_repo_analyzer.py
+          echo "== Output tree =="
+          find data/ultimate -maxdepth 3 -type f | sort || true
 
-      - name: Build train/validation splits
-        env:
-          PYTHONPATH: .
+      - name: Assemble inputs for dataset builder
         run: |
-          python -m tools.monGARS_deep_scan.build_dataset
+          set -euxo pipefail
+          mkdir -p data/raw
+          cp data/ultimate/processed_repo/sft_repo.jsonl            data/raw/repo_sft.jsonl
+          cp data/ultimate/processed_repo/agent_instruct_repo.jsonl data/raw/agent_handoff.jsonl
+          # Repo-only pipeline: use repo SFT as the FRCA source
+          cp data/ultimate/processed_repo/sft_repo.jsonl            data/raw/frca_repo.jsonl
 
-      - name: Publish dataset summary
-        env:
-          PYTHONPATH: .
+      - name: Build final dataset (train/val)
         run: |
-          python -m tools.monGARS_deep_scan.publish_summary --final-dir "${FINAL_OUTPUT_DIR}" --output summary.md
-          cat summary.md >> "$GITHUB_STEP_SUMMARY"
+          set -euxo pipefail
+          python scripts/prepare_dataset.py             --frca data/raw/frca_repo.jsonl             --agent data/raw/agent_handoff.jsonl             --repo data/raw/repo_sft.jsonl             --outdir data/final             --ratio "${{ inputs.ratios || 'frca:0.50,agent:0.40,repo:0.10' }}"             --val_pct ${{ inputs.val_pct || 0.06 }}             $([ "${{ inputs.strict_qc || true }}" = "true" ] && echo "--strict_qc" || true)
 
-      - name: Upload dataset artefacts
+          echo "== Final counts =="
+          wc -l data/final/train.jsonl || true
+          wc -l data/final/val.jsonl   || true
+
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: custom-quebec-french-dataset
+          name: final-custom-dataset
           path: |
-            ${{ env.SCAN_OUTPUT_DIR }}/sft_dataset.jsonl
-            ${{ env.SCAN_OUTPUT_DIR }}/agent_handoff_dataset.jsonl
-            ${{ env.SCAN_OUTPUT_DIR }}/embeddings_corpus.jsonl
-            ${{ env.SCAN_OUTPUT_DIR }}/provenance.csv
-            ${{ env.SCAN_OUTPUT_DIR }}/report.md
-            ${{ env.SCAN_OUTPUT_DIR }}/logs/**
-            ${{ env.FINAL_OUTPUT_DIR }}/train.jsonl
-            ${{ env.FINAL_OUTPUT_DIR }}/val.jsonl
-            ${{ env.FINAL_OUTPUT_DIR }}/dataset_summary.json
-          retention-days: ${{ env.DATASET_RETENTION_DAYS }}
+            data/ultimate/processed_repo/sft_repo.jsonl
+            data/ultimate/processed_repo/agent_instruct_repo.jsonl
+            data/ultimate/processed_repo/embeddings_repo.jsonl
+            data/ultimate/processed_repo/provenance.csv
+            data/ultimate/interaction_graph.dot
+            data/ultimate/interaction_graph.png
+            data/final/train.jsonl
+            data/final/val.jsonl
+          retention-days: ${{ inputs.retention_days || 14 }}
           if-no-files-found: error

--- a/scripts/build_multimodule_dataset.py
+++ b/scripts/build_multimodule_dataset.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Build a module-tagged multitask dataset from analyzer artifacts."""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import random
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, Sequence
+
+RANDOM_SEED = 42
+MIN_LEN = 12
+DEFAULT_VAL_PCT = 0.06
+
+QC_TERMS = {
+    "dépanneur",
+    "poutine",
+    "cégep",
+    "tuque",
+    "magasiner",
+    "char",
+    "chum",
+    "blonde",
+    "icitte",
+    "ben là",
+    "patente",
+    "tabarnak",
+}
+
+MODULE_RULES: Sequence[tuple[str, str]] = (
+    (r"(core/hippocampus|hippocampus)", "Hippocampus"),
+    (r"(core/conversation|cortex|bouche)", "Cortex"),
+    (r"(evolution_engine|sommeil|self_training)", "Evolution"),
+    (r"(neuro_symbolic|reasoner|tronc)", "NeuroSymbolic"),
+    (r"(rag|retriev|vector|embedding)", "RAG"),
+    (r"(api/|fastapi|server|routes|ws)", "API"),
+    (r"(webapp|django|frontend|ui|console)", "WebApp"),
+    (r"(ray|serve|distributed|actors|replica)", "Distributed"),
+    (r"(scripts/|ops/|infra/|docker|k8s|compose)", "Ops"),
+)
+
+
+@dataclass(frozen=True)
+class Record:
+    module: str
+    instruction: str
+    input: str
+    output: str
+    record_id: str
+    source_paths: Sequence[str]
+
+    def to_payload(self) -> Dict[str, str]:
+        return {
+            "module": self.module,
+            "instruction": self.instruction,
+            "input": self.input,
+            "output": self.output,
+        }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build a module-tagged multitask dataset using artifacts produced by "
+            "scripts/ultimate_repo_analyzer.py"
+        )
+    )
+    parser.add_argument(
+        "--repo_sft",
+        default="data/ultimate/processed_repo/sft_repo.jsonl",
+        help="Path to the repository SFT samples",
+    )
+    parser.add_argument(
+        "--agent_sft",
+        default="data/ultimate/processed_repo/agent_instruct_repo.jsonl",
+        help="Path to the agent hand-off style samples",
+    )
+    parser.add_argument(
+        "--provenance",
+        default="data/ultimate/processed_repo/provenance.csv",
+        help="Provenance CSV emitted by the analyzer",
+    )
+    parser.add_argument(
+        "--outdir",
+        default="data/multimodule",
+        help="Directory to write train/val JSONL outputs",
+    )
+    parser.add_argument(
+        "--val_pct",
+        type=float,
+        default=DEFAULT_VAL_PCT,
+        help="Validation split ratio (0-1)",
+    )
+    parser.add_argument(
+        "--strict_qc",
+        action="store_true",
+        help="Filter repo/agent samples for Québec French keywords",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=RANDOM_SEED,
+        help="Random seed controlling shuffling",
+    )
+    return parser.parse_args(argv)
+
+
+def load_jsonl(path: Path) -> Iterator[dict]:
+    if not path.exists():
+        return
+    with path.open("r", encoding="utf-8") as handle:
+        for raw in handle:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                yield json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+
+
+def is_valid_text(value: str) -> bool:
+    return isinstance(value, str) and len(value.strip()) >= MIN_LEN
+
+
+def clamp_output(value: str) -> str:
+    return value.strip()
+
+
+def normalize_sft(record: dict) -> dict | None:
+    if not isinstance(record, dict):
+        return None
+    instruction = (record.get("instruction") or "").strip()
+    input_text = (record.get("input") or "").strip()
+    output = record.get("output")
+    if not isinstance(output, str):
+        output = json.dumps(
+            output,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+    output = clamp_output(output)
+    if not (is_valid_text(instruction) and is_valid_text(output)):
+        return None
+    return {
+        "instruction": instruction,
+        "input": input_text,
+        "output": output,
+    }
+
+
+def qc_ok(text: str) -> bool:
+    lowered = text.lower()
+    return any(term in lowered for term in QC_TERMS)
+
+
+def choose_module(source_file: str) -> str:
+    lowered = source_file.lower()
+    for pattern, module_name in MODULE_RULES:
+        if re.search(pattern, lowered):
+            return module_name
+    parts = [part for part in lowered.split("/") if part and part != "."]
+    if parts:
+        return parts[0].capitalize()
+    return "General"
+
+
+def compute_record_id(payload: dict) -> str:
+    serialized = json.dumps(payload, ensure_ascii=False)
+    return hashlib.sha1(serialized.encode("utf-8")).hexdigest()[:12]
+
+
+def load_provenance(path: Path) -> dict[str, list[str]]:
+    mapping: dict[str, list[str]] = defaultdict(list)
+    if not path.exists():
+        return mapping
+    with path.open("r", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            record_id = (row.get("record_id") or "").strip()
+            source_file = (row.get("source_file") or "").strip()
+            if record_id and source_file:
+                mapping[record_id].append(source_file)
+    return mapping
+
+
+def derive_module(candidate_paths: Sequence[str], default_hint: str) -> str:
+    if not candidate_paths:
+        return default_hint
+    counter: Counter[str] = Counter()
+    for path in candidate_paths:
+        counter[choose_module(path)] += 1
+    most_common = counter.most_common(1)
+    if most_common:
+        return most_common[0][0]
+    return default_hint
+
+
+def build_records(
+    path: Path,
+    provenance: dict[str, list[str]],
+    default_module: str,
+    enforce_qc: bool,
+) -> list[Record]:
+    records: list[Record] = []
+    seen: set[str] = set()
+    for payload in load_jsonl(path):
+        normalized = normalize_sft(payload)
+        if not normalized:
+            continue
+        text_for_qc = " ".join((normalized["instruction"], normalized["output"]))
+        if enforce_qc and not qc_ok(text_for_qc):
+            continue
+        record_payload = {
+            "instruction": normalized["instruction"],
+            "input": normalized["input"],
+            "output": normalized["output"],
+        }
+        record_id = compute_record_id(record_payload)
+        if record_id in seen:
+            continue
+        seen.add(record_id)
+        module = derive_module(provenance.get(record_id, ()), default_module)
+        tagged_instruction = f"[MOD={module}] {normalized['instruction']}"
+        records.append(
+            Record(
+                module=module,
+                instruction=tagged_instruction,
+                input=normalized["input"],
+                output=normalized["output"],
+                record_id=record_id,
+                source_paths=provenance.get(record_id, ()),
+            )
+        )
+    return records
+
+
+def split_train_val(
+    records: Sequence[Record], val_pct: float, seed: int
+) -> tuple[list[Record], list[Record]]:
+    if not 0 <= val_pct < 1:
+        raise ValueError("val_pct must be within [0, 1)")
+    random.Random(seed).shuffle(records := list(records))
+    val_size = int(len(records) * val_pct)
+    val_records = list(records[:val_size])
+    train_records = list(records[val_size:])
+    return train_records, val_records
+
+
+def write_jsonl(path: Path, records: Iterable[Record]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record.to_payload(), ensure_ascii=False) + "\n")
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = parse_args(argv)
+    random.seed(args.seed)
+
+    repo_path = Path(args.repo_sft)
+    agent_path = Path(args.agent_sft)
+    provenance_path = Path(args.provenance)
+    out_dir = Path(args.outdir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    provenance = load_provenance(provenance_path)
+
+    repo_records = build_records(
+        repo_path,
+        provenance,
+        default_module="General",
+        enforce_qc=args.strict_qc,
+    )
+    agent_records = build_records(
+        agent_path,
+        provenance,
+        default_module="API",
+        enforce_qc=args.strict_qc,
+    )
+
+    combined = repo_records + agent_records
+    if not combined:
+        raise SystemExit(
+            "No eligible records found. Run the analyzer first or adjust filters."
+        )
+
+    train_records, val_records = split_train_val(combined, args.val_pct, args.seed)
+
+    write_jsonl(out_dir / "train.jsonl", train_records)
+    write_jsonl(out_dir / "val.jsonl", val_records)
+
+    def describe(records: Sequence[Record]) -> str:
+        module_counts = Counter(rec.module for rec in records)
+        return ", ".join(
+            f"{module}:{count}" for module, count in module_counts.most_common()
+        )
+
+    print("[DONE] Multi-module dataset built")
+    print(f"       output_dir={out_dir}")
+    print(
+        "       summary="
+        f"train={len(train_records)} ({describe(train_records)}) "
+        f"val={len(val_records)} ({describe(val_records)})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_llm2vec_wrapper.py
+++ b/scripts/export_llm2vec_wrapper.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Export a lightweight LLM2Vec-style wrapper for the fine-tuned model."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+WRAPPER_PY = '''# llm2vec_wrapper.py
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+try:
+    from peft import PeftModel
+except Exception:  # pragma: no cover - PEFT may be unavailable on CPU-only setups
+    PeftModel = None
+
+
+class LLM2Vec:
+    """Utility class that exposes :meth:`generate` and :meth:`embed` helpers."""
+
+    def __init__(
+        self,
+        base_dir: str | Path,
+        prefer_merged: bool = False,
+        device: str | None = None,
+        load_in_4bit: bool = True,
+    ) -> None:
+        self.base_dir = Path(base_dir)
+        if not self.base_dir.exists():
+            raise FileNotFoundError(f"Model directory {self.base_dir} does not exist")
+
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        tokenizer_dir = self.base_dir / "tokenizer"
+        if not tokenizer_dir.exists():
+            raise FileNotFoundError("Tokenizer directory not found. Run training first.")
+        self.tokenizer = AutoTokenizer.from_pretrained(str(tokenizer_dir), use_fast=True)
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+
+        if prefer_merged and (self.base_dir / "merged").exists():
+            model_dir = self.base_dir / "merged"
+            self.model = AutoModelForCausalLM.from_pretrained(
+                str(model_dir),
+                torch_dtype=torch.bfloat16 if torch.cuda.is_available() else torch.float32,
+                device_map="auto",
+            )
+        else:
+            adapter_dir = self.base_dir / "lora_adapter"
+            if not adapter_dir.exists():
+                raise FileNotFoundError("LoRA adapter not found; run training before exporting the wrapper.")
+            base_model = "cognitivecomputations/Dolphin3.0-Llama3.1-8B"
+            self.model = AutoModelForCausalLM.from_pretrained(
+                base_model,
+                load_in_4bit=load_in_4bit,
+                device_map="auto",
+                trust_remote_code=True,
+            )
+            if PeftModel is None:
+                raise RuntimeError("peft is required to load the LoRA adapter")
+            self.model = PeftModel.from_pretrained(self.model, str(adapter_dir))
+
+        self.model.to(self.device)
+        self.model.eval()
+
+    @torch.inference_mode()
+    def generate(
+        self,
+        prompt: str,
+        *,
+        max_new_tokens: int = 512,
+        temperature: float = 0.2,
+        top_p: float = 0.9,
+    ) -> str:
+        inputs = self.tokenizer(prompt, return_tensors="pt").to(self.device)
+        outputs = self.model.generate(
+            **inputs,
+            do_sample=temperature > 0,
+            temperature=temperature,
+            top_p=top_p,
+            max_new_tokens=max_new_tokens,
+            pad_token_id=self.tokenizer.eos_token_id,
+            eos_token_id=self.tokenizer.eos_token_id,
+        )
+        return self.tokenizer.decode(outputs[0], skip_special_tokens=True)
+
+    @torch.inference_mode()
+    def embed(self, texts: str | Iterable[str]):
+        if isinstance(texts, str):
+            batch_texts = [texts]
+        else:
+            batch_texts = list(texts)
+        if not batch_texts:
+            raise ValueError("texts must not be empty")
+        encoded = self.tokenizer(
+            batch_texts,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+        ).to(self.device)
+        model = self.model
+        outputs = model(
+            **encoded,
+            output_hidden_states=True,
+            use_cache=False,
+        )
+        last_hidden = outputs.hidden_states[-1]
+        mask = encoded["attention_mask"].unsqueeze(-1)
+        summed = (last_hidden * mask).sum(dim=1)
+        counts = mask.sum(dim=1).clamp(min=1)
+        embeddings = summed / counts
+        return embeddings.cpu()
+'''
+
+README_MD = """# LLM2Vec Wrapper (monGARS)
+
+This wrapper exposes:
+
+- `LLM2Vec.generate(prompt, ...)` → text generation
+- `LLM2Vec.embed(texts)` → embeddings via mean-pooled hidden states
+
+## Quickstart
+
+```python
+from llm2vec_wrapper import LLM2Vec
+wrapper = LLM2Vec(base_dir="..", prefer_merged=False)
+print(wrapper.generate("Bonjour [MOD=Hippocampus] Rappelle-moi le dernier contexte."))
+vector = wrapper.embed("Allô, ça va?")
+print(vector.shape)
+```
+"""
+
+
+CONFIG_JSON = {
+    "name": "monGARS-LLM2Vec",
+    "backbone": "Dolphin3.0-Llama3.1-8B",
+    "adapter": "lora_adapter",
+    "supports_merged": True,
+    "embed_strategy": "last_hidden_mean_pool",
+    "prompt_tag": "[MOD=<Module>]",
+}
+
+
+def write_wrapper(model_dir: Path) -> None:
+    wrap_dir = model_dir / "wrapper"
+    wrap_dir.mkdir(parents=True, exist_ok=True)
+
+    (wrap_dir / "llm2vec_wrapper.py").write_text(WRAPPER_PY, encoding="utf-8")
+    (wrap_dir / "README.md").write_text(README_MD, encoding="utf-8")
+    (wrap_dir / "config.json").write_text(
+        json.dumps(CONFIG_JSON, indent=2),
+        encoding="utf-8",
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model_dir",
+        default="out/monGARS_dolphin_finetuned",
+        help="Directory containing the fine-tuned model artifacts",
+    )
+    args = parser.parse_args()
+
+    model_dir = Path(args.model_dir)
+    if not model_dir.exists():
+        raise SystemExit(
+            f"Model directory {model_dir} does not exist. Train a model first."
+        )
+
+    write_wrapper(model_dir)
+    print(f"[DONE] Wrapper exported to {model_dir / 'wrapper'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prepare_dataset.py
+++ b/scripts/prepare_dataset.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import json
+import random
+from pathlib import Path
+
+QC_TERMS = [
+    "dépanneur",
+    "poutine",
+    "cégep",
+    "tuque",
+    "magasiner",
+    "char",
+    "chum",
+    "blonde",
+    "icitte",
+    "ben là",
+    "patente",
+    "tabarnak",
+]
+MIN_LEN = 12
+MAX_OUT_CHARS = 3000
+
+
+def sha(s):
+    return hashlib.sha1(s.encode("utf-8")).hexdigest()
+
+
+def is_qc(t):
+    t = t.lower()
+    return any(w in t for w in QC_TERMS)
+
+
+def clamp(s, n):
+    s = s.strip()
+    return s if len(s) <= n else s[:n].rsplit(" ", 1)[0] + " …"
+
+
+def load_jsonl(p):
+    p = Path(p)
+    if not p.exists():
+        return []
+    with p.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                yield json.loads(line)
+
+
+def norm_sft(j):
+    if not isinstance(j, dict) or "instruction" not in j or "output" not in j:
+        return None
+    instr = (j.get("instruction") or "").strip()
+    inp = (j.get("input") or "").strip()
+    out = j.get("output")
+    if not isinstance(out, str):
+        out = json.dumps(out, ensure_ascii=False, separators=(",", ":"))
+    out = clamp(out, MAX_OUT_CHARS)
+    if len(instr) < MIN_LEN or len(out) < MIN_LEN:
+        return None
+    return {"instruction": instr, "input": inp, "output": out}
+
+
+def dedupe(xs, key=lambda x: x):
+    s = set()
+    o = []
+    for it in xs:
+        k = key(it)
+        if k in s:
+            continue
+        s.add(k)
+        o.append(it)
+    return o
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--frca", default="data/raw/repo_sft.jsonl")
+    ap.add_argument("--agent", default="data/raw/agent_handoff.jsonl")
+    ap.add_argument("--repo", default="data/raw/repo_sft.jsonl")
+    ap.add_argument("--outdir", default="data/final")
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--ratio", default="frca:0.50,agent:0.40,repo:0.10")
+    ap.add_argument("--val_pct", type=float, default=0.06)
+    ap.add_argument("--strict_qc", action="store_true")
+    a = ap.parse_args()
+    random.seed(a.seed)
+    ratios = {}
+    for part in a.ratio.split(","):
+        k, v = part.split(":")
+        ratios[k.strip()] = float(v)
+    sources = {"frca": a.frca, "agent": a.agent, "repo": a.repo}
+    buckets = {}
+    for name, path in sources.items():
+        rows = []
+        for j in load_jsonl(path):
+            s = norm_sft(j)
+            if not s:
+                continue
+            if a.strict_qc and name != "agent":
+                if not is_qc(s["instruction"] + " " + s["output"]):
+                    continue
+            rows.append(s)
+        rows = dedupe(
+            rows, key=lambda x: sha((x["instruction"] + "|" + x["input"]).lower())
+        )
+        buckets[name] = rows
+        print(f"[LOAD] {name}: {len(rows)}")
+    total = sum(len(v) for v in buckets.values())
+    if total == 0:
+        raise SystemExit("No data")
+    targets = {k: int(ratios.get(k, 0) * total) for k in buckets}
+    mixed = []
+    for k, arr in buckets.items():
+        random.shuffle(arr)
+        take = min(len(arr), max(0, targets.get(k, 0)))
+        mixed.extend(arr[:take])
+    if len(mixed) < total:
+        pool = [x for xs in buckets.values() for x in xs]
+        random.shuffle(pool)
+        for x in pool:
+            if len(mixed) >= total:
+                break
+            mixed.append(x)
+    random.shuffle(mixed)
+    n_val = int(len(mixed) * a.val_pct)
+    val = mixed[:n_val]
+    train = mixed[n_val:]
+    out = Path(a.outdir)
+    out.mkdir(parents=True, exist_ok=True)
+    with (out / "train.jsonl").open("w", encoding="utf-8") as f:
+        for r in train:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    with (out / "val.jsonl").open("w", encoding="utf-8") as f:
+        for r in val:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    print(f"[DONE] train={len(train)} val={len(val)} strict_qc={a.strict_qc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_monGARS_unsloth.py
+++ b/scripts/train_monGARS_unsloth.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Fine-tune Dolphin (Llama3.1-8B) with Unsloth on the multi-module dataset."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+from datasets import load_dataset
+from transformers import (
+    AutoTokenizer,
+    DataCollatorForLanguageModeling,
+    Trainer,
+    TrainingArguments,
+)
+from unsloth import FastLanguageModel
+
+BASE_MODEL = "cognitivecomputations/Dolphin3.0-Llama3.1-8B"
+SYSTEM_PROMPT = (
+    "You are monGARS internal assistant. Follow the module contract indicated by "
+    "tags like [MOD=...]."
+)
+
+
+def load_jsonl_as_dataset(dataset_dir: Path):
+    data_files: dict[str, str] = {}
+    train_file = dataset_dir / "train.jsonl"
+    val_file = dataset_dir / "val.jsonl"
+    if train_file.exists():
+        data_files["train"] = str(train_file)
+    if val_file.exists():
+        data_files["validation"] = str(val_file)
+    if not data_files:
+        raise SystemExit(f"No dataset files found in {dataset_dir}.")
+    return load_dataset("json", data_files=data_files)
+
+
+def build_prompt(example: dict) -> dict[str, str]:
+    instruction = example.get("instruction", "")
+    input_section = example.get("input", "")
+    if input_section:
+        user_block = f"{instruction}\n\n[INPUT]\n{input_section}"
+    else:
+        user_block = instruction
+    assistant_output = example.get("output", "")
+    prompt = (
+        "<|im_start|>system\n"
+        f"{SYSTEM_PROMPT}<|im_end|>\n"
+        "<|im_start|>user\n"
+        f"{user_block}<|im_end|>\n"
+        "<|im_start|>assistant\n"
+    )
+    return {"text": prompt + assistant_output + "<|im_end|>\n"}
+
+
+def tokenize_batch(tokenizer: AutoTokenizer, cutoff_len: int, batch: dict) -> dict:
+    return tokenizer(
+        batch["text"],
+        truncation=True,
+        max_length=cutoff_len,
+    )
+
+
+def configure_tokenizer(tokenizer: AutoTokenizer) -> None:
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    if tokenizer.pad_token_id is None:
+        tokenizer.pad_token_id = tokenizer.eos_token_id
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data_dir", default="data/multimodule")
+    parser.add_argument("--out_dir", default="out/monGARS_dolphin_finetuned")
+    parser.add_argument("--lr", type=float, default=1.5e-4)
+    parser.add_argument("--epochs", type=int, default=2)
+    parser.add_argument("--per_device_bs", type=int, default=1)
+    parser.add_argument("--grad_accum", type=int, default=8)
+    parser.add_argument("--cutoff_len", type=int, default=4096)
+    parser.add_argument("--lora_r", type=int, default=8)
+    parser.add_argument("--lora_alpha", type=int, default=16)
+    parser.add_argument("--lora_dropout", type=float, default=0.05)
+    parser.add_argument(
+        "--merge_and_save",
+        action="store_true",
+        help="Merge LoRA adapter back into base weights for full-weight export.",
+    )
+    args = parser.parse_args()
+
+    data_dir = Path(args.data_dir)
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    dataset = load_jsonl_as_dataset(data_dir)
+
+    model, tokenizer = FastLanguageModel.from_pretrained(
+        model_name=BASE_MODEL,
+        max_seq_length=args.cutoff_len,
+        load_in_4bit=True,
+        dtype=None,
+        device_map="auto",
+        trust_remote_code=True,
+    )
+
+    configure_tokenizer(tokenizer)
+
+    model = FastLanguageModel.get_peft_model(
+        model,
+        r=args.lora_r,
+        lora_alpha=args.lora_alpha,
+        lora_dropout=args.lora_dropout,
+        target_modules="all-linear",
+        bias="none",
+        use_gradient_checkpointing=True,
+    )
+
+    formatted_dataset = dataset.map(build_prompt)
+    train_columns = formatted_dataset["train"].column_names
+    columns_to_remove = [col for col in train_columns if col != "text"]
+    tokenized_dataset = formatted_dataset.map(
+        lambda batch: tokenize_batch(tokenizer, args.cutoff_len, batch),
+        batched=True,
+        remove_columns=columns_to_remove,
+    )
+
+    collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
+
+    supports_bf16 = torch.cuda.is_available() and torch.cuda.is_bf16_supported()
+    use_fp16 = torch.cuda.is_available() and not supports_bf16
+
+    training_args = TrainingArguments(
+        output_dir=str(out_dir),
+        per_device_train_batch_size=args.per_device_bs,
+        per_device_eval_batch_size=1,
+        gradient_accumulation_steps=args.grad_accum,
+        learning_rate=args.lr,
+        num_train_epochs=args.epochs,
+        logging_steps=10,
+        evaluation_strategy="steps" if "validation" in tokenized_dataset else "no",
+        eval_steps=100,
+        save_steps=300,
+        save_total_limit=2,
+        bf16=supports_bf16,
+        fp16=use_fp16,
+        report_to="none",
+    )
+
+    trainer = Trainer(
+        model=model,
+        tokenizer=tokenizer,
+        args=training_args,
+        data_collator=collator,
+        train_dataset=tokenized_dataset["train"],
+        eval_dataset=tokenized_dataset.get("validation"),
+    )
+
+    trainer.train()
+
+    model.save_pretrained(str(out_dir / "lora_adapter"))
+    tokenizer.save_pretrained(str(out_dir / "tokenizer"))
+
+    if args.merge_and_save:
+        merged_model = FastLanguageModel.merge_and_unload(model)
+        merged_path = out_dir / "merged"
+        merged_path.mkdir(parents=True, exist_ok=True)
+        merged_model.save_pretrained(str(merged_path))
+        tokenizer.save_pretrained(str(merged_path))
+
+    print(f"[DONE] Saved artifacts to {out_dir}")
+    print("  - lora_adapter/")
+    if args.merge_and_save:
+        print("  - merged/")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ultimate_repo_analyzer.py
+++ b/scripts/ultimate_repo_analyzer.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+# Lite repo analyzer: mines SFT, agent-handoff, embeddings, and writes a DOT graph.
+import csv
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+OUT = Path("data/ultimate")
+RAW = OUT / "raw_texts"
+PROC = OUT / "processed_repo"
+for d in (RAW, PROC):
+    d.mkdir(parents=True, exist_ok=True)
+SFT = PROC / "sft_repo.jsonl"
+AGT = PROC / "agent_instruct_repo.jsonl"
+EMB = PROC / "embeddings_repo.jsonl"
+PROV = PROC / "provenance.csv"
+DOT = OUT / "interaction_graph.dot"
+PNG = OUT / "interaction_graph.png"
+
+if os.environ.get("CONFIRM_SCAN", "") != "YES":
+    print("ABORT: set CONFIRM_SCAN=YES")
+    sys.exit(2)
+
+EXTS = {
+    "md",
+    "rst",
+    "txt",
+    "json",
+    "yml",
+    "yaml",
+    "py",
+    "sh",
+    "cfg",
+    "ini",
+    "toml",
+    "sql",
+    "js",
+    "ts",
+}
+
+
+def is_text(p):
+    try:
+        with p.open("rb") as f:
+            return b"\x00" not in f.read(4096)
+    except:
+        return False
+
+
+root = Path(".").resolve()
+files = []
+if (root / ".git").exists():
+    try:
+        out = subprocess.check_output(["git", "ls-files"], text=True)
+        for rel in out.splitlines():
+            p = root / rel
+            if p.suffix.lstrip(".") in EXTS and p.exists() and is_text(p):
+                dst = RAW / p.relative_to(root)
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                dst.write_bytes(p.read_bytes())
+                files.append(dst)
+    except:
+        pass
+if not files:
+    for p in root.rglob("*"):
+        if (
+            p.is_file()
+            and p.suffix.lstrip(".") in EXTS
+            and is_text(p)
+            and ".git" not in p.parts
+        ):
+            dst = RAW / p.relative_to(root)
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_bytes(p.read_bytes())
+            files.append(dst)
+
+DIALOG = re.compile(
+    r"^\s*(User|Utilisateur|Client|Moi|Tu|Vous|Assistant|System|Bot|Agent)\s*[:\-—]\s*(.+)",
+    re.I,
+)
+PIPE = re.compile(
+    r"(workflow|pipeline|job|stage|steps|run:|script:|entrypoint|commands?)", re.I
+)
+JSONL = re.compile(r'^\s*[\{\[]\s*".*')
+
+
+def sha(s):
+    return hashlib.sha1(s.encode("utf-8")).hexdigest()[:12]
+
+
+sft_rows = []
+ag_rows = []
+emb_rows = []
+prov = []
+
+for f in files:
+    try:
+        text = f.read_text(encoding="utf-8", errors="ignore")
+    except:
+        continue
+    lines = text.splitlines()
+
+    # dialogues → SFT
+    cur = []
+    for i, ln in enumerate(lines):
+        if DIALOG.match(ln):
+            cur.append((i + 1, ln.strip()))
+        else:
+            if cur:
+                instr = None
+                outs = []
+                for _, l in cur:
+                    m = DIALOG.match(l)
+                    who = m.group(1).lower()
+                    content = m.group(2).strip()
+                    if instr is None and re.match(
+                        r"(user|utilisateur|client|moi|tu|vous)", who, re.I
+                    ):
+                        instr = content
+                    else:
+                        outs.append(content)
+                if instr and outs:
+                    rec = {"instruction": instr, "input": "", "output": " ".join(outs)}
+                    sft_rows.append(rec)
+                    prov.append(
+                        [
+                            sha(json.dumps(rec, ensure_ascii=False)),
+                            str(f.relative_to(RAW)),
+                            cur[0][0],
+                            cur[-1][0],
+                            "sft_dialog",
+                            "auto",
+                        ]
+                    )
+                cur = []
+    if cur:
+        instr = None
+        outs = []
+        for _, l in cur:
+            m = DIALOG.match(l)
+            who = m.group(1).lower()
+            content = m.group(2).strip()
+            if instr is None and re.match(
+                r"(user|utilisateur|client|moi|tu|vous)", who, re.I
+            ):
+                instr = content
+            else:
+                outs.append(content)
+        if instr and outs:
+            rec = {"instruction": instr, "input": "", "output": " ".join(outs)}
+            sft_rows.append(rec)
+            prov.append(
+                [
+                    sha(json.dumps(rec, ensure_ascii=False)),
+                    str(f.relative_to(RAW)),
+                    cur[0][0],
+                    cur[-1][0],
+                    "sft_dialog",
+                    "auto",
+                ]
+            )
+
+    # pipeline fragments → agent samples
+    curp = []
+    for i, ln in enumerate(lines):
+        if (
+            PIPE.search(ln)
+            or JSONL.match(ln)
+            or ln.strip().startswith(("steps:", "- run:", "script:"))
+        ):
+            curp.append((i + 1, ln))
+        else:
+            if curp:
+                block = "\n".join(l for _, l in curp)
+                rec = {
+                    "instruction": "Interpret this pipeline fragment and return structured steps as JSON. Preserve tool names and env vars.",
+                    "input": block,
+                    "output": {"steps": [], "notes": "AUTO"},
+                }
+                ag_rows.append(rec)
+                prov.append(
+                    [
+                        sha(json.dumps(rec, ensure_ascii=False)),
+                        str(f.relative_to(RAW)),
+                        curp[0][0],
+                        curp[-1][0],
+                        "agent_pipeline",
+                        "auto",
+                    ]
+                )
+                curp = []
+    if curp:
+        block = "\n".join(l for _, l in curp)
+        rec = {
+            "instruction": "Interpret this pipeline fragment and return structured steps as JSON. Preserve tool names and env vars.",
+            "input": block,
+            "output": {"steps": [], "notes": "AUTO"},
+        }
+        ag_rows.append(rec)
+        prov.append(
+            [
+                sha(json.dumps(rec, ensure_ascii=False)),
+                str(f.relative_to(RAW)),
+                curp[0][0],
+                curp[-1][0],
+                "agent_pipeline",
+                "auto",
+            ]
+        )
+
+    # paragraphs → embeddings
+    para = []
+    start = 1
+    for i, ln in enumerate(lines):
+        if ln.strip() == "":
+            if para:
+                t = "\n".join(para).strip()
+                if len(t) >= 40:
+                    emb_rows.append({"text": t, "source": str(f.relative_to(RAW))})
+                    prov.append(
+                        [
+                            sha(t),
+                            str(f.relative_to(RAW)),
+                            start,
+                            i,
+                            "embedding_paragraph",
+                            "auto",
+                        ]
+                    )
+                para = []
+                start = i + 2
+        else:
+            para.append(ln)
+    if para:
+        t = "\n".join(para).strip()
+        if len(t) >= 40:
+            emb_rows.append({"text": t, "source": str(f.relative_to(RAW))})
+            prov.append(
+                [
+                    sha(t),
+                    str(f.relative_to(RAW)),
+                    start,
+                    len(lines),
+                    "embedding_paragraph",
+                    "auto",
+                ]
+            )
+
+
+def write_jsonl(p, rows):
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+
+write_jsonl(SFT, sft_rows)
+write_jsonl(AGT, ag_rows)
+write_jsonl(EMB, emb_rows)
+with PROV.open("w", encoding="utf-8", newline="") as f:
+    w = csv.writer(f)
+    w.writerow(["record_id", "source_file", "start_line", "end_line", "type", "note"])
+    w.writerows(prov)
+
+with DOT.open("w", encoding="utf-8") as f:
+    f.write('digraph interactions {\n  "repo" [label="repo"];\n')
+    for i in range(min(20, len(sft_rows))):
+        f.write('  "repo" -> "sft_' + str(i) + '";\n')
+    f.write("}\n")
+try:
+    subprocess.run(["dot", "-Tpng", str(DOT), "-o", str(PNG)], check=True)
+except:
+    pass
+
+print(f"OK: SFT={len(sft_rows)} AGENT={len(ag_rows)} EMB={len(emb_rows)}")
+print("OUT:", SFT, AGT, EMB, PROV, DOT, PNG if PNG.exists() else "(no PNG)")


### PR DESCRIPTION
## Summary
- add a dataset builder that tags analyzer records with module hints and produces balanced train/val splits
- include an Unsloth-based fine-tuning script for Dolphin 3.0 with configurable LoRA and export options
- add a wrapper exporter that bundles a generate/embed helper, README, and config metadata for downstream usage

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4ce45cc9483338b89efd5e0244220

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/monGARS/221)
<!-- GitContextEnd -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * End-to-end dataset pipeline: repository scanner, dataset preparation with ratios/validation/QC, and multi-module dataset builder producing train/val JSONL.
  * Exportable lightweight wrapper enabling text generation and embeddings from fine-tuned models.
  * Training script to fine-tune models with adapters, with optional merged-model export.

* **Chores**
  * Workflow renamed and simplified to a single job; now runs on any branch commit.
  * Upgraded runtime to Python 3.12 and added required OS dependencies.
  * Streamlined artifacts: focused final dataset outputs with updated naming and retention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->