### PR TITLE
feat: add cross encoder reranking to rag context

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ sqlalchemy>=2.0.41
 tenacity>=9.1.2
 torch>=2.7.1
 transformers>=4.45.0
+sentence-transformers>=3.0.1
 peft>=0.13.2
 git+https://github.com/unslothai/unsloth.git
 trafilatura>=2.0.0

--- a/tests/test_rag_context_enricher.py
+++ b/tests/test_rag_context_enricher.py
@@ -106,7 +106,7 @@ async def test_enrich_returns_structured_payload(monkeypatch):
 
     assert calls[0]["json"] == {
         "query": "Review validation edge cases",
-        "max_results": 5,
+        "max_results": 50,
         "repositories": ["all"],
     }
     assert calls[0]["url"] == "http://rag.local/api/rag/context"


### PR DESCRIPTION
## Summary
- expand the context enricher to request a larger candidate set and apply cross-encoder reranking before returning references
- add configurable model loading with logging to document initial and re-ranked counts while handling missing dependencies gracefully
- include sentence-transformers in the requirements and update the unit test expectation for the enlarged retrieval window

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e587a74a188333bf51f9dcf9eda5d0