### PR TITLE
Enable paged optimizers and freeze early transformer layers

### DIFF
--- a/modules/neurons/training/mntp_trainer.py
+++ b/modules/neurons/training/mntp_trainer.py
@@ -932,7 +932,7 @@ class MNTPTrainer:
             "per_device_train_batch_size": schedule.per_device_batch_size,
             "gradient_accumulation_steps": schedule.gradient_accumulation_steps,
             "num_train_epochs": max(1, epochs),
-            "optim": "adamw_8bit",
+            "optim": "paged_adamw_8bit",
             "seed": 3407,
             "output_dir": str(self.output_dir / "outputs"),
             "gradient_checkpointing": True,

--- a/scripts/train_dolphin_unsloth.py
+++ b/scripts/train_dolphin_unsloth.py
@@ -518,6 +518,7 @@ def build_training_arguments(config: TrainingConfig, device: str) -> TrainingArg
         "fp16": config.fp16 and device != "cpu",
         "tf32": config.allow_tf32,
         "remove_unused_columns": False,
+        "optim": "paged_adamw_8bit",
     }
 
     if config.save_steps is not None:


### PR DESCRIPTION
## Summary
- switch MNTP and Unsloth training arguments to use the bitsandbytes paged AdamW optimizer for improved VRAM utilisation
- freeze the earliest transformer layers before attaching LoRA adapters so gradient checkpointing skips their activations and log the outcome
- align the lightweight sliced trainer with paged optimizers for consistency with the QLoRA pipeline

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e53f2394388333a6ab4dc64af35823

## Summary by Sourcery

Enable paged AdamW 8-bit optimizers across training pipelines for better VRAM utilization and introduce early-layer freezing during LoRA model preparation to optimize gradient checkpointing with accompanying logging.

New Features:
- Switch to bitsandbytes paged AdamW 8-bit optimizer by default in sliced trainer, MNTP, and Unsloth training scripts
- Freeze the first half of transformer layers before attaching LoRA adapters to skip their activations during gradient checkpointing

Enhancements:
- Add logging of frozen layer count and debug fallback when no transformer blocks are detected
- Align lightweight sliced trainer configuration with paged optimizer usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added automatic freezing of early transformer layers during lightweight fine-tuning to reduce compute and memory usage.
  - Introduced module-level runtime logging to report freezing status and training progress.

- Chores
  - Updated default optimizer to a paged 8-bit variant across trainers and scripts for improved efficiency on large models and longer sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->