### PR TITLE
Fail fast when production SECRET_KEY is missing

### DIFF
--- a/monGARS/config.py
+++ b/monGARS/config.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Annotated, Any, Iterable, Literal, Optional, TypeAlias, get_args
 
 import hvac
-from dotenv import dotenv_values, set_key
+from dotenv import dotenv_values
 from opentelemetry import metrics, trace
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -1095,74 +1095,6 @@ def ensure_secret_key(
     raise ValueError("SECRET_KEY must be provided in production")
 
 
-def _persist_secret_key(settings: Settings) -> Settings:
-    """Persist an auto-generated SECRET_KEY for misconfigured environments.
-
-    When the runtime is configured for production but no SECRET_KEY is defined,
-    containerised deployments can end up crash-looping. To keep the service
-    available we generate a high-entropy key, inject it into the current process,
-    and attempt to update the configured ``.env`` file so subsequent runs reuse
-    the same value. The caller is responsible for logging any warnings.
-    """
-
-    generated_key = _generate_secret_key()
-    os.environ["SECRET_KEY"] = generated_key
-
-    persisted_key: str | None = None
-
-    for env_path in _iter_env_files(settings):
-        try:
-            env_values = dotenv_values(env_path, encoding="utf-8") or {}
-        except OSError as exc:  # pragma: no cover - unlikely but defend anyway
-            log.warning("Unable to read env file %s: %s", env_path, exc)
-            continue
-
-        existing_key = (env_values.get("SECRET_KEY") or "").strip() or None
-        if existing_key:
-            persisted_key = existing_key
-            log.info(
-                "SECRET_KEY already persisted in %s; reusing existing value.", env_path
-            )
-            break
-
-        try:
-            env_path.parent.mkdir(parents=True, exist_ok=True)
-            set_key(str(env_path), "SECRET_KEY", generated_key)
-        except OSError as exc:  # pragma: no cover - writing may fail on RO filesystems
-            log.warning("Unable to persist SECRET_KEY to %s: %s", env_path, exc)
-            continue
-
-        log.info("Persisted generated SECRET_KEY to %s", env_path)
-
-        try:
-            updated_values = dotenv_values(env_path, encoding="utf-8") or {}
-        except OSError as exc:  # pragma: no cover - best effort re-read
-            log.warning(
-                "Unable to re-read SECRET_KEY from %s after persistence: %s",
-                env_path,
-                exc,
-            )
-            persisted_key = generated_key
-        else:
-            final_key = (updated_values.get("SECRET_KEY") or "").strip()
-            if final_key:
-                persisted_key = final_key
-                if final_key != generated_key:
-                    log.info(
-                        "Adopting SECRET_KEY written by another process in %s.",
-                        env_path,
-                    )
-        break
-
-    final_key = (persisted_key or generated_key).strip()
-    os.environ["SECRET_KEY"] = final_key
-
-    origin: SecretKeyOrigin = "generated" if final_key == generated_key else "persisted"
-    new_settings = settings.model_copy(update={"SECRET_KEY": final_key})
-    object.__setattr__(new_settings, "_secret_key_origin", origin)
-    return new_settings
-
-
 def validate_jwt_configuration(settings: Settings) -> None:
     """Validate that JWT settings have consistent key material."""
 
@@ -1279,12 +1211,10 @@ def get_settings() -> Settings:
         )
 
     if settings.debug:
-        debug_secret = _generate_secret_key()
-        debug_settings = settings.model_copy(update={"SECRET_KEY": debug_secret})
-        object.__setattr__(debug_settings, "_secret_key_origin", "generated")
-        validate_jwt_configuration(debug_settings)
-        configure_telemetry(debug_settings)
-        return debug_settings
+        settings, _ = ensure_secret_key(settings)
+        validate_jwt_configuration(settings)
+        configure_telemetry(settings)
+        return settings
 
     if _vault_configured(settings):
         secrets_map = fetch_secrets_from_vault(settings)
@@ -1307,23 +1237,13 @@ def get_settings() -> Settings:
                 object.__setattr__(settings, "__pydantic_extra__", extra)
             if "SECRET_KEY" in updates:
                 object.__setattr__(settings, "_secret_key_origin", "vault")
-        if (
-            re.fullmatch(r"HS\d+", settings.JWT_ALGORITHM.strip().upper())
-            and not settings.SECRET_KEY
-        ):
-            raise ValueError(
-                "Symmetric JWT algorithms require SECRET_KEY to be configured."
-            )
+        if re.fullmatch(r"HS\d+", settings.JWT_ALGORITHM.strip().upper()):
+            settings, _ = ensure_secret_key(settings)
         validate_jwt_configuration(settings)
         configure_telemetry(settings)
         return settings
 
-    if not settings.SECRET_KEY:
-        log.critical(
-            "SECRET_KEY missing while DEBUG is disabled; generating ephemeral key. "
-            "Persist SECRET_KEY in your environment or Vault to avoid token invalidation."
-        )
-        settings = _persist_secret_key(settings)
+    settings, _ = ensure_secret_key(settings)
 
     validate_jwt_configuration(settings)
     configure_telemetry(settings)

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from monGARS import config
@@ -39,55 +37,12 @@ def test_secret_key_is_random_between_calls(monkeypatch):
     assert len(second.SECRET_KEY) >= 32
 
 
-def test_get_settings_bootstraps_secret_in_production(monkeypatch, tmp_path, caplog):
-    config.get_settings.cache_clear()
-    env_file = tmp_path / ".env"
-    env_file.write_text("DEBUG=false\n")
-    monkeypatch.chdir(tmp_path)
+def test_get_settings_requires_secret_in_production(monkeypatch):
     monkeypatch.setenv("DEBUG", "false")
     monkeypatch.delenv("SECRET_KEY", raising=False)
 
-    with caplog.at_level("INFO"):
-        settings = config.get_settings()
-
-    assert settings.SECRET_KEY
-    assert len(settings.SECRET_KEY) >= 32
-    assert "SECRET_KEY missing while DEBUG is disabled" in caplog.text
-    assert "Persisted generated SECRET_KEY" in caplog.text
-    assert "SECRET_KEY=" in env_file.read_text()
-
-    persisted = settings.SECRET_KEY
-    config.get_settings.cache_clear()
-    caplog.clear()
-    monkeypatch.delenv("SECRET_KEY", raising=False)
-
-    with caplog.at_level("INFO"):
-        settings_again = config.get_settings()
-
-    assert settings_again.SECRET_KEY == persisted
-    assert settings_again._secret_key_origin == "provided"
-    assert "SECRET_KEY missing while DEBUG is disabled" not in caplog.text
-
-
-def test_get_settings_warns_when_env_file_read_only(monkeypatch, tmp_path, caplog):
-    env_file = tmp_path / ".env"
-    env_file.write_text("DEBUG=false\n", encoding="utf-8")
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setenv("DEBUG", "false")
-    monkeypatch.delenv("SECRET_KEY", raising=False)
-
-    def _fail_set_key(*args, **kwargs):
-        raise PermissionError("read-only")
-
-    monkeypatch.setattr(config, "set_key", _fail_set_key)
-
-    with caplog.at_level("WARNING"):
-        settings = config.get_settings()
-
-    assert settings.SECRET_KEY
-    assert os.environ["SECRET_KEY"] == settings.SECRET_KEY
-    assert "Unable to persist SECRET_KEY" in caplog.text
-    assert "SECRET_KEY=" not in env_file.read_text(encoding="utf-8")
+    with pytest.raises(ValueError, match="SECRET_KEY must be provided in production"):
+        config.get_settings()
 
 
 def test_settings_defers_secret_when_vault_configured(monkeypatch):


### PR DESCRIPTION
### Motivation

- Prevent runtime mutation of `.env` and accidental generation/persistence of `SECRET_KEY` in production by enforcing explicit provisioning of secrets. 
- Ensure JWT validation runs only after required key material is guaranteed so misconfigurations surface early.
- Keep ephemeral/generated secret behaviour restricted to debug/development flows.

### Description

- Removed `_persist_secret_key` and the runtime `.env` mutation path and deleted the `set_key` import to stop production-time writes. 
- Reworked `get_settings()` to call `ensure_secret_key()` on debug, Vault, and production paths so missing production secrets raise immediately instead of being auto-persisted. 
- Adjusted HS* JWT handling to call `ensure_secret_key()` before `validate_jwt_configuration()` so symmetric algorithm checks are run only when key presence is ensured. 
- Updated tests in `tests/test_config_settings.py` to assert that production without `SECRET_KEY` raises and that debug mode still auto-generates a safe ephemeral key.

### Testing

- Formatted imports and code with `python -m black monGARS/config.py tests/test_config_settings.py` and `python -m isort monGARS/config.py tests/test_config_settings.py` successfully. 
- Ran unit tests for the affected module with `pytest -q tests/test_config_settings.py`, which completed successfully with `31 passed` and the test-suite warnings noted from `pytest-asyncio` (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a901b76a64833385d5acd8a045d339)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/monGARS/469)
<!-- GitContextEnd -->

## Summary by Sourcery

Enforce explicit SECRET_KEY provisioning in production and ensure JWT configuration validation only runs after required key material is present.

Bug Fixes:
- Prevent production from auto-generating and persisting SECRET_KEY when it is missing, failing fast instead.
- Ensure HS* JWT configurations always validate against an ensured SECRET_KEY rather than potentially missing key material.

Enhancements:
- Reuse the centralized ensure_secret_key flow across debug, Vault-configured, and production settings initialization to unify secret handling behavior.

Tests:
- Replace persistence-focused SECRET_KEY tests with assertions that production without SECRET_KEY now raises and that debug mode still auto-generates a temporary key.