### PR TITLE
Add AWQ quantization export to LoRA build pipeline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ git+https://github.com/unslothai/unsloth.git
 trafilatura>=2.0.0
 uvicorn>=0.35.0
 llm2vec>=0.2.3
+autoawq>=0.2.5
 cryptography>=45.0.5
 durationpy>=0.5,<1.0
 kubernetes>=8.0.2,<10.0.0


### PR DESCRIPTION
## Summary
- add an AWQ export helper that quantizes the merged LoRA checkpoint with AutoAWQ
- persist AWQ artifact metadata in the training summary and CLI output
- include the AutoAWQ dependency so the quantization step is available

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e54635acb88333bdae3f2829493e22